### PR TITLE
Generalize Keycloak build artifact ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ node_modules/
 # Build output
 dist/
 build/
-keycloak/extensions/altcha/target/
+keycloak/extensions/*/target/
 keycloak/providers/*.jar
 
 # Environment


### PR DESCRIPTION
## Summary

- Generalize the Keycloak extension build-output ignore rule from the existing altcha-specific path to all extensions.
- Keep the existing provider JAR ignore rule unchanged.

## Why

PR #50 was based on the outdated develop branch and conflicts with master. This branch reapplies the remaining intended change directly on the latest master without carrying unrelated history.

## Impact

Local Maven build output for current and future Keycloak extensions is no longer shown as untracked content.

## Validation

- git diff --check
- git check-ignore verified the current extension, a future extension, and provider JAR paths.