### PR TITLE
Partial-Credit und stabile Item/Sub-ID-Zeilenschlüssel

### DIFF
--- a/backend/src/acp/feature-config.utils.spec.ts
+++ b/backend/src/acp/feature-config.utils.spec.ts
@@ -12,6 +12,25 @@ describe("normalizeFeatureConfig", () => {
     });
   });
 
+  it("normalizes partial-credit labels", () => {
+    const normalized = normalizeFeatureConfig({
+      itemSubIdLabel: "  Kategorie  ",
+      itemSubIdLabels: {
+        " 1 ": "  teilweise richtig ",
+        "2": "vollständig richtig",
+        empty: "   ",
+      },
+    });
+
+    expect(normalized).toMatchObject({
+      itemSubIdLabel: "Kategorie",
+      itemSubIdLabels: {
+        "1": "teilweise richtig",
+        "2": "vollständig richtig",
+      },
+    });
+  });
+
   it("migrates legacy itemListMetadataColumns to metadataColumns", () => {
     const normalized = normalizeFeatureConfig({
       enableItemList: true,

--- a/backend/src/acp/feature-config.utils.ts
+++ b/backend/src/acp/feature-config.utils.ts
@@ -20,6 +20,19 @@ function asStringArray(value: unknown): string[] {
     .filter((entry) => entry.length > 0);
 }
 
+function normalizeStringMap(value: unknown): Record<string, string> {
+  const source = asRecord(value);
+  const normalized: Record<string, string> = {};
+  for (const [rawKey, rawLabel] of Object.entries(source)) {
+    const key = rawKey.trim();
+    const label = typeof rawLabel === "string" ? rawLabel.trim() : "";
+    if (key && label) {
+      normalized[key] = label;
+    }
+  }
+  return normalized;
+}
+
 function normalizeMetadataColumns(
   metadataColumnsRaw: unknown,
   legacyItemListColumnsRaw: unknown,
@@ -60,6 +73,19 @@ export function normalizeFeatureConfig(featureConfig: unknown): UnknownRecord {
 
   normalized.enablePlayerFocusHighlight =
     source.enablePlayerFocusHighlight === true;
+
+  normalized.itemSubIdLabel =
+    typeof source.itemSubIdLabel === "string" &&
+    source.itemSubIdLabel.trim().length > 0
+      ? source.itemSubIdLabel.trim()
+      : "Sub-ID";
+
+  const itemSubIdLabels = normalizeStringMap(source.itemSubIdLabels);
+  if (Object.keys(itemSubIdLabels).length > 0) {
+    normalized.itemSubIdLabels = itemSubIdLabels;
+  } else {
+    delete normalized.itemSubIdLabels;
+  }
 
   const metadataColumns = normalizeMetadataColumns(
     source.metadataColumns,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { ValidationModule } from "./validation/validation.module";
 import { ServerApiModule } from "./api/server-api.module";
 import { HealthModule } from "./health/health.module";
 import { ItemExplorerModule } from "./item-explorer/item-explorer.module";
+import { createApplicationDataSource } from "./database/database-compatibility";
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { ItemExplorerModule } from "./item-explorer/item-explorer.module";
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
+      dataSourceFactory: createApplicationDataSource,
       useFactory: (configService: ConfigService) => {
         const nodeEnv = configService.get<string>("NODE_ENV", "development");
         const synchronizeDefault = nodeEnv === "development" ? "true" : "false";

--- a/backend/src/database/database-compatibility.spec.ts
+++ b/backend/src/database/database-compatibility.spec.ts
@@ -1,0 +1,54 @@
+import { DataSource, QueryRunner } from "typeorm";
+import { prepareSchemaForSynchronization } from "./database-compatibility";
+
+describe("prepareSchemaForSynchronization", () => {
+  function createDataSource(hasItemResponseStates: boolean) {
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      hasTable: jest.fn().mockResolvedValue(hasItemResponseStates),
+      query: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+    } as unknown as QueryRunner;
+    const dataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(queryRunner),
+    } as unknown as DataSource;
+    return { dataSource, queryRunner };
+  }
+
+  it("does nothing for a fresh database before synchronize creates tables", async () => {
+    const { dataSource, queryRunner } = createDataSource(false);
+
+    await prepareSchemaForSynchronization(dataSource);
+
+    expect(queryRunner.query).not.toHaveBeenCalled();
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("backfills the stable row key before synchronize enforces it", async () => {
+    const { dataSource, queryRunner } = createDataSource(true);
+
+    await prepareSchemaForSynchronization(dataSource);
+
+    const statements = (queryRunner.query as jest.Mock).mock.calls.map(
+      ([statement]) => statement as string,
+    );
+    expect(
+      statements.some((statement) =>
+        statement.includes('ADD COLUMN IF NOT EXISTS "row_key"'),
+      ),
+    ).toBe(true);
+    expect(
+      statements.some(
+        (statement) =>
+          statement.includes('SET "row_key" = "unit_id"') &&
+          !statement.includes('ALTER COLUMN "row_key" SET NOT NULL'),
+      ),
+    ).toBe(true);
+    expect(
+      statements.some((statement) =>
+        statement.includes('ALTER COLUMN "row_key" SET NOT NULL'),
+      ),
+    ).toBe(true);
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/database/database-compatibility.spec.ts
+++ b/backend/src/database/database-compatibility.spec.ts
@@ -51,4 +51,19 @@ describe("prepareSchemaForSynchronization", () => {
     ).toBe(true);
     expect(queryRunner.release).toHaveBeenCalledTimes(1);
   });
+
+  it("reconciles existing item explorer state before synchronization", async () => {
+    const { dataSource, queryRunner } = createDataSource(false);
+    (queryRunner.hasTable as jest.Mock).mockImplementation(
+      async (table: string) =>
+        table === "acp" || table === "acp_item_explorer_state",
+    );
+
+    await prepareSchemaForSynchronization(dataSource);
+
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM "acp_item_explorer_state" state'),
+    );
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
+  });
 });

--- a/backend/src/database/database-compatibility.ts
+++ b/backend/src/database/database-compatibility.ts
@@ -1,5 +1,6 @@
 import { DataSource, DataSourceOptions } from "typeorm";
 import { AddItemResponseStateRowKey1783900000000 } from "./migrations/1783900000000-AddItemResponseStateRowKey";
+import { ReconcileItemExplorerState1783901000000 } from "./migrations/1783901000000-ReconcileItemExplorerState";
 
 /**
  * Prepare schemas that were previously maintained through TypeORM synchronize.
@@ -17,6 +18,12 @@ export async function prepareSchemaForSynchronization(
   try {
     if (await queryRunner.hasTable("item_response_states")) {
       await new AddItemResponseStateRowKey1783900000000().up(queryRunner);
+    }
+    if (
+      (await queryRunner.hasTable("acp")) &&
+      (await queryRunner.hasTable("acp_item_explorer_state"))
+    ) {
+      await new ReconcileItemExplorerState1783901000000().up(queryRunner);
     }
   } finally {
     await queryRunner.release();

--- a/backend/src/database/database-compatibility.ts
+++ b/backend/src/database/database-compatibility.ts
@@ -1,0 +1,59 @@
+import { DataSource, DataSourceOptions } from "typeorm";
+import { AddItemResponseStateRowKey1783900000000 } from "./migrations/1783900000000-AddItemResponseStateRowKey";
+
+/**
+ * Prepare schemas that were previously maintained through TypeORM synchronize.
+ *
+ * Migrations remain the source of truth for deployed environments. Development
+ * databases may not have a migration history, though, so changes that require
+ * data backfills must run before synchronize attempts to enforce the final
+ * entity constraints.
+ */
+export async function prepareSchemaForSynchronization(
+  dataSource: DataSource,
+): Promise<void> {
+  const queryRunner = dataSource.createQueryRunner();
+  await queryRunner.connect();
+  try {
+    if (await queryRunner.hasTable("item_response_states")) {
+      await new AddItemResponseStateRowKey1783900000000().up(queryRunner);
+    }
+  } finally {
+    await queryRunner.release();
+  }
+}
+
+/**
+ * Initialize TypeORM in a deterministic order: migrations first, compatibility
+ * backfills second, and schema synchronization last.
+ */
+export async function createApplicationDataSource(
+  options?: DataSourceOptions,
+): Promise<DataSource> {
+  if (!options) {
+    throw new Error("TypeORM data source options are required");
+  }
+
+  const shouldRunMigrations = options.migrationsRun === true;
+  const shouldSynchronize = options.synchronize === true;
+  const dataSource = new DataSource({
+    ...options,
+    migrationsRun: false,
+    synchronize: false,
+  });
+
+  await dataSource.initialize();
+  try {
+    if (shouldRunMigrations) {
+      await dataSource.runMigrations();
+    }
+    if (shouldSynchronize) {
+      await prepareSchemaForSynchronization(dataSource);
+      await dataSource.synchronize();
+    }
+    return dataSource;
+  } catch (error) {
+    await dataSource.destroy();
+    throw error;
+  }
+}

--- a/backend/src/database/entities/item-response-state.entity.ts
+++ b/backend/src/database/entities/item-response-state.entity.ts
@@ -8,11 +8,9 @@ import {
 } from "typeorm";
 
 @Entity("item_response_states")
-@Index(
-  "IDX_item_response_states_acp_unit_item_unique",
-  ["acpId", "unitId", "itemId"],
-  { unique: true },
-)
+@Index("IDX_item_response_states_acp_row_key_unique", ["acpId", "rowKey"], {
+  unique: true,
+})
 @Index("IDX_item_response_states_acp_unit", ["acpId", "unitId"])
 export class ItemResponseState {
   @PrimaryGeneratedColumn("uuid")
@@ -26,6 +24,9 @@ export class ItemResponseState {
 
   @Column({ name: "unit_id" })
   unitId!: string;
+
+  @Column({ name: "row_key" })
+  rowKey!: string;
 
   @Column({ name: "response_data", type: "jsonb", default: {} })
   responseData!: Record<string, any>;

--- a/backend/src/database/migration-tests/reconcile-item-explorer-state.spec.ts
+++ b/backend/src/database/migration-tests/reconcile-item-explorer-state.spec.ts
@@ -1,0 +1,147 @@
+import { QueryRunner } from "typeorm";
+import { ReconcileItemExplorerState1783901000000 } from "../migrations/1783901000000-ReconcileItemExplorerState";
+
+describe("ReconcileItemExplorerState1783901000000", () => {
+  it("rebases a pending draft onto newer ACP item properties", async () => {
+    const queryRunner = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            id: "state-1",
+            publishedState: {
+              ui: {},
+              tags: {
+                item1: ["old"],
+                stale: ["remove"],
+              },
+              itemProperties: {
+                item1: {
+                  tags: ["old"],
+                  empiricalDifficulty: 1,
+                  excluded: false,
+                },
+              },
+            },
+            draftState: {
+              ui: { filterText: "open draft" },
+              tags: {
+                item1: ["draft"],
+                stale: ["remove"],
+              },
+              itemProperties: {
+                item1: {
+                  tags: ["old"],
+                  empiricalDifficulty: 1,
+                  excluded: false,
+                },
+              },
+            },
+            itemProperties: {
+              item1: {
+                tags: ["domain"],
+                empiricalDifficulty: 2,
+                excluded: false,
+              },
+              item2: { tags: ["new"] },
+            },
+          },
+        ])
+        .mockResolvedValueOnce(undefined),
+    } as unknown as QueryRunner;
+
+    await new ReconcileItemExplorerState1783901000000().up(queryRunner);
+
+    expect(queryRunner.query).toHaveBeenCalledTimes(2);
+    const updateParameters = (queryRunner.query as jest.Mock).mock.calls[1][1];
+    expect(JSON.parse(updateParameters[0])).toEqual({
+      ui: {},
+      tags: {
+        item1: ["domain"],
+        item2: ["new"],
+      },
+      itemProperties: {
+        item1: {
+          tags: ["domain"],
+          empiricalDifficulty: 2,
+          excluded: false,
+        },
+        item2: { tags: ["new"] },
+      },
+    });
+    expect(JSON.parse(updateParameters[1])).toEqual({
+      ui: { filterText: "open draft" },
+      tags: {
+        item1: ["draft"],
+        item2: ["new"],
+      },
+      itemProperties: {
+        item1: {
+          tags: ["draft"],
+          empiricalDifficulty: 2,
+          excluded: false,
+        },
+        item2: { tags: ["new"] },
+      },
+    });
+    expect(updateParameters[2]).toBe("DIRTY");
+    expect(updateParameters[3]).toBe("state-1");
+  });
+
+  it("keeps draft deletions while adopting unrelated domain changes", async () => {
+    const queryRunner = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            id: "state-2",
+            publishedState: {
+              itemProperties: {
+                item1: { excluded: true, previewTargetId: "BASE_A" },
+              },
+            },
+            draftState: {
+              itemProperties: {
+                item1: { previewTargetId: "BASE_A" },
+              },
+            },
+            itemProperties: {
+              item1: {
+                excluded: true,
+                previewTargetId: "BASE_B",
+              },
+            },
+          },
+        ])
+        .mockResolvedValueOnce(undefined),
+    } as unknown as QueryRunner;
+
+    await new ReconcileItemExplorerState1783901000000().up(queryRunner);
+
+    const updateParameters = (queryRunner.query as jest.Mock).mock.calls[1][1];
+    expect(JSON.parse(updateParameters[1]).itemProperties).toEqual({
+      item1: { previewTargetId: "BASE_B" },
+    });
+  });
+
+  it("does not update versions when domain and explorer state already match", async () => {
+    const state = {
+      tags: { item1: ["current"] },
+      itemProperties: { item1: { tags: ["current"] } },
+    };
+    const queryRunner = {
+      query: jest.fn().mockResolvedValueOnce([
+        {
+          id: "state-3",
+          publishedState: state,
+          draftState: state,
+          itemProperties: state.itemProperties,
+        },
+      ]),
+    } as unknown as QueryRunner;
+
+    await new ReconcileItemExplorerState1783901000000().up(queryRunner);
+
+    expect(queryRunner.query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/database/migrations/1783900000000-AddItemResponseStateRowKey.ts
+++ b/backend/src/database/migrations/1783900000000-AddItemResponseStateRowKey.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddItemResponseStateRowKey1783900000000 implements MigrationInterface {
+  name = "AddItemResponseStateRowKey1783900000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "item_response_states"
+      ADD COLUMN IF NOT EXISTS "row_key" character varying
+    `);
+    await queryRunner.query(`
+      UPDATE "item_response_states"
+      SET "row_key" = "unit_id" || '::' || "item_id"
+      WHERE "row_key" IS NULL OR "row_key" = ''
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "item_response_states"
+      ALTER COLUMN "row_key" SET NOT NULL
+    `);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_item_response_states_acp_unit_item_unique"`,
+    );
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_item_response_states_acp_row_key_unique"
+      ON "item_response_states" ("acp_id", "row_key")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_item_response_states_acp_row_key_unique"`,
+    );
+    // The previous schema can keep only one state per ACP/unit/item. Preserve
+    // the most recently updated row deterministically so rollback can finish.
+    await queryRunner.query(`
+      WITH ranked_states AS (
+        SELECT "id",
+          ROW_NUMBER() OVER (
+            PARTITION BY "acp_id", "unit_id", "item_id"
+            ORDER BY "updated_at" DESC, "id" DESC
+          ) AS row_number
+        FROM "item_response_states"
+      )
+      DELETE FROM "item_response_states" state
+      USING ranked_states ranked
+      WHERE state."id" = ranked."id" AND ranked.row_number > 1
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_item_response_states_acp_unit_item_unique"
+      ON "item_response_states" ("acp_id", "unit_id", "item_id")
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "item_response_states" DROP COLUMN IF EXISTS "row_key"
+    `);
+  }
+}

--- a/backend/src/database/migrations/1783901000000-ReconcileItemExplorerState.ts
+++ b/backend/src/database/migrations/1783901000000-ReconcileItemExplorerState.ts
@@ -1,0 +1,229 @@
+import { isDeepStrictEqual } from "node:util";
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+type JsonObject = Record<string, unknown>;
+
+interface DivergedExplorerStateRow {
+  id: string;
+  publishedState: JsonObject;
+  draftState: JsonObject;
+  itemProperties: JsonObject;
+}
+
+const missing = Symbol("missing");
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asJsonObject(value: unknown): JsonObject {
+  return isJsonObject(value) ? value : {};
+}
+
+function hasOwn(source: JsonObject, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(source, key);
+}
+
+function extractTags(itemProperties: JsonObject): JsonObject {
+  const tags: JsonObject = {};
+
+  for (const [rawItemKey, rawProperties] of Object.entries(itemProperties)) {
+    const itemKey = rawItemKey.trim();
+    if (!itemKey || !isJsonObject(rawProperties)) {
+      continue;
+    }
+
+    const rawTags = rawProperties.tags;
+    if (!Array.isArray(rawTags)) {
+      continue;
+    }
+
+    const normalizedTags = Array.from(
+      new Set(
+        rawTags
+          .map((value) => String(value || "").trim())
+          .filter((value) => value.length > 0),
+      ),
+    );
+    if (normalizedTags.length > 0 || itemKey.includes("::")) {
+      tags[itemKey] = normalizedTags;
+    }
+  }
+
+  return tags;
+}
+
+function applyTagsToItemProperties(
+  itemProperties: JsonObject,
+  tags: JsonObject,
+): JsonObject {
+  const nextItemProperties: JsonObject = {};
+
+  for (const [itemKey, rawProperties] of Object.entries(itemProperties)) {
+    if (!isJsonObject(rawProperties)) {
+      continue;
+    }
+    const nextProperties = { ...rawProperties };
+    delete nextProperties.tags;
+    if (Object.keys(nextProperties).length > 0) {
+      nextItemProperties[itemKey] = nextProperties;
+    }
+  }
+
+  for (const [itemKey, rawTags] of Object.entries(tags)) {
+    if (!Array.isArray(rawTags)) {
+      continue;
+    }
+    nextItemProperties[itemKey] = {
+      ...asJsonObject(nextItemProperties[itemKey]),
+      tags: rawTags,
+    };
+  }
+
+  return nextItemProperties;
+}
+
+function rebaseObject(
+  base: JsonObject,
+  draft: JsonObject,
+  published: JsonObject,
+): JsonObject {
+  const result: JsonObject = {};
+  const keys = new Set([
+    ...Object.keys(base),
+    ...Object.keys(draft),
+    ...Object.keys(published),
+  ]);
+
+  for (const key of keys) {
+    const baseValue = hasOwn(base, key) ? base[key] : missing;
+    const draftValue = hasOwn(draft, key) ? draft[key] : missing;
+    const publishedValue = hasOwn(published, key) ? published[key] : missing;
+
+    if (isDeepStrictEqual(draftValue, baseValue)) {
+      if (publishedValue !== missing) {
+        result[key] = publishedValue;
+      }
+      continue;
+    }
+
+    if (draftValue === missing) {
+      continue;
+    }
+
+    if (
+      isJsonObject(draftValue) &&
+      isJsonObject(publishedValue) &&
+      (baseValue === missing || isJsonObject(baseValue))
+    ) {
+      result[key] = rebaseObject(
+        baseValue === missing ? {} : baseValue,
+        draftValue,
+        publishedValue,
+      );
+      continue;
+    }
+
+    result[key] = draftValue;
+  }
+
+  return result;
+}
+
+/**
+ * Before direct item-property writes were unified with Item Explorer state,
+ * explorer snapshots could lag behind the ACP domain record. Reconcile the
+ * published snapshot and rebase pending draft changes field by field so that
+ * neither newer domain data nor intentional draft edits are lost.
+ */
+export class ReconcileItemExplorerState1783901000000 implements MigrationInterface {
+  name = "ReconcileItemExplorerState1783901000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const rows = (await queryRunner.query(`
+      SELECT
+        state."id" AS "id",
+        state."published_state" AS "publishedState",
+        state."draft_state" AS "draftState",
+        acp."item_properties" AS "itemProperties"
+      FROM "acp_item_explorer_state" state
+      INNER JOIN "acp" acp ON acp."id" = state."acp_id"
+    `)) as DivergedExplorerStateRow[] | undefined;
+
+    for (const row of rows || []) {
+      const publishedState = asJsonObject(row.publishedState);
+      const draftState = asJsonObject(row.draftState);
+      const previousItemProperties = asJsonObject(
+        publishedState.itemProperties,
+      );
+      const draftItemProperties = asJsonObject(draftState.itemProperties);
+      const currentItemProperties = asJsonObject(row.itemProperties);
+      const previousTags = asJsonObject(publishedState.tags);
+      const draftTags = asJsonObject(draftState.tags);
+      const currentTags = extractTags(currentItemProperties);
+      const rebasedDraftTags = rebaseObject(
+        previousTags,
+        draftTags,
+        currentTags,
+      );
+      const rebasedDraftItemProperties = rebaseObject(
+        previousItemProperties,
+        draftItemProperties,
+        currentItemProperties,
+      );
+      const nextDraftItemProperties = isDeepStrictEqual(
+        rebasedDraftTags,
+        currentTags,
+      )
+        ? rebasedDraftItemProperties
+        : applyTagsToItemProperties(
+            rebasedDraftItemProperties,
+            rebasedDraftTags,
+          );
+
+      const nextPublishedState = {
+        ...publishedState,
+        tags: currentTags,
+        itemProperties: currentItemProperties,
+      };
+      const nextDraftState = {
+        ...draftState,
+        tags: rebasedDraftTags,
+        itemProperties: nextDraftItemProperties,
+      };
+      if (
+        isDeepStrictEqual(nextPublishedState, publishedState) &&
+        isDeepStrictEqual(nextDraftState, draftState)
+      ) {
+        continue;
+      }
+      const status = isDeepStrictEqual(nextDraftState, nextPublishedState)
+        ? "CLEAN"
+        : "DIRTY";
+
+      await queryRunner.query(
+        `
+          UPDATE "acp_item_explorer_state"
+          SET
+            "published_state" = $1::jsonb,
+            "draft_state" = $2::jsonb,
+            "status" = $3,
+            "version" = "version" + 1,
+            "published_version" = "published_version" + 1,
+            "updated_at" = CURRENT_TIMESTAMP
+          WHERE "id" = $4
+        `,
+        [
+          JSON.stringify(nextPublishedState),
+          JSON.stringify(nextDraftState),
+          status,
+          row.id,
+        ],
+      );
+    }
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // The superseded snapshots cannot be reconstructed after reconciliation.
+  }
+}

--- a/backend/src/files/files.controller.spec.ts
+++ b/backend/src/files/files.controller.spec.ts
@@ -8,6 +8,7 @@ describe("FilesController", () => {
   let unitParserService: any;
   let validationService: any;
   let fileProcessingJobsService: any;
+  let itemExplorerStateService: any;
 
   const baseFile = {
     id: "file-1",
@@ -125,11 +126,18 @@ describe("FilesController", () => {
       ),
     };
 
+    itemExplorerStateService = {
+      getStateForViewer: jest.fn().mockResolvedValue({
+        activeState: { itemProperties: {} },
+      }),
+    };
+
     controller = new FilesController(
       filesService,
       unitParserService,
       validationService,
       fileProcessingJobsService,
+      itemExplorerStateService,
     );
   });
 
@@ -408,6 +416,10 @@ describe("FilesController", () => {
 
     expect(result).toEqual([{ itemId: "item-1" }]);
     expect(filesService.getFeatureConfig).not.toHaveBeenCalled();
+    expect(unitParserService.getItemListFromFiles).toHaveBeenCalledWith(
+      "acp-1",
+      { itemPropertiesOverride: {} },
+    );
   });
 
   it("applies read-only perspective checks for managers in item list", async () => {

--- a/backend/src/files/files.controller.ts
+++ b/backend/src/files/files.controller.ts
@@ -32,6 +32,7 @@ import { AcpAccessGuard } from "../auth/guards/acp-access.guard";
 import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { FileProcessingJobsService } from "./file-processing-jobs.service";
+import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
 
 @ApiTags("ACP Files")
 @Controller("acp/:acpId/files")
@@ -41,6 +42,7 @@ export class FilesController {
     private readonly unitParserService: UnitParserService,
     private readonly validationService: ValidationService,
     private readonly fileProcessingJobsService: FileProcessingJobsService,
+    private readonly itemExplorerStateService: ItemExplorerStateService,
   ) {}
 
   @Get()
@@ -146,7 +148,13 @@ export class FilesController {
         throw new ForbiddenException("Item list is not enabled for this ACP");
       }
     }
-    return this.unitParserService.getItemListFromFiles(acpId);
+    const explorerState = await this.itemExplorerStateService.getStateForViewer(
+      acpId,
+      isManager,
+    );
+    return this.unitParserService.getItemListFromFiles(acpId, {
+      itemPropertiesOverride: explorerState.activeState.itemProperties,
+    });
   }
 
   @Get("unit-view/:unitId")

--- a/backend/src/files/files.module.ts
+++ b/backend/src/files/files.module.ts
@@ -15,6 +15,7 @@ import {
 import { AuthModule } from "../auth/auth.module";
 import { ValidationModule } from "../validation/validation.module";
 import { FileProcessingJobsService } from "./file-processing-jobs.service";
+import { ItemExplorerModule } from "../item-explorer/item-explorer.module";
 
 const MAX_UPLOAD_FILE_SIZE_BYTES = 512 * 1024 * 1024;
 
@@ -33,6 +34,7 @@ const MAX_UPLOAD_FILE_SIZE_BYTES = 512 * 1024 * 1024;
     }),
     AuthModule,
     ValidationModule,
+    ItemExplorerModule,
   ],
   controllers: [FilesController],
   providers: [FilesService, UnitParserService, FileProcessingJobsService],

--- a/backend/src/files/files.service.spec.ts
+++ b/backend/src/files/files.service.spec.ts
@@ -541,12 +541,28 @@ describe("FilesService", () => {
   describe("cleanupOrphanedResponseStates", () => {
     it("deletes response states that no longer match any file-backed item", async () => {
       stateRepo.find.mockResolvedValueOnce([
-        { id: "state-1", unitId: "unit-1", itemId: "item-a" },
-        { id: "state-2", unitId: "unit-1", itemId: "item-b" },
+        {
+          id: "state-1",
+          unitId: "unit-1",
+          itemId: "item-a",
+          rowKey: "unit-1::item-a",
+        },
+        {
+          id: "state-2",
+          unitId: "unit-1",
+          itemId: "item-b",
+          rowKey: "unit-1::item-b",
+        },
       ]);
       unitParserService.getItemListFromFiles.mockResolvedValueOnce({
         columns: [],
-        items: [{ itemId: "item-a", unitId: "unit-1" }],
+        items: [
+          {
+            itemId: "item-a",
+            unitId: "unit-1",
+            rowKey: "uuid-a",
+          },
+        ],
         unitMetadata: {},
         codingSchemes: {},
       });
@@ -572,6 +588,45 @@ describe("FilesService", () => {
         totalStates: 0,
         deletedStates: 0,
         keptStates: 0,
+      });
+    });
+
+    it("keeps draft partial-credit states while their underlying item still exists", async () => {
+      stateRepo.find.mockResolvedValueOnce([
+        {
+          id: "state-valid-partial",
+          unitId: "unit-1",
+          itemId: "item-a",
+          rowKey: "uuid-a::1",
+        },
+        {
+          id: "state-orphaned-partial",
+          unitId: "unit-1",
+          itemId: "item-missing",
+          rowKey: "uuid-missing::1",
+        },
+      ]);
+      unitParserService.getItemListFromFiles.mockResolvedValueOnce({
+        columns: [],
+        items: [
+          {
+            itemId: "item-a",
+            unitId: "unit-1",
+            uuid: "uuid-a",
+            rowKey: "uuid-a",
+          },
+        ],
+        unitMetadata: {},
+        codingSchemes: {},
+      });
+
+      const result = await service.cleanupOrphanedResponseStates("acp-1");
+
+      expect(stateRepo.delete).toHaveBeenCalledWith(["state-orphaned-partial"]);
+      expect(result).toEqual({
+        totalStates: 2,
+        deletedStates: 1,
+        keptStates: 1,
       });
     });
   });

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -29,6 +29,7 @@ import {
   AutoValidationSummary,
 } from "../validation/validation.service";
 import { FileProcessingProgressReporter } from "./file-processing-progress";
+import { parseItemRowKeyParts } from "../items/item-row-key.util";
 
 type UploadConflictStrategy = "reject" | "overwrite" | "keep-both";
 export type FilePreviewMode =
@@ -401,6 +402,7 @@ export class FilesService {
         id: true,
         unitId: true,
         itemId: true,
+        rowKey: true,
       },
     });
 
@@ -414,14 +416,24 @@ export class FilesService {
 
     const fileItemList =
       await this.unitParserService.getItemListFromFiles(acpId);
-    const validKeys = new Set(
-      (fileItemList.items || []).map(
-        (item) => `${item.unitId}::${item.itemId}`,
-      ),
-    );
+    const validKeys = new Set<string>();
+    const validItemUuids = new Set<string>();
+    for (const item of fileItemList.items || []) {
+      validKeys.add(item.rowKey);
+      validKeys.add(`${item.unitId}::${item.itemId}`);
+      if (item.uuid) {
+        validItemUuids.add(item.uuid);
+      }
+    }
 
     const staleStateIds = existingStates
-      .filter((state) => !validKeys.has(`${state.unitId}::${state.itemId}`))
+      .filter((state) => {
+        if (validKeys.has(state.rowKey)) {
+          return false;
+        }
+        const partialRow = parseItemRowKeyParts(state.rowKey);
+        return !partialRow || !validItemUuids.has(partialRow.itemUuid);
+      })
       .map((state) => state.id);
 
     if (staleStateIds.length) {

--- a/backend/src/files/unit-parser.service.spec.ts
+++ b/backend/src/files/unit-parser.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
 import * as fs from "fs/promises";
 import { UnitParserService } from "./unit-parser.service";
-import { Acp, AcpFile } from "../database/entities";
+import { Acp, AcpAccessConfig, AcpFile } from "../database/entities";
 
 jest.mock("fs/promises", () => ({
   readFile: jest.fn(),
@@ -12,6 +12,7 @@ describe("UnitParserService", () => {
   let service: UnitParserService;
   let fileRepo: any;
   let acpRepo: any;
+  let accessConfigRepo: any;
 
   const xmlContent = `<?xml version="1.0" encoding="UTF-8"?>
 <Unit>
@@ -96,6 +97,13 @@ describe("UnitParserService", () => {
       save: jest.fn().mockImplementation(async (entity) => entity),
     };
 
+    accessConfigRepo = {
+      findOne: jest.fn().mockResolvedValue({
+        acpId: "acp-1",
+        featureConfig: {},
+      }),
+    };
+
     (fs.readFile as jest.Mock).mockImplementation(async (path: string) => {
       if (path === "/tmp/u1.xml") return xmlContent;
       if (path === "/tmp/u1.vomd") return vomdContent;
@@ -107,6 +115,10 @@ describe("UnitParserService", () => {
         UnitParserService,
         { provide: getRepositoryToken(AcpFile), useValue: fileRepo },
         { provide: getRepositoryToken(Acp), useValue: acpRepo },
+        {
+          provide: getRepositoryToken(AcpAccessConfig),
+          useValue: accessConfigRepo,
+        },
       ],
     }).compile();
 
@@ -354,4 +366,90 @@ describe("UnitParserService", () => {
       }),
     );
   });
+
+  it("merges item properties across legacy, resolved and UUID aliases", async () => {
+    const vomdWithUuid = JSON.stringify({
+      profiles: [],
+      items: [
+        {
+          id: "i1",
+          uuid: "uuid-1",
+          description: "Item 1",
+          variableId: "V1",
+          useUnitAliasAsPrefix: true,
+          profiles: [],
+        },
+      ],
+    });
+
+    (fs.readFile as jest.Mock).mockImplementation(async (path: string) => {
+      if (path === "/tmp/u1.xml") return xmlContent;
+      if (path === "/tmp/u1.vomd") return vomdWithUuid;
+      return "";
+    });
+
+    const result = await service.getItemListFromFiles("acp-1", {
+      itemPropertiesOverride: {
+        i1: { tags: ["legacy"], empiricalDifficulty: 0.25 },
+        u1_i1: { tags: ["resolved"] },
+        "uuid-1": { empiricalDifficulty: 0.75 },
+      },
+    });
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        uuid: "uuid-1",
+        rowKey: "uuid-1",
+        empiricalDifficulty: 0.75,
+        tags: ["resolved"],
+      }),
+    ]);
+  });
+
+  it("expands one VOMD item into labeled partial-credit rows", async () => {
+    accessConfigRepo.findOne.mockResolvedValueOnce({
+      acpId: "acp-1",
+      featureConfig: {
+        itemSubIdLabel: "Kategorie",
+        itemSubIdLabels: {
+          "1": "teilweise richtig",
+          "2": "vollständig richtig",
+        },
+      },
+    });
+
+    const result = await service.getItemListFromFiles("acp-1", {
+      itemPropertiesOverride: {
+        "u1_i1::1": {
+          itemUuid: "u1_i1",
+          subId: "1",
+          empiricalDifficulty: 0,
+        },
+        "u1_i1::2": {
+          itemUuid: "u1_i1",
+          subId: "2",
+          empiricalDifficulty: 0.75,
+        },
+      },
+    });
+
+    expect(result.subIdLabel).toBe("Kategorie");
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        uuid: "u1_i1",
+        rowKey: "u1_i1::1",
+        subId: "1",
+        subIdDisplay: "teilweise richtig",
+        empiricalDifficulty: 0,
+      }),
+      expect.objectContaining({
+        uuid: "u1_i1",
+        rowKey: "u1_i1::2",
+        subId: "2",
+        subIdDisplay: "vollständig richtig",
+        empiricalDifficulty: 0.75,
+      }),
+    ]);
+  });
+
 });

--- a/backend/src/files/unit-parser.service.spec.ts
+++ b/backend/src/files/unit-parser.service.spec.ts
@@ -451,5 +451,4 @@ describe("UnitParserService", () => {
       }),
     ]);
   });
-
 });

--- a/backend/src/files/unit-parser.service.ts
+++ b/backend/src/files/unit-parser.service.ts
@@ -2,12 +2,17 @@ import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import * as fs from "fs/promises";
-import { AcpFile, Acp } from "../database/entities";
+import { AcpFile, Acp, AcpAccessConfig } from "../database/entities";
 import {
   getAssessmentParts,
   normalizeIndexForStorage,
 } from "../acp/acp-index.utils";
 import { FileProcessingProgressReporter } from "./file-processing-progress";
+import { normalizeFeatureConfig } from "../acp/feature-config.utils";
+import {
+  buildItemRowKey,
+  parseItemRowKeyParts,
+} from "../items/item-row-key.util";
 
 /** Parsed reference data from a unit .xml file */
 export interface UnitXmlData {
@@ -44,6 +49,9 @@ export interface MetadataColumn {
 export interface VomdItemData {
   itemId: string;
   uuid: string;
+  rowKey: string;
+  subId?: string;
+  subIdDisplay?: string;
   unitId: string;
   unitLabel: string;
   description: string;
@@ -58,8 +66,16 @@ export interface VomdItemData {
 export interface ItemListResult {
   columns: MetadataColumn[];
   items: VomdItemData[];
+  subIdLabel: string;
+  subIdLabels: Record<string, string>;
   unitMetadata: Record<string, any[]>; // unitId → unit-level profile entries
   codingSchemes: Record<string, any>; // unitId → coding scheme JSON
+}
+
+interface PartialCreditRow {
+  rowKey: string;
+  subId: string;
+  properties: Record<string, unknown>;
 }
 
 export interface IndexSyncReport {
@@ -87,6 +103,8 @@ export class UnitParserService {
     private readonly fileRepository: Repository<AcpFile>,
     @InjectRepository(Acp)
     private readonly acpRepository: Repository<Acp>,
+    @InjectRepository(AcpAccessConfig)
+    private readonly accessConfigRepository: Repository<AcpAccessConfig>,
   ) {}
 
   /**
@@ -552,10 +570,29 @@ export class UnitParserService {
    * Read all .vomd files for an ACP, extract items with profile metadata,
    * and determine dynamic columns.
    */
-  async getItemListFromFiles(acpId: string): Promise<ItemListResult> {
+  async getItemListFromFiles(
+    acpId: string,
+    options: {
+      itemPropertiesOverride?: Record<string, Record<string, unknown>>;
+    } = {},
+  ): Promise<ItemListResult> {
     const allFiles = await this.fileRepository.find({ where: { acpId } });
     const acp = await this.acpRepository.findOne({ where: { id: acpId } });
-    const itemProps = acp?.itemProperties || {};
+    const accessConfig = await this.accessConfigRepository.findOne({
+      where: { acpId },
+    });
+    const itemProps =
+      options.itemPropertiesOverride || acp?.itemProperties || {};
+    const normalizedFeatureConfig = normalizeFeatureConfig(
+      accessConfig?.featureConfig || {},
+    ) as Record<string, unknown>;
+    const subIdLabel = String(
+      normalizedFeatureConfig.itemSubIdLabel || "Sub-ID",
+    );
+    const subIdLabels = this.asStringMap(
+      normalizedFeatureConfig.itemSubIdLabels,
+    );
+    const partialRowsByItemUuid = this.indexPartialCreditRows(itemProps);
 
     // Collect all columns and items
     const columnMap = new Map<string, string>(); // id → label
@@ -648,31 +685,57 @@ export class UnitParserService {
             item.variableReadOnlyId ||
             "";
 
-          items.push({
-            itemId: item.id,
-            uuid: item.uuid || `${parsed.unitId}_${item.id}`,
-            unitId: parsed.unitId,
-            unitLabel: parsed.unitLabel,
-            description: item.description || "",
-            variableId: sourceVariable,
-            sourceVariable: sourceVariable || undefined,
-            metadata,
-            empiricalDifficulty:
-              (item.uuid && itemProps[item.uuid]?.empiricalDifficulty) ||
-              itemProps[resolvedItemId]?.empiricalDifficulty ||
-              itemProps[item.id]?.empiricalDifficulty,
-            tags:
-              (item.uuid && Array.isArray(itemProps[item.uuid]?.tags)
-                ? itemProps[item.uuid].tags
-                : undefined) ||
-              (Array.isArray(itemProps[resolvedItemId]?.tags)
-                ? itemProps[resolvedItemId].tags
-                : undefined) ||
-              (Array.isArray(itemProps[item.id]?.tags)
-                ? itemProps[item.id].tags
-                : undefined) ||
-              [],
-          });
+          const itemUuid = item.uuid || `${parsed.unitId}_${item.id}`;
+          const baseProperties = this.resolveItemProperties(itemProps, [
+            itemUuid,
+            resolvedItemId,
+            item.id,
+          ]);
+          const partialRows = partialRowsByItemUuid.get(itemUuid) || [];
+
+          const explorerRows = partialRows.length
+            ? partialRows
+            : [
+                {
+                  rowKey: buildItemRowKey(itemUuid),
+                  subId: "",
+                  properties: baseProperties,
+                },
+              ];
+
+          for (const explorerRow of explorerRows) {
+            const rowProperties = {
+              ...baseProperties,
+              ...explorerRow.properties,
+            };
+            const empiricalDifficultyRaw = rowProperties.empiricalDifficulty;
+            const empiricalDifficulty =
+              empiricalDifficultyRaw === undefined ||
+              empiricalDifficultyRaw === null ||
+              !Number.isFinite(Number(empiricalDifficultyRaw))
+                ? undefined
+                : Number(empiricalDifficultyRaw);
+
+            items.push({
+              itemId: item.id,
+              uuid: itemUuid,
+              rowKey: explorerRow.rowKey,
+              subId: explorerRow.subId || undefined,
+              subIdDisplay: explorerRow.subId
+                ? subIdLabels[explorerRow.subId] || explorerRow.subId
+                : undefined,
+              unitId: parsed.unitId,
+              unitLabel: parsed.unitLabel,
+              description: item.description || "",
+              variableId: sourceVariable,
+              sourceVariable: sourceVariable || undefined,
+              metadata: { ...metadata },
+              empiricalDifficulty,
+              tags: Array.isArray(rowProperties.tags)
+                ? rowProperties.tags.map((tag) => String(tag))
+                : [],
+            });
+          }
         }
       } catch (e) {
         this.logger.error(`Error processing ${xmlFile.originalName}: ${e}`);
@@ -684,7 +747,67 @@ export class UnitParserService {
       ([id, label]) => ({ id, label }),
     );
 
-    return { columns, items, unitMetadata, codingSchemes };
+    return {
+      columns,
+      items,
+      subIdLabel,
+      subIdLabels,
+      unitMetadata,
+      codingSchemes,
+    };
+  }
+
+  private resolveItemProperties(
+    itemProperties: Record<string, Record<string, unknown>>,
+    keys: string[],
+  ): Record<string, unknown> {
+    const merged: Record<string, unknown> = {};
+    for (const key of [...keys].reverse()) {
+      const value = itemProperties[key];
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        Object.assign(merged, value);
+      }
+    }
+    return merged;
+  }
+
+  private indexPartialCreditRows(
+    itemProperties: Record<string, Record<string, unknown>>,
+  ): Map<string, PartialCreditRow[]> {
+    const indexed = new Map<string, PartialCreditRow[]>();
+    for (const [rowKey, rawProperties] of Object.entries(itemProperties)) {
+      const parts = parseItemRowKeyParts(rowKey);
+      if (
+        !parts ||
+        !rawProperties ||
+        typeof rawProperties !== "object" ||
+        Array.isArray(rawProperties)
+      ) {
+        continue;
+      }
+
+      const rows = indexed.get(parts.itemUuid) || [];
+      rows.push({
+        rowKey,
+        subId: parts.subId,
+        properties: rawProperties,
+      });
+      indexed.set(parts.itemUuid, rows);
+    }
+    return indexed;
+  }
+
+  private asStringMap(value: unknown): Record<string, string> {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return {};
+    }
+    const normalized: Record<string, string> = {};
+    for (const [key, label] of Object.entries(value)) {
+      if (typeof label === "string" && key.trim() && label.trim()) {
+        normalized[key.trim()] = label.trim();
+      }
+    }
+    return normalized;
   }
 
   /**

--- a/backend/src/item-explorer/item-explorer-state.service.spec.ts
+++ b/backend/src/item-explorer/item-explorer-state.service.spec.ts
@@ -338,6 +338,62 @@ describe("ItemExplorerStateService", () => {
     );
   });
 
+  it("preserves explicit empty overrides for partial-credit rows", async () => {
+    const record = buildStateRecord({
+      draftState: {
+        ...baseSharedState,
+        tags: { "uuid-1": ["base"] },
+        itemProperties: {
+          "uuid-1": {
+            tags: ["base"],
+            excluded: true,
+            previewTargetId: "BASE_A",
+          },
+          "uuid-1::1": {
+            itemUuid: "uuid-1",
+            subId: "1",
+          },
+        },
+      } as any,
+    });
+    stateRepo.findOne.mockResolvedValue(record);
+    stateRepo.save.mockImplementation(async (entity: any) => ({
+      ...entity,
+      updatedAt: new Date("2026-04-19T11:15:00.000Z"),
+    }));
+    changeLogRepo.save.mockResolvedValue(undefined);
+
+    const envelope = await service.patchDraft(
+      "acp-1",
+      {
+        tags: {
+          "uuid-1": ["base"],
+          "uuid-1::1": [],
+        },
+        itemPropertiesPatch: {
+          "uuid-1::1": {
+            tags: [],
+            excluded: false,
+            previewTargetId: "",
+          },
+        },
+      },
+      {
+        baseVersion: 1,
+        changeType: "PARTIAL_ROW_OVERRIDES_CLEARED",
+      },
+    );
+
+    expect(envelope.draftState.tags["uuid-1::1"]).toEqual([]);
+    expect(envelope.draftState.itemProperties["uuid-1::1"]).toEqual(
+      expect.objectContaining({
+        tags: [],
+        excluded: false,
+        previewTargetId: "",
+      }),
+    );
+  });
+
   it("publishes draft atomically into ACP domain data and feature config", async () => {
     const draftState = {
       ...baseSharedState,

--- a/backend/src/item-explorer/item-explorer-state.service.spec.ts
+++ b/backend/src/item-explorer/item-explorer-state.service.spec.ts
@@ -15,6 +15,7 @@ describe("ItemExplorerStateService", () => {
   let accessConfigRepo: any;
   let stateRepo: any;
   let changeLogRepo: any;
+  let transactionManager: any;
 
   const baseSharedState = {
     ui: {},
@@ -63,6 +64,18 @@ describe("ItemExplorerStateService", () => {
       find: jest.fn(),
       create: jest.fn().mockImplementation((payload) => payload),
       save: jest.fn(),
+    };
+    transactionManager = {
+      getRepository: jest.fn((entity) => {
+        if (entity === Acp) return acpRepo;
+        if (entity === AcpAccessConfig) return accessConfigRepo;
+        if (entity === AcpItemExplorerState) return stateRepo;
+        if (entity === AcpItemExplorerChangeLog) return changeLogRepo;
+        throw new Error(`Unexpected repository: ${String(entity)}`);
+      }),
+    };
+    stateRepo.manager = {
+      transaction: jest.fn((callback) => callback(transactionManager)),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -150,6 +163,28 @@ describe("ItemExplorerStateService", () => {
     expect(changeLogRepo.save).not.toHaveBeenCalled();
   });
 
+  it("rechecks the draft version after acquiring the transaction lock", async () => {
+    stateRepo.findOne
+      .mockResolvedValueOnce(buildStateRecord({ version: 4 }))
+      .mockResolvedValueOnce(buildStateRecord({ version: 5 }));
+
+    await expect(
+      service.patchDraft(
+        "acp-1",
+        { ui: { filterText: "new" } },
+        { baseVersion: 4 },
+      ),
+    ).rejects.toThrow(ConflictException);
+
+    expect(stateRepo.manager.transaction).toHaveBeenCalledTimes(1);
+    expect(stateRepo.findOne).toHaveBeenLastCalledWith({
+      where: { acpId: "acp-1" },
+      lock: { mode: "pessimistic_write" },
+    });
+    expect(stateRepo.save).not.toHaveBeenCalled();
+    expect(changeLogRepo.save).not.toHaveBeenCalled();
+  });
+
   it("patches draft, increments version and writes audit log entry", async () => {
     const record = buildStateRecord();
     stateRepo.findOne.mockResolvedValue(record);
@@ -175,6 +210,7 @@ describe("ItemExplorerStateService", () => {
 
     expect(envelope.status).toBe("DIRTY");
     expect(envelope.version).toBe(2);
+    expect(stateRepo.manager.transaction).toHaveBeenCalledTimes(1);
     expect(changeLogRepo.create).toHaveBeenCalledWith(
       expect.objectContaining({
         acpId: "acp-1",
@@ -354,12 +390,95 @@ describe("ItemExplorerStateService", () => {
     expect(envelope.status).toBe("CLEAN");
     expect(envelope.version).toBe(4);
     expect(envelope.publishedVersion).toBe(3);
+    expect(stateRepo.manager.transaction).toHaveBeenCalledTimes(1);
     expect(changeLogRepo.create).toHaveBeenCalledWith(
       expect.objectContaining({
         changeType: "SAVE_DRAFT",
         publishedVersion: 3,
       }),
     );
+  });
+
+  it("publishes immediate item properties in one locked transaction", async () => {
+    const record = buildStateRecord({
+      publishedState: {
+        ...baseSharedState,
+        itemProperties: { item1: { empiricalDifficulty: 0.2 } },
+      },
+      draftState: {
+        ...baseSharedState,
+        itemProperties: { item1: { empiricalDifficulty: 0.2 } },
+      },
+      version: 4,
+      publishedVersion: 2,
+    });
+    stateRepo.findOne.mockResolvedValue(record);
+    stateRepo.save.mockImplementation(async (entity: any) => ({
+      ...entity,
+      updatedAt: new Date("2026-04-19T12:30:00.000Z"),
+    }));
+    acpRepo.findOne.mockResolvedValue({ id: "acp-1", itemProperties: {} });
+    acpRepo.save.mockImplementation(async (entity: any) => entity);
+    accessConfigRepo.findOne.mockResolvedValue(null);
+    changeLogRepo.save.mockResolvedValue(undefined);
+
+    const envelope = await service.publishItemPropertiesImmediately(
+      "acp-1",
+      { item1: { empiricalDifficulty: 0.8 } },
+      {
+        actor: { username: "alice", role: "ACP_MANAGER" },
+        changeType: "CSV_UPLOAD_EMPIRICAL_DIFFICULTY",
+        baseVersion: 4,
+      },
+    );
+
+    expect(stateRepo.manager.transaction).toHaveBeenCalledTimes(1);
+    expect(stateRepo.findOne).toHaveBeenCalledWith({
+      where: { acpId: "acp-1" },
+      lock: { mode: "pessimistic_write" },
+    });
+    expect(acpRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemProperties: { item1: { empiricalDifficulty: 0.8 } },
+      }),
+    );
+    expect(envelope.status).toBe("CLEAN");
+    expect(envelope.version).toBe(5);
+    expect(envelope.publishedVersion).toBe(3);
+    expect(envelope.publishedState.itemProperties).toEqual({
+      item1: { empiricalDifficulty: 0.8 },
+    });
+    expect(changeLogRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changeType: "CSV_UPLOAD_EMPIRICAL_DIFFICULTY",
+        draftVersion: 5,
+        publishedVersion: 3,
+      }),
+    );
+  });
+
+  it("keeps audit logging inside the immediate publish transaction", async () => {
+    const record = buildStateRecord({ version: 4, publishedVersion: 2 });
+    stateRepo.findOne.mockResolvedValue(record);
+    stateRepo.save.mockImplementation(async (entity: any) => entity);
+    acpRepo.findOne.mockResolvedValue({ id: "acp-1", itemProperties: {} });
+    acpRepo.save.mockImplementation(async (entity: any) => entity);
+    accessConfigRepo.findOne.mockResolvedValue(null);
+    changeLogRepo.save.mockRejectedValue(new Error("audit write failed"));
+
+    await expect(
+      service.publishItemPropertiesImmediately(
+        "acp-1",
+        { item1: { empiricalDifficulty: 0.8 } },
+        {
+          changeType: "CSV_UPLOAD_EMPIRICAL_DIFFICULTY",
+          baseVersion: 4,
+        },
+      ),
+    ).rejects.toThrow("audit write failed");
+
+    expect(stateRepo.manager.transaction).toHaveBeenCalledTimes(1);
+    expect(changeLogRepo.save).toHaveBeenCalledTimes(1);
   });
 
   it("discard resets draft to published and logs change", async () => {
@@ -391,6 +510,7 @@ describe("ItemExplorerStateService", () => {
 
     expect(envelope.status).toBe("CLEAN");
     expect(envelope.version).toBe(6);
+    expect(stateRepo.manager.transaction).toHaveBeenCalledTimes(1);
     expect(envelope.draftState.ui).toEqual(publishedState.ui);
     expect(changeLogRepo.create).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/backend/src/item-explorer/item-explorer-state.service.spec.ts
+++ b/backend/src/item-explorer/item-explorer-state.service.spec.ts
@@ -537,6 +537,90 @@ describe("ItemExplorerStateService", () => {
     expect(changeLogRepo.save).toHaveBeenCalledTimes(1);
   });
 
+  it("replaces tags in domain and explorer state in one transaction", async () => {
+    const currentState = {
+      ...baseSharedState,
+      tags: {
+        item1: ["old"],
+        item2: ["stale"],
+        "uuid-1::1": ["inherited"],
+      },
+      itemProperties: {
+        item1: { empiricalDifficulty: 0.2, tags: ["old"] },
+        item2: { tags: ["stale"] },
+        "uuid-1::1": {
+          itemUuid: "uuid-1",
+          subId: "1",
+          tags: ["inherited"],
+        },
+      },
+    };
+    const record = buildStateRecord({
+      publishedState: JSON.parse(JSON.stringify(currentState)),
+      draftState: JSON.parse(JSON.stringify(currentState)),
+      version: 4,
+      publishedVersion: 2,
+    });
+    stateRepo.findOne.mockResolvedValue(record);
+    stateRepo.save.mockImplementation(async (entity: any) => ({
+      ...entity,
+      updatedAt: new Date("2026-04-19T12:45:00.000Z"),
+    }));
+    acpRepo.findOne.mockResolvedValue({ id: "acp-1", itemProperties: {} });
+    acpRepo.save.mockImplementation(async (entity: any) => entity);
+    accessConfigRepo.findOne.mockResolvedValue(null);
+    changeLogRepo.save.mockResolvedValue(undefined);
+
+    const result = await service.publishTagsImmediately(
+      "acp-1",
+      {
+        item1: [" new ", "new"],
+        "uuid-1::1": [],
+      },
+      {
+        actor: { username: "reader", role: "READ_ONLY" },
+        changeType: "REPLACE_ITEM_TAGS",
+      },
+    );
+
+    expect(result.tags).toEqual({
+      item1: ["new"],
+      "uuid-1::1": [],
+    });
+    expect(result.state.publishedState.tags).toEqual(result.tags);
+    expect(result.state.draftState.tags).toEqual(result.tags);
+    expect(result.state.publishedState.itemProperties).toEqual({
+      item1: { empiricalDifficulty: 0.2, tags: ["new"] },
+      "uuid-1::1": {
+        itemUuid: "uuid-1",
+        subId: "1",
+        tags: [],
+      },
+    });
+    expect(acpRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemProperties: result.state.publishedState.itemProperties,
+      }),
+    );
+    expect(changeLogRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ changeType: "REPLACE_ITEM_TAGS" }),
+    );
+  });
+
+  it("rejects direct tag replacement while a draft is pending", async () => {
+    stateRepo.findOne.mockResolvedValue(
+      buildStateRecord({ status: "DIRTY", version: 3 }),
+    );
+
+    await expect(
+      service.publishTagsImmediately("acp-1", { item1: ["new"] }),
+    ).rejects.toThrow(ConflictException);
+
+    expect(acpRepo.save).not.toHaveBeenCalled();
+    expect(stateRepo.save).not.toHaveBeenCalled();
+    expect(changeLogRepo.save).not.toHaveBeenCalled();
+  });
+
   it("discard resets draft to published and logs change", async () => {
     const publishedState = {
       ...baseSharedState,

--- a/backend/src/item-explorer/item-explorer-state.service.spec.ts
+++ b/backend/src/item-explorer/item-explorer-state.service.spec.ts
@@ -141,6 +141,25 @@ describe("ItemExplorerStateService", () => {
     expect(stateRepo.save).toHaveBeenCalledTimes(1);
   });
 
+  it("returns state created by a concurrent initializer after locking the ACP", async () => {
+    const concurrentlyCreated = buildStateRecord();
+    stateRepo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(concurrentlyCreated);
+    acpRepo.findOne.mockResolvedValue({ id: "acp-1", itemProperties: {} });
+
+    const envelope = await service.getStateForViewer("acp-1", false);
+
+    expect(acpRepo.findOne).toHaveBeenCalledWith({
+      where: { id: "acp-1" },
+      lock: { mode: "pessimistic_write" },
+    });
+    expect(envelope.version).toBe(1);
+    expect(stateRepo.create).not.toHaveBeenCalled();
+    expect(stateRepo.save).not.toHaveBeenCalled();
+    expect(accessConfigRepo.findOne).not.toHaveBeenCalled();
+  });
+
   it("returns conflict on outdated draft version", async () => {
     stateRepo.findOne.mockResolvedValue(buildStateRecord({ version: 7 }));
 

--- a/backend/src/item-explorer/item-explorer-state.service.ts
+++ b/backend/src/item-explorer/item-explorer-state.service.ts
@@ -246,6 +246,104 @@ export class ItemExplorerStateService {
     );
   }
 
+  async publishTagsImmediately(
+    acpId: string,
+    tags: Record<string, string[]>,
+    options: {
+      actor?: ExplorerActor;
+      changeType?: string;
+      baseVersion?: number;
+    } = {},
+  ): Promise<{
+    tags: Record<string, string[]>;
+    state: ExplorerStateEnvelope;
+  }> {
+    return this.withLockedState(
+      acpId,
+      async (
+        {
+          stateRepository,
+          acpRepository,
+          accessConfigRepository,
+          changeLogRepository,
+        },
+        record,
+      ) => {
+        if (record.status === "DIRTY") {
+          throw new ConflictException(
+            "Direct item-tag changes are not allowed while an Item Explorer draft is pending.",
+          );
+        }
+        this.assertVersion(record, options.baseVersion);
+
+        const before = this.normalizeStatePayload(record.publishedState);
+        const normalizedTags = this.normalizeTags(tags);
+        const itemProperties = this.normalizeItemProperties(
+          before.itemProperties,
+        );
+
+        for (const [itemKey, currentProperties] of Object.entries(
+          itemProperties,
+        )) {
+          const nextProperties = { ...currentProperties };
+          delete nextProperties.tags;
+          if (Object.keys(nextProperties).length > 0) {
+            itemProperties[itemKey] = nextProperties;
+          } else {
+            delete itemProperties[itemKey];
+          }
+        }
+
+        for (const [itemKey, tagValues] of Object.entries(normalizedTags)) {
+          itemProperties[itemKey] = {
+            ...(itemProperties[itemKey] || {}),
+            tags: tagValues,
+          };
+        }
+
+        const nextPublished: ExplorerSharedStatePayload = {
+          ...before,
+          tags: normalizedTags,
+          itemProperties: this.normalizeItemProperties(itemProperties),
+        };
+
+        await this.applyPublishedStateToDomain(acpId, nextPublished, {
+          acpRepository,
+          accessConfigRepository,
+        });
+
+        record.publishedState = nextPublished as unknown as Record<
+          string,
+          unknown
+        >;
+        record.draftState = nextPublished as unknown as Record<string, unknown>;
+        record.status = "CLEAN";
+        record.version += 1;
+        record.publishedVersion += 1;
+        this.applyActor(record, options.actor);
+        const saved = await stateRepository.save(record);
+
+        await this.logChange(
+          {
+            acpId,
+            changeType: options.changeType || "REPLACE_ITEM_TAGS",
+            before,
+            after: nextPublished,
+            draftVersion: saved.version,
+            publishedVersion: saved.publishedVersion,
+            actor: options.actor,
+          },
+          changeLogRepository,
+        );
+
+        return {
+          tags: normalizedTags,
+          state: this.toEnvelope(saved, true),
+        };
+      },
+    );
+  }
+
   async discardDraft(
     acpId: string,
     options: { actor?: ExplorerActor; baseVersion?: number } = {},

--- a/backend/src/item-explorer/item-explorer-state.service.ts
+++ b/backend/src/item-explorer/item-explorer-state.service.ts
@@ -89,92 +89,196 @@ export class ItemExplorerStateService {
       baseVersion?: number;
     } = {},
   ): Promise<ExplorerStateEnvelope> {
-    const record = await this.ensureStateRecord(acpId);
-    this.assertVersion(record, options.baseVersion);
-
-    const before = this.normalizeStatePayload(record.draftState);
-    const after = this.mergeDraftPatch(before, patch);
-    const published = this.normalizeStatePayload(record.publishedState);
-
-    record.draftState = after as unknown as Record<string, unknown>;
-    record.status = this.statesEqual(after, published) ? "CLEAN" : "DIRTY";
-    record.version += 1;
-    this.applyActor(record, options.actor);
-    const saved = await this.stateRepository.save(record);
-
-    await this.logChange({
+    return this.withLockedState(
       acpId,
-      changeType: options.changeType || "PATCH_DRAFT",
-      before,
-      after,
-      draftVersion: saved.version,
-      publishedVersion: saved.publishedVersion,
-      actor: options.actor,
-    });
+      async ({ stateRepository, changeLogRepository }, record) => {
+        this.assertVersion(record, options.baseVersion);
 
-    return this.toEnvelope(saved, true);
+        const before = this.normalizeStatePayload(record.draftState);
+        const after = this.mergeDraftPatch(before, patch);
+        const published = this.normalizeStatePayload(record.publishedState);
+
+        record.draftState = after as unknown as Record<string, unknown>;
+        record.status = this.statesEqual(after, published) ? "CLEAN" : "DIRTY";
+        record.version += 1;
+        this.applyActor(record, options.actor);
+        const saved = await stateRepository.save(record);
+
+        await this.logChange(
+          {
+            acpId,
+            changeType: options.changeType || "PATCH_DRAFT",
+            before,
+            after,
+            draftVersion: saved.version,
+            publishedVersion: saved.publishedVersion,
+            actor: options.actor,
+          },
+          changeLogRepository,
+        );
+
+        return this.toEnvelope(saved, true);
+      },
+    );
   }
 
   async saveDraft(
     acpId: string,
     options: { actor?: ExplorerActor; baseVersion?: number } = {},
   ): Promise<ExplorerStateEnvelope> {
-    const record = await this.ensureStateRecord(acpId);
-    this.assertVersion(record, options.baseVersion);
-
-    const beforePublished = this.normalizeStatePayload(record.publishedState);
-    const nextPublished = this.normalizeStatePayload(record.draftState);
-
-    await this.applyPublishedStateToDomain(acpId, nextPublished);
-
-    record.publishedState = nextPublished as unknown as Record<string, unknown>;
-    record.draftState = nextPublished as unknown as Record<string, unknown>;
-    record.status = "CLEAN";
-    record.version += 1;
-    record.publishedVersion += 1;
-    this.applyActor(record, options.actor);
-    const saved = await this.stateRepository.save(record);
-
-    await this.logChange({
+    return this.withLockedState(
       acpId,
-      changeType: "SAVE_DRAFT",
-      before: beforePublished,
-      after: nextPublished,
-      draftVersion: saved.version,
-      publishedVersion: saved.publishedVersion,
-      actor: options.actor,
-    });
+      async (
+        {
+          stateRepository,
+          acpRepository,
+          accessConfigRepository,
+          changeLogRepository,
+        },
+        record,
+      ) => {
+        this.assertVersion(record, options.baseVersion);
 
-    return this.toEnvelope(saved, true);
+        const beforePublished = this.normalizeStatePayload(
+          record.publishedState,
+        );
+        const nextPublished = this.normalizeStatePayload(record.draftState);
+
+        await this.applyPublishedStateToDomain(acpId, nextPublished, {
+          acpRepository,
+          accessConfigRepository,
+        });
+
+        record.publishedState = nextPublished as unknown as Record<
+          string,
+          unknown
+        >;
+        record.draftState = nextPublished as unknown as Record<string, unknown>;
+        record.status = "CLEAN";
+        record.version += 1;
+        record.publishedVersion += 1;
+        this.applyActor(record, options.actor);
+        const saved = await stateRepository.save(record);
+
+        await this.logChange(
+          {
+            acpId,
+            changeType: "SAVE_DRAFT",
+            before: beforePublished,
+            after: nextPublished,
+            draftVersion: saved.version,
+            publishedVersion: saved.publishedVersion,
+            actor: options.actor,
+          },
+          changeLogRepository,
+        );
+
+        return this.toEnvelope(saved, true);
+      },
+    );
+  }
+
+  async publishItemPropertiesImmediately(
+    acpId: string,
+    itemProperties: Record<string, Record<string, unknown>>,
+    options: {
+      actor?: ExplorerActor;
+      changeType: string;
+      baseVersion: number;
+    },
+  ): Promise<ExplorerStateEnvelope> {
+    return this.withLockedState(
+      acpId,
+      async (
+        {
+          stateRepository,
+          acpRepository,
+          accessConfigRepository,
+          changeLogRepository,
+        },
+        record,
+      ) => {
+        if (record.status === "DIRTY") {
+          throw new ConflictException(
+            "Direct item-property changes are not allowed while an Item Explorer draft is pending.",
+          );
+        }
+        this.assertVersion(record, options.baseVersion);
+
+        const before = this.normalizeStatePayload(record.publishedState);
+        const nextPublished: ExplorerSharedStatePayload = {
+          ...before,
+          itemProperties: this.normalizeItemProperties(itemProperties),
+        };
+
+        await this.applyPublishedStateToDomain(acpId, nextPublished, {
+          acpRepository,
+          accessConfigRepository,
+        });
+
+        record.publishedState = nextPublished as unknown as Record<
+          string,
+          unknown
+        >;
+        record.draftState = nextPublished as unknown as Record<string, unknown>;
+        record.status = "CLEAN";
+        record.version += 1;
+        record.publishedVersion += 1;
+        this.applyActor(record, options.actor);
+        const saved = await stateRepository.save(record);
+
+        await this.logChange(
+          {
+            acpId,
+            changeType: options.changeType,
+            before,
+            after: nextPublished,
+            draftVersion: saved.version,
+            publishedVersion: saved.publishedVersion,
+            actor: options.actor,
+          },
+          changeLogRepository,
+        );
+
+        return this.toEnvelope(saved, true);
+      },
+    );
   }
 
   async discardDraft(
     acpId: string,
     options: { actor?: ExplorerActor; baseVersion?: number } = {},
   ): Promise<ExplorerStateEnvelope> {
-    const record = await this.ensureStateRecord(acpId);
-    this.assertVersion(record, options.baseVersion);
-
-    const before = this.normalizeStatePayload(record.draftState);
-    const published = this.normalizeStatePayload(record.publishedState);
-
-    record.draftState = published as unknown as Record<string, unknown>;
-    record.status = "CLEAN";
-    record.version += 1;
-    this.applyActor(record, options.actor);
-    const saved = await this.stateRepository.save(record);
-
-    await this.logChange({
+    return this.withLockedState(
       acpId,
-      changeType: "DISCARD_DRAFT",
-      before,
-      after: published,
-      draftVersion: saved.version,
-      publishedVersion: saved.publishedVersion,
-      actor: options.actor,
-    });
+      async ({ stateRepository, changeLogRepository }, record) => {
+        this.assertVersion(record, options.baseVersion);
 
-    return this.toEnvelope(saved, true);
+        const before = this.normalizeStatePayload(record.draftState);
+        const published = this.normalizeStatePayload(record.publishedState);
+
+        record.draftState = published as unknown as Record<string, unknown>;
+        record.status = "CLEAN";
+        record.version += 1;
+        this.applyActor(record, options.actor);
+        const saved = await stateRepository.save(record);
+
+        await this.logChange(
+          {
+            acpId,
+            changeType: "DISCARD_DRAFT",
+            before,
+            after: published,
+            draftVersion: saved.version,
+            publishedVersion: saved.publishedVersion,
+            actor: options.actor,
+          },
+          changeLogRepository,
+        );
+
+        return this.toEnvelope(saved, true);
+      },
+    );
   }
 
   async listChanges(
@@ -217,6 +321,39 @@ export class ItemExplorerStateService {
       username,
       role,
     };
+  }
+
+  private async withLockedState<T>(
+    acpId: string,
+    operation: (
+      repositories: {
+        stateRepository: Repository<AcpItemExplorerState>;
+        acpRepository: Repository<Acp>;
+        accessConfigRepository: Repository<AcpAccessConfig>;
+        changeLogRepository: Repository<AcpItemExplorerChangeLog>;
+      },
+      record: AcpItemExplorerState,
+    ) => Promise<T>,
+  ): Promise<T> {
+    await this.ensureStateRecord(acpId);
+
+    return this.stateRepository.manager.transaction(async (manager) => {
+      const repositories = {
+        stateRepository: manager.getRepository(AcpItemExplorerState),
+        acpRepository: manager.getRepository(Acp),
+        accessConfigRepository: manager.getRepository(AcpAccessConfig),
+        changeLogRepository: manager.getRepository(AcpItemExplorerChangeLog),
+      };
+      const record = await repositories.stateRepository.findOne({
+        where: { acpId },
+        lock: { mode: "pessimistic_write" },
+      });
+      if (!record) {
+        throw new NotFoundException("Item Explorer state not found");
+      }
+
+      return operation(repositories, record);
+    });
   }
 
   private async ensureStateRecord(
@@ -288,16 +425,25 @@ export class ItemExplorerStateService {
   private async applyPublishedStateToDomain(
     acpId: string,
     state: ExplorerSharedStatePayload,
+    repositories: {
+      acpRepository: Repository<Acp>;
+      accessConfigRepository: Repository<AcpAccessConfig>;
+    } = {
+      acpRepository: this.acpRepository,
+      accessConfigRepository: this.accessConfigRepository,
+    },
   ): Promise<void> {
-    const acp = await this.acpRepository.findOne({ where: { id: acpId } });
+    const acp = await repositories.acpRepository.findOne({
+      where: { id: acpId },
+    });
     if (!acp) {
       throw new NotFoundException("ACP not found");
     }
 
     acp.itemProperties = this.normalizeItemProperties(state.itemProperties);
-    await this.acpRepository.save(acp);
+    await repositories.acpRepository.save(acp);
 
-    const config = await this.accessConfigRepository.findOne({
+    const config = await repositories.accessConfigRepository.findOne({
       where: { acpId },
     });
     if (!config) {
@@ -320,7 +466,7 @@ export class ItemExplorerStateService {
     }
 
     config.featureConfig = normalizedFeatureConfig;
-    await this.accessConfigRepository.save(config);
+    await repositories.accessConfigRepository.save(config);
   }
 
   private toEnvelope(
@@ -443,21 +589,24 @@ export class ItemExplorerStateService {
     return merged;
   }
 
-  private async logChange(params: {
-    acpId: string;
-    changeType: string;
-    before: ExplorerSharedStatePayload;
-    after: ExplorerSharedStatePayload;
-    draftVersion?: number | null;
-    publishedVersion?: number | null;
-    actor?: ExplorerActor;
-  }): Promise<void> {
+  private async logChange(
+    params: {
+      acpId: string;
+      changeType: string;
+      before: ExplorerSharedStatePayload;
+      after: ExplorerSharedStatePayload;
+      draftVersion?: number | null;
+      publishedVersion?: number | null;
+      actor?: ExplorerActor;
+    },
+    repository = this.changeLogRepository,
+  ): Promise<void> {
     const diff = this.buildTopLevelDiff(params.before, params.after);
     const actorUserId = this.isUuid(params.actor?.userId)
       ? params.actor?.userId
       : null;
 
-    const entry = this.changeLogRepository.create({
+    const entry = repository.create({
       acpId: params.acpId,
       changeType: params.changeType,
       beforeState: params.before as unknown as Record<string, unknown>,
@@ -470,7 +619,7 @@ export class ItemExplorerStateService {
       actorRole: params.actor?.role || null,
     } as DeepPartial<AcpItemExplorerChangeLog>);
 
-    await this.changeLogRepository.save(entry);
+    await repository.save(entry);
   }
 
   private buildTopLevelDiff(

--- a/backend/src/item-explorer/item-explorer-state.service.ts
+++ b/backend/src/item-explorer/item-explorer-state.service.ts
@@ -13,6 +13,7 @@ import {
   ItemExplorerDraftStatus,
 } from "../database/entities";
 import { normalizeFeatureConfig } from "../acp/feature-config.utils";
+import { parseItemRowKeyParts } from "../items/item-row-key.util";
 
 export interface ExplorerActor {
   userId?: string;
@@ -694,7 +695,10 @@ export class ItemExplorerStateService {
         continue;
       }
       const normalizedValues = this.normalizeTagArray(value);
-      if (normalizedValues.length) {
+      if (
+        normalizedValues.length ||
+        parseItemRowKeyParts(normalizedItemKey) !== null
+      ) {
         tags[normalizedItemKey] = normalizedValues;
       }
     }
@@ -725,6 +729,7 @@ export class ItemExplorerStateService {
       if (!normalizedKey || !this.isRecord(value)) {
         continue;
       }
+      const isPartialRow = parseItemRowKeyParts(normalizedKey) !== null;
 
       const itemValue = this.asRecord(value);
       const nextItemValue: Record<string, unknown> = { ...itemValue };
@@ -733,6 +738,8 @@ export class ItemExplorerStateService {
         const tags = this.normalizeTagArray(itemValue.tags);
         if (tags.length) {
           nextItemValue.tags = tags;
+        } else if (isPartialRow) {
+          nextItemValue.tags = [];
         } else {
           delete nextItemValue.tags;
         }
@@ -756,6 +763,8 @@ export class ItemExplorerStateService {
         const normalizedPreviewTargetId = previewTargetIdRaw.trim();
         if (normalizedPreviewTargetId.length > 0) {
           nextItemValue.previewTargetId = normalizedPreviewTargetId;
+        } else if (isPartialRow) {
+          nextItemValue.previewTargetId = "";
         } else {
           delete nextItemValue.previewTargetId;
         }
@@ -766,6 +775,8 @@ export class ItemExplorerStateService {
       if (typeof itemValue.excluded === "boolean") {
         if (itemValue.excluded) {
           nextItemValue.excluded = true;
+        } else if (isPartialRow) {
+          nextItemValue.excluded = false;
         } else {
           delete nextItemValue.excluded;
         }

--- a/backend/src/item-explorer/item-explorer-state.service.ts
+++ b/backend/src/item-explorer/item-explorer-state.service.ts
@@ -458,31 +458,53 @@ export class ItemExplorerStateService {
   private async ensureStateRecord(
     acpId: string,
   ): Promise<AcpItemExplorerState> {
-    let record = await this.stateRepository.findOne({ where: { acpId } });
+    const record = await this.stateRepository.findOne({ where: { acpId } });
     if (record) {
       return record;
     }
 
-    const acp = await this.acpRepository.findOne({ where: { id: acpId } });
-    if (!acp) {
-      throw new NotFoundException("ACP not found");
-    }
+    return this.stateRepository.manager.transaction(async (manager) => {
+      const stateRepository = manager.getRepository(AcpItemExplorerState);
+      const acpRepository = manager.getRepository(Acp);
+      const accessConfigRepository = manager.getRepository(AcpAccessConfig);
 
-    const accessConfig = await this.accessConfigRepository.findOne({
-      where: { acpId },
+      // Serialize first-time initialization on the ACP row. The Item Explorer
+      // loads its item list and shared state concurrently, so both requests may
+      // observe a missing state before either one inserts it.
+      const acp = await acpRepository.findOne({
+        where: { id: acpId },
+        lock: { mode: "pessimistic_write" },
+      });
+      if (!acp) {
+        throw new NotFoundException("ACP not found");
+      }
+
+      const concurrentlyCreated = await stateRepository.findOne({
+        where: { acpId },
+      });
+      if (concurrentlyCreated) {
+        return concurrentlyCreated;
+      }
+
+      const accessConfig = await accessConfigRepository.findOne({
+        where: { acpId },
+      });
+      const defaultState = this.buildDefaultState(
+        acp,
+        accessConfig || undefined,
+      );
+
+      const newRecord = stateRepository.create({
+        acpId,
+        publishedState: defaultState as unknown as Record<string, unknown>,
+        draftState: defaultState as unknown as Record<string, unknown>,
+        status: "CLEAN",
+        version: 1,
+        publishedVersion: 1,
+      } as DeepPartial<AcpItemExplorerState>);
+
+      return stateRepository.save(newRecord);
     });
-    const defaultState = this.buildDefaultState(acp, accessConfig || undefined);
-
-    record = this.stateRepository.create({
-      acpId,
-      publishedState: defaultState as unknown as Record<string, unknown>,
-      draftState: defaultState as unknown as Record<string, unknown>,
-      status: "CLEAN",
-      version: 1,
-      publishedVersion: 1,
-    } as DeepPartial<AcpItemExplorerState>);
-
-    return this.stateRepository.save(record);
   }
 
   private buildDefaultState(

--- a/backend/src/items/item-response-state.service.spec.ts
+++ b/backend/src/items/item-response-state.service.spec.ts
@@ -57,7 +57,12 @@ describe("ItemResponseStateService", () => {
     );
     expect(result).toEqual(expect.objectContaining({ id: "state-1" }));
     expect(stateRepository.findOne).toHaveBeenCalledWith({
-      where: { acpId: "acp-1", itemId: "item-1", unitId: "unit-1" },
+      where: {
+        acpId: "acp-1",
+        itemId: "item-1",
+        unitId: "unit-1",
+        rowKey: "unit-1::item-1",
+      },
     });
   });
 
@@ -76,6 +81,7 @@ describe("ItemResponseStateService", () => {
       acpId: "acp-1",
       itemId: "item-2",
       unitId: "unit-2",
+      rowKey: "unit-2::item-2",
       responseData: { answer: 2 },
     });
     expect(stateRepository.save).toHaveBeenCalled();
@@ -170,7 +176,58 @@ describe("ItemResponseStateService", () => {
     ]);
     expect(stateRepository.find).toHaveBeenCalledWith({
       where: { acpId: "acp-1" },
-      order: { unitId: "ASC", itemId: "ASC" },
+      order: { unitId: "ASC", itemId: "ASC", rowKey: "ASC" },
+    });
+  });
+
+  it("stores response states independently for partial-credit row keys", async () => {
+    stateRepository.findOne.mockResolvedValue(null);
+
+    await service.saveResponseState(
+      "acp-1",
+      "item-1",
+      "unit-1",
+      { answer: 1 },
+      true,
+      "uuid-1::1",
+    );
+    await service.saveResponseState(
+      "acp-1",
+      "item-1",
+      "unit-1",
+      { answer: 2 },
+      true,
+      "uuid-1::2",
+    );
+
+    expect(stateRepository.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        rowKey: "uuid-1::1",
+        responseData: { answer: 1 },
+      }),
+    );
+    expect(stateRepository.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        rowKey: "uuid-1::2",
+        responseData: { answer: 2 },
+      }),
+    );
+  });
+
+  it("does not resolve a row key through a different item route", async () => {
+    stateRepository.findOne.mockResolvedValue(null);
+
+    await service.getResponseState("acp-1", "item-b", "unit-b", "uuid-a::1");
+
+    expect(stateRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        acpId: "acp-1",
+        itemId: "item-b",
+        unitId: "unit-b",
+        rowKey: "uuid-a::1",
+      },
     });
   });
 

--- a/backend/src/items/item-response-state.service.spec.ts
+++ b/backend/src/items/item-response-state.service.spec.ts
@@ -154,6 +154,57 @@ describe("ItemResponseStateService", () => {
     );
   });
 
+  it("keeps legacy fallback reads side-effect free", async () => {
+    const legacyState = {
+      id: "state-legacy",
+      acpId: "acp-1",
+      itemId: "item-1",
+      unitId: "unit-1",
+      rowKey: "unit-1::item-1",
+      responseData: { answer: 1 },
+    };
+    stateRepository.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(legacyState);
+
+    await expect(
+      service.getResponseState("acp-1", "item-1", "unit-1", "uuid-1"),
+    ).resolves.toEqual(legacyState);
+
+    expect(stateRepository.save).not.toHaveBeenCalled();
+  });
+
+  it("migrates a legacy row key only during a manager save", async () => {
+    const legacyState = {
+      id: "state-legacy",
+      acpId: "acp-1",
+      itemId: "item-1",
+      unitId: "unit-1",
+      rowKey: "unit-1::item-1",
+      responseData: { answer: 1 },
+    };
+    stateRepository.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(legacyState);
+
+    await service.saveResponseState(
+      "acp-1",
+      "item-1",
+      "unit-1",
+      { answer: 2 },
+      true,
+      "uuid-1",
+    );
+
+    expect(stateRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "state-legacy",
+        rowKey: "uuid-1",
+        responseData: { answer: 2 },
+      }),
+    );
+  });
+
   it("returns direct response state when available", async () => {
     stateRepository.findOne.mockResolvedValueOnce({ id: "state-direct" });
 

--- a/backend/src/items/item-response-state.service.spec.ts
+++ b/backend/src/items/item-response-state.service.spec.ts
@@ -19,7 +19,7 @@ describe("ItemResponseStateService", () => {
         .fn()
         .mockImplementation(async (value) => ({ id: "state-1", ...value })),
       delete: jest.fn(),
-      find: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
     };
 
     service = new ItemResponseStateService(stateRepository as any);
@@ -87,6 +87,73 @@ describe("ItemResponseStateService", () => {
     expect(stateRepository.save).toHaveBeenCalled();
   });
 
+  it("finds UUID-backed standard states for callers without a row key", async () => {
+    const canonicalState = {
+      id: "state-canonical",
+      acpId: "acp-1",
+      itemId: "item-1",
+      unitId: "unit-1",
+      rowKey: "uuid-1",
+      responseData: { answer: 1 },
+      updatedAt: new Date("2026-07-13T10:00:00.000Z"),
+    };
+    stateRepository.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(canonicalState);
+
+    await expect(
+      service.getResponseState("acp-1", "item-1", "unit-1"),
+    ).resolves.toEqual(canonicalState);
+
+    expect(stateRepository.findOne).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          acpId: "acp-1",
+          itemId: "item-1",
+          unitId: "unit-1",
+          rowKey: expect.anything(),
+        }),
+        order: { updatedAt: "DESC" },
+      }),
+    );
+    const rowKeyOperator = stateRepository.findOne.mock.calls[1][0].where
+      .rowKey as any;
+    expect(rowKeyOperator.type).toBe("not");
+    expect(rowKeyOperator.child.type).toBe("like");
+    expect(rowKeyOperator.child.value).toBe("%::%");
+  });
+
+  it("does not rename a canonical standard state back to its legacy key", async () => {
+    const canonicalState = {
+      id: "state-canonical",
+      acpId: "acp-1",
+      itemId: "item-1",
+      unitId: "unit-1",
+      rowKey: "uuid-1",
+      responseData: { answer: 1 },
+    };
+    stateRepository.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(canonicalState);
+
+    await service.saveResponseState(
+      "acp-1",
+      "item-1",
+      "unit-1",
+      { answer: 2 },
+      true,
+    );
+
+    expect(stateRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "state-canonical",
+        rowKey: "uuid-1",
+        responseData: { answer: 2 },
+      }),
+    );
+  });
+
   it("returns direct response state when available", async () => {
     stateRepository.findOne.mockResolvedValueOnce({ id: "state-direct" });
 
@@ -108,6 +175,7 @@ describe("ItemResponseStateService", () => {
 
   it("returns fallback state from previous item in same unit", async () => {
     stateRepository.findOne
+      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ id: "state-prev", itemId: "item-1" });
 

--- a/backend/src/items/item-response-state.service.ts
+++ b/backend/src/items/item-response-state.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, ForbiddenException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { Like, Not, Repository } from "typeorm";
 import { ItemResponseState } from "../database/entities";
 
 @Injectable()
@@ -29,12 +29,15 @@ export class ItemResponseStateService {
     }
 
     // Check if state already exists
-    const resolvedRowKey = this.resolveRowKey(rowKey, unitId, itemId);
-    let state = await this.findState(acpId, itemId, unitId, resolvedRowKey);
+    const explicitRowKey = this.normalizeRowKey(rowKey);
+    const resolvedRowKey = this.resolveRowKey(explicitRowKey, unitId, itemId);
+    let state = await this.findState(acpId, itemId, unitId, explicitRowKey);
 
     if (state) {
       // Update existing
-      state.rowKey = resolvedRowKey;
+      if (explicitRowKey) {
+        state.rowKey = resolvedRowKey;
+      }
       state.responseData = responseData;
     } else {
       // Create new
@@ -59,12 +62,7 @@ export class ItemResponseStateService {
     unitId: string,
     rowKey?: string,
   ): Promise<ItemResponseState | null> {
-    return this.findState(
-      acpId,
-      itemId,
-      unitId,
-      this.resolveRowKey(rowKey, unitId, itemId),
-    );
+    return this.findState(acpId, itemId, unitId, this.normalizeRowKey(rowKey));
   }
 
   /**
@@ -144,8 +142,12 @@ export class ItemResponseStateService {
       );
     }
 
-    const resolvedRowKey = this.resolveRowKey(rowKey, unitId, itemId);
-    const state = await this.findState(acpId, itemId, unitId, resolvedRowKey);
+    const state = await this.findState(
+      acpId,
+      itemId,
+      unitId,
+      this.normalizeRowKey(rowKey),
+    );
     const result = state
       ? await this.stateRepository.delete({ id: state.id })
       : { affected: 0 };
@@ -194,25 +196,47 @@ export class ItemResponseStateService {
     return String(rowKey || "").trim() || `${unitId}::${itemId}`;
   }
 
+  private normalizeRowKey(rowKey?: string): string | undefined {
+    const normalized = String(rowKey || "").trim();
+    return normalized || undefined;
+  }
+
   private async findState(
     acpId: string,
     itemId: string,
     unitId: string,
-    rowKey: string,
+    explicitRowKey?: string,
   ): Promise<ItemResponseState | null> {
+    const legacyRowKey = `${unitId}::${itemId}`;
+    const requestedRowKey = explicitRowKey || legacyRowKey;
     const direct = await this.stateRepository.findOne({
-      where: { acpId, itemId, unitId, rowKey },
+      where: { acpId, itemId, unitId, rowKey: requestedRowKey },
     });
-    if (direct || rowKey.includes("::")) {
+    if (direct) {
       return direct;
     }
 
-    const legacyRowKey = `${unitId}::${itemId}`;
+    if (!explicitRowKey) {
+      return this.stateRepository.findOne({
+        where: {
+          acpId,
+          itemId,
+          unitId,
+          rowKey: Not(Like("%::%")),
+        },
+        order: { updatedAt: "DESC" },
+      });
+    }
+
+    if (explicitRowKey.includes("::")) {
+      return null;
+    }
+
     const legacy = await this.stateRepository.findOne({
       where: { acpId, itemId, unitId, rowKey: legacyRowKey },
     });
     if (legacy) {
-      legacy.rowKey = rowKey;
+      legacy.rowKey = explicitRowKey;
       return this.stateRepository.save(legacy);
     }
     return null;

--- a/backend/src/items/item-response-state.service.ts
+++ b/backend/src/items/item-response-state.service.ts
@@ -235,10 +235,6 @@ export class ItemResponseStateService {
     const legacy = await this.stateRepository.findOne({
       where: { acpId, itemId, unitId, rowKey: legacyRowKey },
     });
-    if (legacy) {
-      legacy.rowKey = explicitRowKey;
-      return this.stateRepository.save(legacy);
-    }
-    return null;
+    return legacy;
   }
 }

--- a/backend/src/items/item-response-state.service.ts
+++ b/backend/src/items/item-response-state.service.ts
@@ -20,6 +20,7 @@ export class ItemResponseStateService {
     unitId: string,
     responseData: Record<string, any>,
     userIsManager: boolean,
+    rowKey?: string,
   ): Promise<ItemResponseState> {
     if (!userIsManager) {
       throw new ForbiddenException(
@@ -28,12 +29,12 @@ export class ItemResponseStateService {
     }
 
     // Check if state already exists
-    let state = await this.stateRepository.findOne({
-      where: { acpId, itemId, unitId },
-    });
+    const resolvedRowKey = this.resolveRowKey(rowKey, unitId, itemId);
+    let state = await this.findState(acpId, itemId, unitId, resolvedRowKey);
 
     if (state) {
       // Update existing
+      state.rowKey = resolvedRowKey;
       state.responseData = responseData;
     } else {
       // Create new
@@ -41,6 +42,7 @@ export class ItemResponseStateService {
         acpId,
         itemId,
         unitId,
+        rowKey: resolvedRowKey,
         responseData,
       });
     }
@@ -55,10 +57,14 @@ export class ItemResponseStateService {
     acpId: string,
     itemId: string,
     unitId: string,
+    rowKey?: string,
   ): Promise<ItemResponseState | null> {
-    return this.stateRepository.findOne({
-      where: { acpId, itemId, unitId },
-    });
+    return this.findState(
+      acpId,
+      itemId,
+      unitId,
+      this.resolveRowKey(rowKey, unitId, itemId),
+    );
   }
 
   /**
@@ -69,21 +75,30 @@ export class ItemResponseStateService {
     acpId: string,
     itemId: string,
     unitId: string,
-    itemList: { itemId: string; unitId: string }[],
+    itemList: { itemId: string; unitId: string; rowKey?: string }[],
+    rowKey?: string,
   ): Promise<{
     state: ItemResponseState | null;
     isFallback: boolean;
     fallbackItemId?: string;
   }> {
     // First try to get direct state
-    const directState = await this.getResponseState(acpId, itemId, unitId);
+    const directState = await this.getResponseState(
+      acpId,
+      itemId,
+      unitId,
+      rowKey,
+    );
     if (directState) {
       return { state: directState, isFallback: false };
     }
 
     // Find position of current item in the list
     const currentIndex = itemList.findIndex(
-      (i) => i.itemId === itemId && i.unitId === unitId,
+      (i) =>
+        i.itemId === itemId &&
+        i.unitId === unitId &&
+        (!rowKey || i.rowKey === rowKey),
     );
     if (currentIndex <= 0) {
       return { state: null, isFallback: false };
@@ -97,6 +112,7 @@ export class ItemResponseStateService {
           acpId,
           prevItem.itemId,
           prevItem.unitId,
+          prevItem.rowKey,
         );
         if (prevState) {
           return {
@@ -120,6 +136,7 @@ export class ItemResponseStateService {
     itemId: string,
     unitId: string,
     userIsManager: boolean,
+    rowKey?: string,
   ): Promise<{ success: boolean }> {
     if (!userIsManager) {
       throw new ForbiddenException(
@@ -127,7 +144,11 @@ export class ItemResponseStateService {
       );
     }
 
-    const result = await this.stateRepository.delete({ acpId, itemId, unitId });
+    const resolvedRowKey = this.resolveRowKey(rowKey, unitId, itemId);
+    const state = await this.findState(acpId, itemId, unitId, resolvedRowKey);
+    const result = state
+      ? await this.stateRepository.delete({ id: state.id })
+      : { affected: 0 };
     return {
       success:
         result.affected !== undefined &&
@@ -152,7 +173,7 @@ export class ItemResponseStateService {
 
     return this.stateRepository.find({
       where: { acpId },
-      order: { unitId: "ASC", itemId: "ASC" },
+      order: { unitId: "ASC", itemId: "ASC", rowKey: "ASC" },
     });
   }
 
@@ -163,5 +184,37 @@ export class ItemResponseStateService {
     // This is a placeholder - actual role checking should be done via AcpUserRole entity
     // The controller will handle the actual authorization check
     return false;
+  }
+
+  private resolveRowKey(
+    rowKey: string | undefined,
+    unitId: string,
+    itemId: string,
+  ): string {
+    return String(rowKey || "").trim() || `${unitId}::${itemId}`;
+  }
+
+  private async findState(
+    acpId: string,
+    itemId: string,
+    unitId: string,
+    rowKey: string,
+  ): Promise<ItemResponseState | null> {
+    const direct = await this.stateRepository.findOne({
+      where: { acpId, itemId, unitId, rowKey },
+    });
+    if (direct || rowKey.includes("::")) {
+      return direct;
+    }
+
+    const legacyRowKey = `${unitId}::${itemId}`;
+    const legacy = await this.stateRepository.findOne({
+      where: { acpId, itemId, unitId, rowKey: legacyRowKey },
+    });
+    if (legacy) {
+      legacy.rowKey = rowKey;
+      return this.stateRepository.save(legacy);
+    }
+    return null;
   }
 }

--- a/backend/src/items/item-row-key.util.spec.ts
+++ b/backend/src/items/item-row-key.util.spec.ts
@@ -1,0 +1,28 @@
+import {
+  buildItemRowKey,
+  normalizeItemSubId,
+  parseItemRowKey,
+  parseItemRowKeyParts,
+} from "./item-row-key.util";
+
+describe("item row keys", () => {
+  it("uses the item UUID unchanged for simple item rows", () => {
+    expect(buildItemRowKey("uuid-1")).toBe("uuid-1");
+    expect(parseItemRowKey("uuid-1", "uuid-1")).toEqual({});
+  });
+
+  it("creates a reversible key for a partial-credit sub ID", () => {
+    const key = buildItemRowKey("uuid-1", "Stufe 1/2");
+    expect(key).toBe("uuid-1::Stufe%201%2F2");
+    expect(parseItemRowKey(key, "uuid-1")).toEqual({ subId: "Stufe 1/2" });
+    expect(parseItemRowKeyParts(key)).toEqual({
+      itemUuid: "uuid-1",
+      subId: "Stufe 1/2",
+    });
+  });
+
+  it("normalizes whitespace and rejects unrelated keys", () => {
+    expect(normalizeItemSubId("  A  ")).toBe("A");
+    expect(parseItemRowKey("uuid-2::A", "uuid-1")).toBeNull();
+  });
+});

--- a/backend/src/items/item-row-key.util.ts
+++ b/backend/src/items/item-row-key.util.ts
@@ -1,0 +1,58 @@
+export const ITEM_ROW_KEY_SEPARATOR = "::";
+
+export function normalizeItemSubId(value: unknown): string {
+  return typeof value === "string" ? value.trim() : String(value ?? "").trim();
+}
+
+export function buildItemRowKey(itemUuid: string, subId?: unknown): string {
+  const normalizedUuid = String(itemUuid || "").trim();
+  const normalizedSubId = normalizeItemSubId(subId);
+  if (!normalizedSubId) {
+    return normalizedUuid;
+  }
+  return `${normalizedUuid}${ITEM_ROW_KEY_SEPARATOR}${encodeURIComponent(normalizedSubId)}`;
+}
+
+export function parseItemRowKeyParts(
+  rowKey: unknown,
+): { itemUuid: string; subId: string } | null {
+  const normalizedRowKey = String(rowKey || "").trim();
+  const separatorIndex = normalizedRowKey.indexOf(ITEM_ROW_KEY_SEPARATOR);
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const itemUuid = normalizedRowKey.slice(0, separatorIndex).trim();
+  const encodedSubId = normalizedRowKey.slice(
+    separatorIndex + ITEM_ROW_KEY_SEPARATOR.length,
+  );
+  if (!itemUuid || !encodedSubId) {
+    return null;
+  }
+
+  try {
+    const subId = normalizeItemSubId(decodeURIComponent(encodedSubId));
+    if (!subId || buildItemRowKey(itemUuid, subId) !== normalizedRowKey) {
+      return null;
+    }
+    return { itemUuid, subId };
+  } catch {
+    return null;
+  }
+}
+
+export function parseItemRowKey(
+  rowKey: unknown,
+  itemUuid: string,
+): { subId?: string } | null {
+  const normalizedRowKey = String(rowKey || "").trim();
+  const normalizedUuid = String(itemUuid || "").trim();
+  if (!normalizedRowKey || !normalizedUuid) {
+    return null;
+  }
+  if (normalizedRowKey === normalizedUuid) {
+    return {};
+  }
+  const parts = parseItemRowKeyParts(normalizedRowKey);
+  return parts?.itemUuid === normalizedUuid ? { subId: parts.subId } : null;
+}

--- a/backend/src/items/items.controller.spec.ts
+++ b/backend/src/items/items.controller.spec.ts
@@ -12,7 +12,6 @@ describe("ItemsController", () => {
       getFilteredItems: jest.fn().mockResolvedValue([{ itemId: "item-1" }]),
       canUseItemTags: jest.fn().mockResolvedValue(true),
       getItemTags: jest.fn().mockResolvedValue({ item1: ["A"] }),
-      saveItemTags: jest.fn().mockResolvedValue({ saved: true }),
       getItem: jest.fn().mockResolvedValue({ itemId: "item-1" }),
       uploadEmpiricalDifficulties: jest.fn().mockResolvedValue({
         updated: 2,
@@ -63,6 +62,10 @@ describe("ItemsController", () => {
       publishItemPropertiesImmediately: jest
         .fn()
         .mockResolvedValue({ status: "CLEAN", version: 5 }),
+      publishTagsImmediately: jest.fn().mockResolvedValue({
+        tags: { item1: ["A"] },
+        state: { status: "CLEAN", version: 5 },
+      }),
     };
 
     controller = new ItemsController(
@@ -120,9 +123,16 @@ describe("ItemsController", () => {
       req,
     );
 
-    expect(itemsService.saveItemTags).toHaveBeenCalledWith("acp-1", {
-      item1: ["A"],
-    });
+    expect(
+      itemExplorerStateService.publishTagsImmediately,
+    ).toHaveBeenCalledWith(
+      "acp-1",
+      { item1: ["A"] },
+      expect.objectContaining({
+        actor: { type: "user", id: "u-1" },
+        changeType: "REPLACE_ITEM_TAGS",
+      }),
+    );
   });
 
   it("uses empty map when save item tags payload has no tags", async () => {
@@ -130,7 +140,13 @@ describe("ItemsController", () => {
 
     await controller.saveItemTags("acp-1", {} as any, req);
 
-    expect(itemsService.saveItemTags).toHaveBeenCalledWith("acp-1", {});
+    expect(
+      itemExplorerStateService.publishTagsImmediately,
+    ).toHaveBeenCalledWith(
+      "acp-1",
+      {},
+      expect.objectContaining({ changeType: "REPLACE_ITEM_TAGS" }),
+    );
   });
 
   it("rejects save item tags for non-managers when feature disabled", async () => {

--- a/backend/src/items/items.controller.spec.ts
+++ b/backend/src/items/items.controller.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException } from "@nestjs/common";
+import { ConflictException, ForbiddenException } from "@nestjs/common";
 import { ItemsController } from "./items.controller";
 
 describe("ItemsController", () => {
@@ -44,6 +44,13 @@ describe("ItemsController", () => {
 
     itemExplorerStateService = {
       getStateForViewer: jest.fn().mockResolvedValue({
+        status: "CLEAN",
+        version: 4,
+        publishedState: {
+          itemProperties: {
+            "item-1": { id: "item-1", empiricalDifficulty: 0.4 },
+          },
+        },
         draftState: {
           itemProperties: {
             "item-1": { id: "item-1" },
@@ -52,6 +59,10 @@ describe("ItemsController", () => {
       }),
       resolveActor: jest.fn().mockReturnValue({ type: "user", id: "u-1" }),
       patchDraft: jest.fn().mockResolvedValue({ status: "DIRTY", version: 5 }),
+      saveDraft: jest.fn().mockResolvedValue({ status: "CLEAN", version: 6 }),
+      publishItemPropertiesImmediately: jest
+        .fn()
+        .mockResolvedValue({ status: "CLEAN", version: 5 }),
     };
 
     controller = new ItemsController(
@@ -157,11 +168,27 @@ describe("ItemsController", () => {
     expect(itemsService.uploadEmpiricalDifficulties).toHaveBeenCalledWith(
       "acp-1",
       file.buffer,
+      {
+        persist: false,
+        itemPropertiesOverride: {
+          "item-1": { id: "item-1", empiricalDifficulty: 0.4 },
+        },
+      },
     );
     expect(
       itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty,
     ).toHaveBeenCalledWith("acp-1");
-    expect(itemExplorerStateService.getStateForViewer).not.toHaveBeenCalled();
+    expect(
+      itemExplorerStateService.publishItemPropertiesImmediately,
+    ).toHaveBeenCalledWith(
+      "acp-1",
+      {
+        "item-1": { id: "item-1", empiricalDifficulty: 0.7 },
+      },
+      expect.objectContaining({ baseVersion: 4 }),
+    );
+    expect(itemExplorerStateService.patchDraft).not.toHaveBeenCalled();
+    expect(itemExplorerStateService.saveDraft).not.toHaveBeenCalled();
   });
 
   it("uploads empirical difficulties in draft mode and patches explorer state", async () => {
@@ -231,8 +258,40 @@ describe("ItemsController", () => {
 
     expect(itemsService.clearEmpiricalDifficulties).toHaveBeenCalledWith(
       "acp-1",
+      {
+        persist: false,
+        itemPropertiesOverride: {
+          "item-1": { id: "item-1", empiricalDifficulty: 0.4 },
+        },
+      },
+    );
+    expect(
+      itemExplorerStateService.publishItemPropertiesImmediately,
+    ).toHaveBeenCalledWith(
+      "acp-1",
+      { "item-1": { id: "item-1" } },
+      expect.objectContaining({
+        changeType: "CLEAR_EMPIRICAL_DIFFICULTY",
+        baseVersion: 4,
+      }),
     );
     expect(itemExplorerStateService.patchDraft).not.toHaveBeenCalled();
+    expect(itemExplorerStateService.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it("rejects direct item-property writes while a draft is pending", async () => {
+    itemExplorerStateService.getStateForViewer.mockResolvedValueOnce({
+      status: "DIRTY",
+      version: 7,
+      publishedState: { itemProperties: {} },
+      draftState: { itemProperties: {} },
+    });
+    const file = { buffer: Buffer.from("csv-data") } as Express.Multer.File;
+
+    await expect(
+      controller.uploadEmpiricalDifficulties("acp-1", file, "false"),
+    ).rejects.toThrow(ConflictException);
+    expect(itemsService.uploadEmpiricalDifficulties).not.toHaveBeenCalled();
   });
 
   it("clears empirical difficulties in draft mode and patches explorer state", async () => {
@@ -303,6 +362,7 @@ describe("ItemsController", () => {
       "unit-1",
       { answer: 1 },
       true,
+      undefined,
     );
   });
 
@@ -316,6 +376,7 @@ describe("ItemsController", () => {
       "acp-1",
       "item-1",
       "unit-1",
+      undefined,
     );
 
     stateService.getResponseState.mockResolvedValueOnce(null);
@@ -340,6 +401,7 @@ describe("ItemsController", () => {
       "item-1",
       "unit-1",
       itemList,
+      undefined,
     );
   });
 
@@ -359,6 +421,7 @@ describe("ItemsController", () => {
       "item-1",
       "unit-1",
       true,
+      undefined,
     );
   });
 

--- a/backend/src/items/items.controller.ts
+++ b/backend/src/items/items.controller.ts
@@ -13,6 +13,7 @@ import {
   Put,
   ForbiddenException,
   BadRequestException,
+  ConflictException,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -138,10 +139,35 @@ export class ItemsController {
     const parsedBaseVersion = parseInt(baseVersion || "", 10);
 
     if (!draftMode) {
+      const currentState =
+        await this.itemExplorerStateService.getStateForViewer(acpId, true);
+      this.assertCleanExplorerStateForDirectWrite(currentState.status);
       const uploadResult = await this.itemsService.uploadEmpiricalDifficulties(
         acpId,
         file.buffer,
+        {
+          persist: false,
+          itemPropertiesOverride: currentState.publishedState.itemProperties,
+        },
       );
+      if (uploadResult.updated > 0) {
+        const actor = this.itemExplorerStateService.resolveActor(
+          req?.user,
+          acpId,
+        );
+        await this.itemExplorerStateService.publishItemPropertiesImmediately(
+          acpId,
+          uploadResult.nextItemProperties as Record<
+            string,
+            Record<string, unknown>
+          >,
+          {
+            actor,
+            changeType: "CSV_UPLOAD_EMPIRICAL_DIFFICULTY",
+            baseVersion: currentState.version,
+          },
+        );
+      }
       const showOnlyItemsWithEmpiricalDifficulty =
         uploadResult.updated > 0
           ? await this.itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty(
@@ -216,7 +242,38 @@ export class ItemsController {
     const parsedBaseVersion = parseInt(baseVersion || "", 10);
 
     if (!draftMode) {
-      return this.itemsService.clearEmpiricalDifficulties(acpId);
+      const currentState =
+        await this.itemExplorerStateService.getStateForViewer(acpId, true);
+      this.assertCleanExplorerStateForDirectWrite(currentState.status);
+      const clearResult = await this.itemsService.clearEmpiricalDifficulties(
+        acpId,
+        {
+          persist: false,
+          itemPropertiesOverride: currentState.publishedState.itemProperties,
+        },
+      );
+      if (
+        JSON.stringify(clearResult.nextItemProperties) !==
+        JSON.stringify(currentState.publishedState.itemProperties)
+      ) {
+        const actor = this.itemExplorerStateService.resolveActor(
+          req?.user,
+          acpId,
+        );
+        await this.itemExplorerStateService.publishItemPropertiesImmediately(
+          acpId,
+          clearResult.nextItemProperties as Record<
+            string,
+            Record<string, unknown>
+          >,
+          {
+            actor,
+            changeType: "CLEAR_EMPIRICAL_DIFFICULTY",
+            baseVersion: currentState.version,
+          },
+        );
+      }
+      return clearResult;
     }
 
     const currentState = await this.itemExplorerStateService.getStateForViewer(
@@ -279,7 +336,12 @@ export class ItemsController {
   async saveResponseState(
     @Param("acpId") acpId: string,
     @Param("itemId") itemId: string,
-    @Body() body: { unitId: string; responseData: Record<string, any> },
+    @Body()
+    body: {
+      unitId: string;
+      rowKey?: string;
+      responseData: Record<string, any>;
+    },
     @Request() _req: any,
   ) {
     return this.stateService.saveResponseState(
@@ -288,6 +350,7 @@ export class ItemsController {
       body.unitId,
       body.responseData,
       true,
+      body.rowKey,
     );
   }
 
@@ -298,6 +361,7 @@ export class ItemsController {
     @Param("acpId") acpId: string,
     @Param("itemId") itemId: string,
     @Query("unitId") unitId?: string,
+    @Query("rowKey") rowKey?: string,
   ) {
     if (!unitId) {
       throw new BadRequestException('Query parameter "unitId" is required.');
@@ -306,6 +370,7 @@ export class ItemsController {
       acpId,
       itemId,
       unitId,
+      rowKey,
     );
     return state || { state: null };
   }
@@ -320,13 +385,18 @@ export class ItemsController {
     @Param("acpId") acpId: string,
     @Param("itemId") itemId: string,
     @Body()
-    body: { unitId: string; itemList: { itemId: string; unitId: string }[] },
+    body: {
+      unitId: string;
+      rowKey?: string;
+      itemList: { itemId: string; unitId: string; rowKey?: string }[];
+    },
   ) {
     return this.stateService.getResponseStateWithFallback(
       acpId,
       itemId,
       body.unitId,
       body.itemList,
+      body.rowKey,
     );
   }
 
@@ -340,10 +410,25 @@ export class ItemsController {
     @Param("itemId") itemId: string,
     @Query("unitId") unitId: string | undefined,
     @Request() _req: any,
+    @Query("rowKey") rowKey?: string,
   ) {
     if (!unitId) {
       throw new BadRequestException('Query parameter "unitId" is required.');
     }
-    return this.stateService.deleteResponseState(acpId, itemId, unitId, true);
+    return this.stateService.deleteResponseState(
+      acpId,
+      itemId,
+      unitId,
+      true,
+      rowKey,
+    );
+  }
+
+  private assertCleanExplorerStateForDirectWrite(status: string): void {
+    if (status === "DIRTY") {
+      throw new ConflictException(
+        "Direct item-property changes are not allowed while an Item Explorer draft is pending. Use draft mode or publish/discard the draft first.",
+      );
+    }
   }
 }

--- a/backend/src/items/items.controller.ts
+++ b/backend/src/items/items.controller.ts
@@ -95,7 +95,16 @@ export class ItemsController {
     if (!isManager && !(await this.itemsService.canUseItemTags(acpId))) {
       throw new ForbiddenException("Item tags are not enabled for this ACP");
     }
-    return this.itemsService.saveItemTags(acpId, dto.tags || {});
+    const actor = this.itemExplorerStateService.resolveActor(req?.user, acpId);
+    const result = await this.itemExplorerStateService.publishTagsImmediately(
+      acpId,
+      dto.tags || {},
+      {
+        actor,
+        changeType: "REPLACE_ITEM_TAGS",
+      },
+    );
+    return result.tags;
   }
 
   @Get(":itemId")

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -605,11 +605,13 @@ describe("ItemsService", () => {
         itemA: { tags: ["tag-a", " tag-a ", "tag-b", ""] },
         itemB: { tags: [] },
         itemC: { tags: "invalid" },
+        "uuid-1::1": { tags: [] },
       },
     });
 
     await expect(service.getItemTags("acp-1")).resolves.toEqual({
       itemA: ["tag-a", "tag-b"],
+      "uuid-1::1": [],
     });
   });
 
@@ -626,43 +628,5 @@ describe("ItemsService", () => {
 
     accessConfigRepository.findOne.mockResolvedValueOnce(null);
     await expect(service.canUseItemTags("acp-1")).resolves.toBe(false);
-  });
-
-  it("saves normalized tags and replaces previous tag state", async () => {
-    acpRepository.findOne.mockResolvedValueOnce(null);
-    await expect(service.saveItemTags("acp-1", {})).rejects.toThrow(
-      NotFoundException,
-    );
-
-    const acp = {
-      id: "acp-1",
-      itemProperties: {
-        itemA: { tags: ["old"], empiricalDifficulty: 0.4 },
-        itemB: { tags: ["to-remove"] },
-      },
-    };
-    acpRepository.findOne.mockResolvedValueOnce(acp);
-
-    const saved = await service.saveItemTags("acp-1", {
-      itemA: ["new", "new", "  keep  "],
-      itemB: [],
-      "   ": ["invalid-key"],
-      itemC: ["fresh"],
-    });
-
-    expect(saved).toEqual({
-      itemA: ["new", "keep"],
-      itemC: ["fresh"],
-    });
-
-    expect(acpRepository.save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        itemProperties: {
-          itemA: { empiricalDifficulty: 0.4, tags: ["new", "keep"] },
-          itemB: {},
-          itemC: { tags: ["fresh"] },
-        },
-      }),
-    );
   });
 });

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -225,7 +225,14 @@ describe("ItemsService", () => {
       { csvRow: "unknown-item", reason: "Kein passendes Item gefunden" },
     ]);
     expect(result.successes).toEqual([
-      { itemId: "I-1", unitId: "U-1", value: 0.75 },
+      {
+        itemId: "I-1",
+        unitId: "U-1",
+        rowKey: "uuid-1",
+        affectedRowKeys: ["uuid-1"],
+        subId: undefined,
+        value: 0.75,
+      },
     ]);
     expect(result.nextItemProperties).toEqual({
       existing: { unchanged: true },
@@ -263,6 +270,186 @@ describe("ItemsService", () => {
     await expect(
       service.uploadEmpiricalDifficulties("acp-1", Buffer.from(csv)),
     ).rejects.toThrow(BadRequestException);
+  });
+
+  it("imports multiple partial-credit rows for the same item by second-column Sub-ID", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {},
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          uuid: "uuid-1",
+          itemId: "I-1",
+          unitId: "U-1",
+          unitLabel: "U1",
+        },
+      ],
+    });
+
+    const csv = ["item;category;est", "I1;1;0.2", 'I1;"2";0.8'].join("\n");
+    const result = await service.uploadEmpiricalDifficulties(
+      "acp-1",
+      Buffer.from(csv),
+    );
+
+    expect(result.updated).toBe(2);
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1::1": {
+        itemUuid: "uuid-1",
+        subId: "1",
+        empiricalDifficulty: 0.2,
+      },
+      "uuid-1::2": {
+        itemUuid: "uuid-1",
+        subId: "2",
+        empiricalDifficulty: 0.8,
+      },
+    });
+    expect(result.successes).toEqual([
+      expect.objectContaining({
+        rowKey: "uuid-1::1",
+        affectedRowKeys: ["uuid-1::1"],
+        subId: "1",
+        value: 0.2,
+      }),
+      expect.objectContaining({
+        rowKey: "uuid-1::2",
+        affectedRowKeys: ["uuid-1::2"],
+        subId: "2",
+        value: 0.8,
+      }),
+    ]);
+  });
+
+  it("applies a standard difficulty to existing partial-credit rows without discarding their properties", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {
+        "uuid-1": { tags: ["base"], empiricalDifficulty: 0.1 },
+        "uuid-1::1": {
+          itemUuid: "uuid-1",
+          subId: "1",
+          empiricalDifficulty: 0.2,
+          tags: ["partial"],
+          excluded: true,
+        },
+        "uuid-1::2": {
+          itemUuid: "uuid-1",
+          subId: "2",
+          empiricalDifficulty: 0.8,
+          previewTargetId: "score-2",
+        },
+        unrelated: { unchanged: true },
+      },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          uuid: "uuid-1",
+          itemId: "I-1",
+          unitId: "U-1",
+          unitLabel: "U1",
+        },
+      ],
+    });
+
+    const result = await service.uploadEmpiricalDifficulties(
+      "acp-1",
+      Buffer.from("item;est\nI1;0.5"),
+    );
+
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1": { tags: ["base"] },
+      "uuid-1::1": {
+        itemUuid: "uuid-1",
+        subId: "1",
+        empiricalDifficulty: 0.5,
+        tags: ["partial"],
+        excluded: true,
+      },
+      "uuid-1::2": {
+        itemUuid: "uuid-1",
+        subId: "2",
+        empiricalDifficulty: 0.5,
+        previewTargetId: "score-2",
+      },
+      unrelated: { unchanged: true },
+    });
+    expect(result.successes).toEqual([
+      {
+        itemId: "I-1",
+        unitId: "U-1",
+        affectedRowKeys: ["uuid-1::1", "uuid-1::2"],
+        subId: undefined,
+        value: 0.5,
+      },
+    ]);
+  });
+
+  it("removes a hidden standard difficulty when importing partial-credit rows", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {
+        "uuid-1": { tags: ["base"], empiricalDifficulty: 0.5 },
+      },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          uuid: "uuid-1",
+          itemId: "I-1",
+          unitId: "U-1",
+          unitLabel: "U1",
+        },
+      ],
+    });
+
+    const result = await service.uploadEmpiricalDifficulties(
+      "acp-1",
+      Buffer.from("item;level;est\nI1;1;0.2\nI1;2;0.8"),
+    );
+
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1": { tags: ["base"] },
+      "uuid-1::1": {
+        itemUuid: "uuid-1",
+        subId: "1",
+        empiricalDifficulty: 0.2,
+      },
+      "uuid-1::2": {
+        itemUuid: "uuid-1",
+        subId: "2",
+        empiricalDifficulty: 0.8,
+      },
+    });
+  });
+
+  it("rejects mixing standard and partial-credit rows for one item", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {},
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          uuid: "uuid-1",
+          itemId: "I-1",
+          unitId: "U-1",
+          unitLabel: "U1",
+        },
+      ],
+    });
+
+    await expect(
+      service.uploadEmpiricalDifficulties(
+        "acp-1",
+        Buffer.from("item;level;est\nI1;;0.5\nI1;1;0.2"),
+      ),
+    ).rejects.toThrow(/sowohl mit als auch ohne Sub-ID/);
+
+    expect(acpRepository.save).not.toHaveBeenCalled();
   });
 
   it("supports dry-run upload mode without persistence", async () => {

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -359,36 +359,6 @@ export class ItemsService {
     return Boolean(featureConfig.enableItemListTags);
   }
 
-  async saveItemTags(
-    acpId: string,
-    tags: Record<string, string[]>,
-  ): Promise<Record<string, string[]>> {
-    const acp = await this.acpRepository.findOne({ where: { id: acpId } });
-    if (!acp) throw new NotFoundException("ACP not found");
-
-    const normalizedTags = this.normalizeTags(tags || {});
-    const itemProperties = { ...(acp.itemProperties || {}) };
-
-    // Replace current tag state completely to keep client and server in sync.
-    for (const itemId of Object.keys(itemProperties)) {
-      if (itemProperties[itemId] && "tags" in itemProperties[itemId]) {
-        delete itemProperties[itemId].tags;
-      }
-    }
-
-    for (const [itemId, tagList] of Object.entries(normalizedTags)) {
-      if (!tagList.length) continue;
-      itemProperties[itemId] = {
-        ...(itemProperties[itemId] || {}),
-        tags: tagList,
-      };
-    }
-
-    acp.itemProperties = itemProperties;
-    await this.acpRepository.save(acp);
-    return normalizedTags;
-  }
-
   async ensureShowOnlyItemsWithEmpiricalDifficulty(
     acpId: string,
   ): Promise<boolean> {
@@ -451,25 +421,11 @@ export class ItemsService {
     for (const [itemId, props] of Object.entries(itemProperties || {})) {
       if (!Array.isArray(props?.tags)) continue;
       const normalized = this.normalizeTagArray(props.tags);
-      if (normalized.length) {
+      if (normalized.length || parseItemRowKeyParts(itemId) !== null) {
         tags[itemId] = normalized;
       }
     }
     return tags;
-  }
-
-  private normalizeTags(
-    tags: Record<string, string[]>,
-  ): Record<string, string[]> {
-    const normalized: Record<string, string[]> = {};
-    for (const [itemId, values] of Object.entries(tags || {})) {
-      if (!itemId || !itemId.trim()) continue;
-      const clean = this.normalizeTagArray(values);
-      if (clean.length) {
-        normalized[itemId] = clean;
-      }
-    }
-    return normalized;
   }
 
   private normalizeTagArray(values: unknown[]): string[] {

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -9,6 +9,11 @@ import { Acp, AcpAccessConfig, AccessModel } from "../database/entities";
 import { UnitParserService } from "../files/unit-parser.service";
 import { getIndexUnits } from "../acp/acp-index.utils";
 import { normalizeFeatureConfig } from "../acp/feature-config.utils";
+import {
+  buildItemRowKey,
+  normalizeItemSubId,
+  parseItemRowKeyParts,
+} from "./item-row-key.util";
 
 const SHOW_ONLY_ITEMS_WITH_EMPIRICAL_DIFFICULTY_KEY =
   "showOnlyItemsWithEmpiricalDifficulty";
@@ -132,11 +137,13 @@ export class ItemsService {
     const lines = content.split(/\r?\n/);
     if (lines.length < 2) return { updated: 0, failed: [] };
 
-    const headers = lines[0]
-      .split(";")
-      .map((h) => h.replace(/^"|"$/g, "").trim());
+    const headers = this.parseCsvLine(lines[0]).map((header) =>
+      header.trim().toLowerCase(),
+    );
     const itemIdx = headers.indexOf("item");
     const estIdx = headers.indexOf("est");
+    const subIdIdx =
+      headers.length > 2 && ![itemIdx, estIdx].includes(1) ? 1 : -1;
 
     if (itemIdx === -1 || estIdx === -1) {
       throw new BadRequestException(
@@ -146,7 +153,11 @@ export class ItemsService {
 
     const failed = [];
     const successes = [];
-    const matchedUuids = new Map<string, number>(); // uuid -> row index
+    const matchedRowKeys = new Map<string, number>(); // stable row key -> row index
+    const matchedItemModes = new Map<
+      string,
+      { mode: "standard" | "partial"; rowIndex: number }
+    >();
     let updatedCount = 0;
 
     // Copy existing prop configurations
@@ -163,9 +174,10 @@ export class ItemsService {
       const line = lines[i].trim();
       if (!line) continue;
 
-      const row = line.split(";");
-      const itemValRaw = row[itemIdx]?.replace(/^"|"$/g, "") || "";
-      const estValRaw = row[estIdx]?.replace(/^"|"$/g, "") || "";
+      const row = this.parseCsvLine(line);
+      const itemValRaw = row[itemIdx]?.trim() || "";
+      const estValRaw = row[estIdx]?.trim() || "";
+      const subId = subIdIdx >= 0 ? normalizeItemSubId(row[subIdIdx]) : "";
 
       const estValNum = parseFloat(estValRaw.replace(",", "."));
 
@@ -187,20 +199,57 @@ export class ItemsService {
       });
 
       if (match) {
-        if (matchedUuids.has(match.uuid)) {
+        const rowKey = buildItemRowKey(match.uuid, subId);
+        const mode = subId ? "partial" : "standard";
+        const previousMode = matchedItemModes.get(match.uuid);
+        if (previousMode && previousMode.mode !== mode) {
           throw new BadRequestException(
-            `Konflikt: Das Item "${match.itemId}" (Aufgabe: ${match.unitId}) kommt mehrfach in der CSV vor (Zeile ${matchedUuids.get(match.uuid)! + 1} und Zeile ${i + 1}). Bitte bereinigen Sie die Datei.`,
+            `Konflikt: Das Item "${match.itemId}" wird in derselben CSV sowohl mit als auch ohne Sub-ID verwendet (Zeile ${previousMode.rowIndex + 1} und Zeile ${i + 1}). Bitte verwenden Sie pro Item nur eine Darstellungsform.`,
           );
         }
-        matchedUuids.set(match.uuid, i);
+        matchedItemModes.set(match.uuid, { mode, rowIndex: i });
 
-        props[match.uuid] = {
-          ...props[match.uuid],
-          empiricalDifficulty: estValNum,
-        };
+        if (matchedRowKeys.has(rowKey)) {
+          throw new BadRequestException(
+            `Konflikt: Die Zeile für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} kommt mehrfach in der CSV vor (Zeile ${matchedRowKeys.get(rowKey)! + 1} und Zeile ${i + 1}). Bitte bereinigen Sie die Datei.`,
+          );
+        }
+        matchedRowKeys.set(rowKey, i);
+
+        const partialRowKeys = this.getPartialCreditRowKeys(props, match.uuid);
+        let affectedRowKeys = [rowKey];
+        if (mode === "standard" && partialRowKeys.length) {
+          affectedRowKeys = partialRowKeys;
+          if (props[match.uuid]?.empiricalDifficulty !== undefined) {
+            delete props[match.uuid].empiricalDifficulty;
+          }
+          for (const partialRowKey of partialRowKeys) {
+            props[partialRowKey] = {
+              ...props[partialRowKey],
+              empiricalDifficulty: estValNum,
+            };
+          }
+        } else {
+          if (
+            mode === "partial" &&
+            props[match.uuid]?.empiricalDifficulty !== undefined
+          ) {
+            delete props[match.uuid].empiricalDifficulty;
+          }
+          props[rowKey] = {
+            ...props[rowKey],
+            ...(subId ? { itemUuid: match.uuid, subId } : {}),
+            empiricalDifficulty: estValNum,
+          };
+        }
         successes.push({
           itemId: match.itemId,
           unitId: match.unitId,
+          ...(affectedRowKeys.length === 1
+            ? { rowKey: affectedRowKeys[0] }
+            : {}),
+          affectedRowKeys,
+          subId: subId || undefined,
           value: estValNum,
         });
         updatedCount++;
@@ -224,6 +273,40 @@ export class ItemsService {
       successes,
       nextItemProperties: props,
     };
+  }
+
+  private getPartialCreditRowKeys(
+    itemProperties: Record<string, Record<string, unknown>>,
+    itemUuid: string,
+  ): string[] {
+    return Object.keys(itemProperties).filter(
+      (rowKey) => parseItemRowKeyParts(rowKey)?.itemUuid === itemUuid,
+    );
+  }
+
+  private parseCsvLine(line: string): string[] {
+    const cells: string[] = [];
+    let current = "";
+    let quoted = false;
+
+    for (let index = 0; index < line.length; index++) {
+      const character = line[index];
+      if (character === '"') {
+        if (quoted && line[index + 1] === '"') {
+          current += '"';
+          index += 1;
+        } else {
+          quoted = !quoted;
+        }
+      } else if (character === ";" && !quoted) {
+        cells.push(current);
+        current = "";
+      } else {
+        current += character;
+      }
+    }
+    cells.push(current);
+    return cells;
   }
 
   /**

--- a/backend/src/views/views.controller.spec.ts
+++ b/backend/src/views/views.controller.spec.ts
@@ -184,7 +184,7 @@ describe("ViewsController", () => {
       "item-list",
     );
 
-    expect(result).toEqual({ ui: {}, tags: {} });
+    expect(result).toEqual({ ui: {}, tags: {}, rowData: {} });
     expect(viewsService.getItemPreferences).not.toHaveBeenCalled();
   });
 
@@ -217,7 +217,7 @@ describe("ViewsController", () => {
       { user: { sub: "u-1" } },
     );
 
-    expect(result).toEqual({ ui: {}, tags: {} });
+    expect(result).toEqual({ ui: {}, tags: {}, rowData: {} });
     expect(viewsService.saveItemPreferences).not.toHaveBeenCalled();
   });
 

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -51,6 +51,15 @@ class SaveItemPreferencesDto {
   @IsOptional()
   @IsObject()
   tags?: Record<string, string[]>;
+
+  @ApiPropertyOptional({
+    description: "Personal working data keyed by stable item row key",
+    type: "object",
+    additionalProperties: true,
+  })
+  @IsOptional()
+  @IsObject()
+  rowData?: Record<string, Record<string, unknown>>;
 }
 
 @ApiTags("Public Views")
@@ -167,7 +176,7 @@ export class ViewsController {
     @Query("viewId") viewId?: string,
   ) {
     if (!(await this.isPreferencePersistenceEnabled(acpId))) {
-      return { ui: {}, tags: {} };
+      return { ui: {}, tags: {}, rowData: {} };
     }
 
     return this.viewsService.getItemPreferences(acpId, req?.user, viewId);
@@ -183,7 +192,7 @@ export class ViewsController {
     @Request() req: any,
   ) {
     if (!(await this.isPreferencePersistenceEnabled(acpId))) {
-      return { ui: {}, tags: {} };
+      return { ui: {}, tags: {}, rowData: {} };
     }
 
     return this.viewsService.saveItemPreferences(
@@ -192,6 +201,7 @@ export class ViewsController {
       {
         ui: dto.ui,
         tags: dto.tags,
+        rowData: dto.rowData,
       },
       dto.viewId,
     );

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -176,7 +176,7 @@ describe("ViewsService", () => {
 
   it("returns empty item preferences when no authenticated identity is available", async () => {
     const prefs = await service.getItemPreferences("acp-1", null, "item-list");
-    expect(prefs).toEqual({ ui: {}, tags: {} });
+    expect(prefs).toEqual({ ui: {}, tags: {}, rowData: {} });
     expect(itemPreferenceRepository.findOne).not.toHaveBeenCalled();
   });
 
@@ -207,6 +207,7 @@ describe("ViewsService", () => {
       tags: {
         item1: ["alpha", "beta"],
       },
+      rowData: {},
     });
   });
 
@@ -234,6 +235,7 @@ describe("ViewsService", () => {
       tags: {
         item1: ["tag1", "tag2"],
       },
+      rowData: {},
     });
     expect(itemPreferenceRepository.save).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -503,6 +505,7 @@ describe("ViewsService", () => {
     ).resolves.toEqual({
       ui: { filterText: "abc" },
       tags: { item1: ["x"] },
+      rowData: {},
     });
     expect(itemPreferenceRepository.save).not.toHaveBeenCalled();
   });
@@ -533,8 +536,29 @@ describe("ViewsService", () => {
         preferences: {
           ui: { sortBy: "name" },
           tags: { itemA: ["A", "B"] },
+          rowData: {},
         },
       }),
     );
+  });
+
+  it("persists personal working data by stable row key", async () => {
+    itemPreferenceRepository.findOne.mockResolvedValue(null);
+
+    const saved = await service.saveItemPreferences(
+      "acp-1",
+      { sub: "user-1", type: "oidc" },
+      {
+        rowData: {
+          "uuid-1::1": { category: "A", note: "Notiz" },
+          "  ": { category: "ignored" },
+        },
+      },
+      "item-explorer",
+    );
+
+    expect(saved.rowData).toEqual({
+      "uuid-1::1": { category: "A", note: "Notiz" },
+    });
   });
 });

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -21,6 +21,7 @@ export interface ItemPreferencesPayload {
   [key: string]: unknown;
   ui: Record<string, unknown>;
   tags: Record<string, string[]>;
+  rowData: Record<string, Record<string, unknown>>;
 }
 
 interface PreferenceIdentity {
@@ -341,7 +342,7 @@ export class ViewsService {
   ): Promise<ItemPreferencesPayload> {
     const identity = this.resolvePreferenceIdentity(user);
     if (!identity) {
-      return { ui: {}, tags: {} };
+      return { ui: {}, tags: {}, rowData: {} };
     }
 
     const normalizedViewId = this.normalizeViewId(viewId);
@@ -460,7 +461,25 @@ export class ViewsService {
     return {
       ui,
       tags: this.normalizeTags(payload.tags),
+      rowData: this.normalizeRowData(payload.rowData),
     };
+  }
+
+  private normalizeRowData(
+    rawRowData: unknown,
+  ): Record<string, Record<string, unknown>> {
+    if (!this.isRecord(rawRowData)) {
+      return {};
+    }
+
+    const normalized: Record<string, Record<string, unknown>> = {};
+    for (const [rawRowKey, value] of Object.entries(rawRowData)) {
+      const rowKey = rawRowKey.trim();
+      if (rowKey && this.isRecord(value)) {
+        normalized[rowKey] = { ...value };
+      }
+    }
+    return normalized;
   }
 
   private normalizeTags(rawTags: unknown): Record<string, string[]> {

--- a/docs/features/item-explorer.md
+++ b/docs/features/item-explorer.md
@@ -168,7 +168,10 @@ Two modes exist:
 
 ### Direct persistence
 
-The import updates ACP item properties immediately.
+The import updates ACP item properties and the clean published explorer state immediately. If an
+unpublished explorer draft already exists, the direct operation is rejected with a conflict so it
+cannot silently overwrite or be overwritten by that draft. The caller must then use draft-aware
+persistence or publish/discard the pending draft first.
 
 ### Draft-aware persistence
 
@@ -176,6 +179,27 @@ The import updates explorer draft state instead, allowing managers to review and
 the result later.
 
 The same distinction exists when clearing empirical difficulty values.
+
+### Partial-credit rows
+
+Difficulty CSV files may use the second column as a Sub-ID, category, or score level. The
+expected shape is `item;<sub-id>;est`; the middle header may be chosen freely. Multiple rows may
+refer to the same item as long as their Sub-IDs differ.
+
+The explorer then creates one table row per Sub-ID. Every row has:
+
+- a stable key made from the item UUID and the encoded Sub-ID,
+- its own empirical difficulty,
+- a visible and sortable/filterable Sub-ID column,
+- the normal item preview and coding view of the underlying item.
+
+The ACP feature configuration controls `itemSubIdLabel` (the column heading) and
+`itemSubIdLabels` (display labels keyed by imported Sub-ID). Items without a Sub-ID continue to
+use their item UUID as their row key and remain single rows.
+
+Shared explorer properties, tags, manual ordering, saved response states, and personal
+`rowData` preferences use the stable row key. This prevents two partial-credit rows of the same
+item from overwriting one another and gives exports a unique identifier for every table row.
 
 ## Player Preview and Legacy Player Compatibility
 

--- a/frontend/src/app/acp-manager/access-config/access-config.component.spec.ts
+++ b/frontend/src/app/acp-manager/access-config/access-config.component.spec.ts
@@ -257,4 +257,28 @@ describe('AccessConfigComponent', () => {
       }),
     );
   });
+  it('persists the configured Sub-ID label and value labels', () => {
+    const component = new AccessConfigComponent(route as any, api as any);
+    component.acpId = 'acp-1';
+    component.featureConfig = { enableItemList: true, itemSubIdLabel: 'Kategorie' };
+    component.itemSubIdLabelEntries = [
+      { value: '1', label: 'teilweise richtig' },
+      { value: '2', label: 'vollständig richtig' },
+    ];
+
+    component.saveFeatures();
+
+    expect(api.updateAccessConfig).toHaveBeenCalledWith(
+      'acp-1',
+      expect.objectContaining({
+        featureConfig: expect.objectContaining({
+          itemSubIdLabel: 'Kategorie',
+          itemSubIdLabels: {
+            '1': 'teilweise richtig',
+            '2': 'vollständig richtig',
+          },
+        }),
+      }),
+    );
+  });
 });

--- a/frontend/src/app/acp-manager/access-config/access-config.component.ts
+++ b/frontend/src/app/acp-manager/access-config/access-config.component.ts
@@ -396,6 +396,45 @@ import { AcpManagerContextComponent } from '../shared/acp-manager-context.compon
             <span>{{ feat.label }}</span>
           </label>
         }
+        <div class="indent-section">
+          <label class="help-text" for="item-sub-id-label">Bezeichnung der Sub-ID-Spalte</label>
+          <input
+            id="item-sub-id-label"
+            class="tag-input"
+            type="text"
+            [(ngModel)]="featureConfig[itemSubIdLabelKey]"
+            placeholder="Sub-ID"
+          />
+          <span class="help-text">
+            Die zweite Spalte einer Itemschwierigkeits-CSV wird als Sub-ID/Kategorie/Stufe
+            verwendet.
+          </span>
+          <label class="help-text" style="margin-top: 10px;">Labels der Ausprägungen</label>
+          <div class="tags-editor">
+            @for (entry of itemSubIdLabelEntries; track $index) {
+              <div class="tag-add">
+                <input
+                  class="tag-input"
+                  type="text"
+                  [(ngModel)]="entry.value"
+                  placeholder="Wert, z. B. 1"
+                />
+                <input
+                  class="tag-input"
+                  type="text"
+                  [(ngModel)]="entry.label"
+                  placeholder="Label, z. B. teilweise richtig"
+                />
+                <button class="tag-remove" type="button" (click)="removeItemSubIdLabel($index)">
+                  ✕
+                </button>
+              </div>
+            }
+            <button class="btn btn-outline btn-sm" type="button" (click)="addItemSubIdLabel()">
+              + Ausprägung
+            </button>
+          </div>
+        </div>
         <label class="feature-toggle">
           <input type="checkbox" [(ngModel)]="featureConfig[showAudioVideoCodingVariablesKey]" />
           <span>Kodierungsvariablen mit "audio"/"video" im Namen anzeigen</span>
@@ -700,6 +739,8 @@ export class AccessConfigComponent implements OnInit {
   readonly showOnlyItemsWithEmpiricalDifficultyKey = 'showOnlyItemsWithEmpiricalDifficulty';
   readonly enablePlayerFocusHighlightKey = 'enablePlayerFocusHighlight';
   readonly showItemExplorerPlayerTargetInfoKey = 'showItemExplorerPlayerTargetInfo';
+  readonly itemSubIdLabelKey = 'itemSubIdLabel';
+  readonly itemSubIdLabelsKey = 'itemSubIdLabels';
 
   acpId = '';
   accessModel: AccessModel = 'PRIVATE';
@@ -713,6 +754,7 @@ export class AccessConfigComponent implements OnInit {
   commentTargets: string[] = [];
   availableTags: string[] = [];
   newTag = '';
+  itemSubIdLabelEntries: Array<{ value: string; label: string }> = [];
   accessSaved = false;
   featuresSaved = false;
   credentials: Credential[] = [];
@@ -835,6 +877,9 @@ export class AccessConfigComponent implements OnInit {
         this.validUntil = this.toDateTimeLocalString(config.validUntil);
         this.commentTargets = (this.featureConfig['commentTargets'] as string[]) || [];
         this.availableTags = (this.featureConfig['availableTags'] as string[]) || [];
+        this.itemSubIdLabelEntries = Object.entries(
+          (this.featureConfig[this.itemSubIdLabelsKey] as Record<string, string>) || {},
+        ).map(([value, label]) => ({ value, label }));
       },
     });
   }
@@ -914,6 +959,12 @@ export class AccessConfigComponent implements OnInit {
 
   saveFeatures() {
     this.applyFeatureConfigDefaults();
+    this.featureConfig[this.itemSubIdLabelsKey] = Object.fromEntries(
+      this.itemSubIdLabelEntries
+        .map((entry) => ({ value: entry.value.trim(), label: entry.label.trim() }))
+        .filter((entry) => entry.value && entry.label)
+        .map((entry) => [entry.value, entry.label]),
+    );
     this.featureConfig['commentTargets'] = this.commentTargets;
     this.featureConfig['availableTags'] = this.availableTags;
     this.api
@@ -931,6 +982,8 @@ export class AccessConfigComponent implements OnInit {
   }
 
   private applyFeatureConfigDefaults() {
+    const itemSubIdLabel = String(this.featureConfig[this.itemSubIdLabelKey] || '').trim();
+    this.featureConfig[this.itemSubIdLabelKey] = itemSubIdLabel || 'Sub-ID';
     const showAudioVideoCodingVariables = this.featureConfig[this.showAudioVideoCodingVariablesKey];
     this.featureConfig[this.showAudioVideoCodingVariablesKey] =
       showAudioVideoCodingVariables !== false;
@@ -963,6 +1016,14 @@ export class AccessConfigComponent implements OnInit {
 
   removeTag(index: number) {
     this.availableTags.splice(index, 1);
+  }
+
+  addItemSubIdLabel() {
+    this.itemSubIdLabelEntries.push({ value: '', label: '' });
+  }
+
+  removeItemSubIdLabel(index: number) {
+    this.itemSubIdLabelEntries.splice(index, 1);
   }
 
   // Manual credential management

--- a/frontend/src/app/core/models/api.models.ts
+++ b/frontend/src/app/core/models/api.models.ts
@@ -375,6 +375,8 @@ export interface FeatureConfig {
   enableItemExplorerConditionalVisibility?: boolean;
   enablePlayerFocusHighlight?: boolean;
   showItemExplorerPlayerTargetInfo?: boolean;
+  itemSubIdLabel?: string;
+  itemSubIdLabels?: Record<string, string>;
   availableTags?: string[];
   persistUserPreferences?: boolean;
 }
@@ -441,6 +443,7 @@ export interface FileDependency {
 export interface ItemViewPreferences {
   ui?: Record<string, unknown>;
   tags?: Record<string, string[]>;
+  rowData?: Record<string, Record<string, unknown>>;
 }
 
 export interface ItemExplorerMetadataColumns {

--- a/frontend/src/app/core/services/api.service.spec.ts
+++ b/frontend/src/app/core/services/api.service.spec.ts
@@ -1089,6 +1089,29 @@ describe('ApiService', () => {
       expect(httpClientMock.get).toHaveBeenCalledWith('/api/acp/acp1/items/response-state/all');
     });
 
+    it('should scope response state requests to a stable partial-credit row key', () => {
+      httpClientMock.post.mockReturnValue(of({}));
+      httpClientMock.get.mockReturnValue(of({}));
+      httpClientMock.delete.mockReturnValue(of({}));
+
+      service.saveResponseState('acp1', 'item1', 'unit1', { answer: 1 }, 'uuid-1::1').subscribe();
+      expect(httpClientMock.post).toHaveBeenCalledWith('/api/acp/acp1/items/item1/response-state', {
+        unitId: 'unit1',
+        responseData: { answer: 1 },
+        rowKey: 'uuid-1::1',
+      });
+
+      service.getResponseState('acp1', 'item1', 'unit1', 'uuid-1::1').subscribe();
+      expect(httpClientMock.get).toHaveBeenCalledWith(
+        '/api/acp/acp1/items/item1/response-state?unitId=unit1&rowKey=uuid-1%3A%3A1',
+      );
+
+      service.deleteResponseState('acp1', 'item1', 'unit1', 'uuid-1::1').subscribe();
+      expect(httpClientMock.delete).toHaveBeenCalledWith(
+        '/api/acp/acp1/items/item1/response-state?unitId=unit1&rowKey=uuid-1%3A%3A1',
+      );
+    });
+
     it('should get and save item tags', () => {
       httpClientMock.get.mockReturnValue(of({ item1: ['A'] }));
       httpClientMock.put.mockReturnValue(of({ item1: ['A', 'B'] }));

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -565,22 +565,36 @@ export class ApiService {
     itemId: string,
     unitId: string,
     responseData: Record<string, any>,
+    rowKey?: string,
   ): Observable<any> {
     return this.http.post(`${this.API}/acp/${acpId}/items/${itemId}/response-state`, {
       unitId,
       responseData,
+      ...(rowKey ? { rowKey } : {}),
     });
   }
 
-  getResponseState(acpId: string, itemId: string, unitId: string): Observable<any> {
+  getResponseState(
+    acpId: string,
+    itemId: string,
+    unitId: string,
+    rowKey?: string,
+  ): Observable<any> {
+    const rowKeyQuery = rowKey ? `&rowKey=${encodeURIComponent(rowKey)}` : '';
     return this.http.get(
-      `${this.API}/acp/${acpId}/items/${itemId}/response-state?unitId=${encodeURIComponent(unitId)}`,
+      `${this.API}/acp/${acpId}/items/${itemId}/response-state?unitId=${encodeURIComponent(unitId)}${rowKeyQuery}`,
     );
   }
 
-  deleteResponseState(acpId: string, itemId: string, unitId: string): Observable<any> {
+  deleteResponseState(
+    acpId: string,
+    itemId: string,
+    unitId: string,
+    rowKey?: string,
+  ): Observable<any> {
+    const rowKeyQuery = rowKey ? `&rowKey=${encodeURIComponent(rowKey)}` : '';
     return this.http.delete(
-      `${this.API}/acp/${acpId}/items/${itemId}/response-state?unitId=${encodeURIComponent(unitId)}`,
+      `${this.API}/acp/${acpId}/items/${itemId}/response-state?unitId=${encodeURIComponent(unitId)}${rowKeyQuery}`,
     );
   }
 
@@ -588,11 +602,12 @@ export class ApiService {
     acpId: string,
     itemId: string,
     unitId: string,
-    itemList: { itemId: string; unitId: string }[],
+    itemList: { itemId: string; unitId: string; rowKey?: string }[],
+    rowKey?: string,
   ): Observable<{ state: any; isFallback: boolean; fallbackItemId?: string }> {
     return this.http.post<{ state: any; isFallback: boolean; fallbackItemId?: string }>(
       `${this.API}/acp/${acpId}/items/${itemId}/response-state/with-fallback`,
-      { unitId, itemList },
+      { unitId, itemList, ...(rowKey ? { rowKey } : {}) },
     );
   }
 

--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -141,6 +141,105 @@ describe('ItemExplorerComponent', () => {
     expect(component.sortIsMeta).toBe(false);
   });
 
+  it('filters and sorts partial-credit rows independently by Sub-ID label', () => {
+    const component = createComponent();
+    component.hasPartialCredit = true;
+    component.items = [
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1::2',
+        subId: '2',
+        subIdDisplay: 'vollständig richtig',
+        unitId: 'UNIT_1',
+        unitLabel: 'Unit 1',
+        description: '',
+        variableId: '',
+        metadata: {},
+        empiricalDifficulty: 0.8,
+      },
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1::1',
+        subId: '1',
+        subIdDisplay: 'teilweise richtig',
+        unitId: 'UNIT_1',
+        unitLabel: 'Unit 1',
+        description: '',
+        variableId: '',
+        metadata: {},
+        empiricalDifficulty: 0.2,
+      },
+    ];
+    component.filteredItems = [...component.items];
+
+    component.sortBy('subIdDisplay');
+    expect(component.filteredItems.map((item) => item.rowKey)).toEqual(['uuid-1::1', 'uuid-1::2']);
+
+    component.columnFilters['subId'] = 'vollständig';
+    component.applyFilter(false);
+    expect(component.filteredItems.map((item) => item.rowKey)).toEqual(['uuid-1::2']);
+    expect(component.filteredItems[0].empiricalDifficulty).toBe(0.8);
+  });
+
+  it('sorts partial-credit rows manually by stable row key', () => {
+    const component = createComponent();
+    component.items = [
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1::1',
+        subId: '1',
+        unitId: 'UNIT_1',
+        unitLabel: 'Unit 1',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1::2',
+        subId: '2',
+        unitId: 'UNIT_1',
+        unitLabel: 'Unit 1',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+    ];
+    component.filteredItems = [...component.items];
+    component.itemOrder = ['uuid-1::2', 'uuid-1::1'];
+    component.sortField = '__manual__';
+
+    (component as any).applySort(false);
+
+    expect(component.filteredItems.map((item) => item.rowKey)).toEqual(['uuid-1::2', 'uuid-1::1']);
+  });
+
+  it('selects partial-credit rows with the same item UUID by stable row key', () => {
+    const component = createComponent();
+    const first = {
+      itemId: 'ITEM_1',
+      uuid: 'uuid-1',
+      rowKey: 'uuid-1::1',
+      subId: '1',
+      unitId: 'UNIT_1',
+      unitLabel: 'Unit 1',
+      description: '',
+      variableId: '',
+      metadata: {},
+    } as any;
+    const second = { ...first, rowKey: 'uuid-1::2', subId: '2' };
+
+    component.selectItem(first, 0);
+    component.selectItem(second, 1);
+
+    expect(component.selectedItem?.rowKey).toBe('uuid-1::2');
+    expect(component.selectedIndex).toBe(1);
+  });
+
   it('does not persist fullscreen mode in the shared ui preferences', () => {
     const component = createComponent();
     component.isFullscreen = true;
@@ -952,6 +1051,66 @@ describe('ItemExplorerComponent', () => {
     expect(getFileItemList).toHaveBeenLastCalledWith('acp-1', {
       perspective: 'editor',
     });
+  });
+
+  it('restores a partial-credit manual order only after editor rows are loaded', async () => {
+    const envelope = createExplorerEnvelope();
+    envelope.draftState.ui = {
+      filterText: '',
+      sortField: '__manual__',
+      sortDir: 'asc',
+      sortIsMeta: false,
+    };
+    envelope.draftState.itemOrder = ['uuid-1::2', 'uuid-1::1'];
+    const editorRows = [
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1::1',
+        subId: '1',
+        unitId: 'UNIT_1',
+        unitLabel: 'Unit 1',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1::2',
+        subId: '2',
+        unitId: 'UNIT_1',
+        unitLabel: 'Unit 1',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+    ];
+    const component = createComponent({
+      api: {
+        getItemExplorerState: vi.fn(() => of(envelope)),
+        getFileItemList: vi.fn(() =>
+          of({ columns: [], items: editorRows, unitMetadata: {}, codingSchemes: {} }),
+        ),
+      },
+    });
+    component.acpId = 'acp-1';
+    component.hasExplorerEditPermission = true;
+    component.viewPerspective = 'read-only';
+    component.items = [
+      {
+        ...editorRows[0],
+        rowKey: 'uuid-1',
+        subId: undefined,
+      },
+    ];
+    component.filteredItems = [...component.items];
+    (component as any).applySharedExplorerEnvelope(envelope);
+
+    await component.toggleReadOnlyPreview();
+
+    expect(component.itemOrder).toEqual(['uuid-1::2', 'uuid-1::1']);
+    expect(component.filteredItems.map((item) => item.rowKey)).toEqual(['uuid-1::2', 'uuid-1::1']);
   });
 
   it('does not enter read-only preview when the pending draft patch cannot be flushed', async () => {

--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -240,6 +240,51 @@ describe('ItemExplorerComponent', () => {
     expect(component.selectedIndex).toBe(1);
   });
 
+  it('lets a partial-credit row clear inherited tags, exclusion and preview target', () => {
+    const component = createComponent();
+    const item = {
+      itemId: 'ITEM_1',
+      uuid: 'uuid-1',
+      rowKey: 'uuid-1::1',
+      subId: '1',
+      unitId: 'UNIT_1',
+      unitLabel: 'Unit 1',
+      description: '',
+      variableId: '',
+      metadata: {},
+      tags: ['base'],
+      excluded: true,
+      previewTargetId: 'BASE_A',
+    } as any;
+    component.items = [item];
+    component.filteredItems = [item];
+
+    const envelope = createExplorerEnvelope();
+    envelope.draftState.tags = {
+      'uuid-1': ['base'],
+      'uuid-1::1': [],
+    };
+    envelope.draftState.itemProperties = {
+      'uuid-1': {
+        tags: ['base'],
+        excluded: true,
+        previewTargetId: 'BASE_A',
+      },
+      'uuid-1::1': {
+        tags: [],
+        excluded: false,
+        previewTargetId: '',
+      },
+    };
+
+    (component as any).applySharedExplorerEnvelope(envelope);
+
+    expect(component.itemTags['uuid-1::1']).toEqual([]);
+    expect(item.tags).toEqual([]);
+    expect(item.excluded).toBeUndefined();
+    expect(item.previewTargetId).toBeUndefined();
+  });
+
   it('does not persist fullscreen mode in the shared ui preferences', () => {
     const component = createComponent();
     component.isFullscreen = true;

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -5225,7 +5225,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       }
 
       const tagsFromState = this.getTagsForKeys(stateTags, keys);
-      if (tagsFromState.length) {
+      if (tagsFromState !== null) {
         item.tags = tagsFromState;
       } else if (Array.isArray(itemProps?.['tags'])) {
         item.tags = this.normalizeTagValues(itemProps['tags']);
@@ -5286,14 +5286,14 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     return found ? merged : null;
   }
 
-  private getTagsForKeys(tagsMap: Record<string, string[]>, keys: string[]): string[] {
+  private getTagsForKeys(tagsMap: Record<string, string[]>, keys: string[]): string[] | null {
     for (const key of keys) {
       const tags = tagsMap[key];
-      if (Array.isArray(tags) && tags.length) {
+      if (Array.isArray(tags)) {
         return this.normalizeTagValues(tags);
       }
     }
-    return [];
+    return null;
   }
 
   private normalizeTagValues(values: unknown[]): string[] {
@@ -6000,7 +6000,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
         ),
       );
 
-      if (normalizedValues.length) {
+      if (normalizedValues.length || normalizedItemId.includes('::')) {
         tags[normalizedItemId] = normalizedValues;
       }
     }

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -30,6 +30,9 @@ interface MetadataColumn {
 interface ExplorerItem {
   itemId: string;
   uuid: string;
+  rowKey: string;
+  subId?: string;
+  subIdDisplay?: string;
   unitId: string;
   unitLabel: string;
   description: string;
@@ -89,7 +92,7 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
         </div>
         <div class="header-actions">
           <span class="item-count"
-            >{{ filteredItems.length }} von {{ visibleItemsCount }} Items</span
+            >{{ filteredItems.length }} von {{ visibleItemsCount }} Zeilen</span
           >
           <button
             class="btn btn-outline btn-sm"
@@ -382,6 +385,11 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                   <th (click)="sortBy('unitLabel')" class="sortable">
                     Aufgabe {{ getSortIndicator('unitLabel') }}
                   </th>
+                  @if (hasPartialCredit) {
+                    <th (click)="sortBy('subIdDisplay')" class="sortable">
+                      {{ itemSubIdLabel }} {{ getSortIndicator('subIdDisplay') }}
+                    </th>
+                  }
                   @if (hasEmpiricalDifficulty) {
                     <th (click)="sortBy('empiricalDifficulty')" class="sortable">
                       Empirische Itemschwierigkeit {{ getSortIndicator('empiricalDifficulty') }}
@@ -413,6 +421,16 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                       (input)="applyFilter()"
                     />
                   </th>
+                  @if (hasPartialCredit) {
+                    <th>
+                      <input
+                        class="col-filter-input"
+                        [(ngModel)]="columnFilters['subId']"
+                        [placeholder]="'🔍 ' + itemSubIdLabel + '...'"
+                        (input)="applyFilter()"
+                      />
+                    </th>
+                  }
                   @if (hasEmpiricalDifficulty) {
                     <th>
                       <input
@@ -447,17 +465,13 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                 </tr>
               </thead>
               <tbody>
-                @for (
-                  item of filteredItems;
-                  track item.unitId + '_' + item.itemId;
-                  let i = $index
-                ) {
+                @for (item of filteredItems; track item.rowKey; let i = $index) {
                   <tr
                     [id]="getItemRowId(item)"
-                    [class.active]="selectedItem?.uuid === item.uuid"
+                    [class.active]="selectedItem?.rowKey === item.rowKey"
                     [class.excluded]="isItemExcluded(item)"
                     [class.no-preview]="!canPreviewItem(item)"
-                    [attr.aria-selected]="selectedItem?.uuid === item.uuid"
+                    [attr.aria-selected]="selectedItem?.rowKey === item.rowKey"
                     (click)="selectItem(item, i)"
                   >
                     <td class="sticky-col">
@@ -481,6 +495,11 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                       </div>
                     </td>
                     <td>{{ item.unitLabel }}</td>
+                    @if (hasPartialCredit) {
+                      <td>
+                        <span [title]="item.subId || ''">{{ item.subIdDisplay || '–' }}</span>
+                      </td>
+                    }
                     @if (hasEmpiricalDifficulty) {
                       <td>
                         {{
@@ -496,13 +515,10 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                     }
                     @if (enableTags) {
                       <td class="tags-cell" (click)="$event.stopPropagation()">
-                        @for (
-                          tag of itemTags[item.uuid || item.unitId + '_' + item.itemId] || [];
-                          track tag
-                        ) {
+                        @for (tag of itemTags[item.rowKey] || []; track tag) {
                           <span
                             class="badge badge-info tag-badge"
-                            (click)="removeItemTag(item.uuid, tag)"
+                            (click)="removeItemTag(item.rowKey, tag)"
                             >{{ tag }}
                             @if (canEditExplorer) {
                               ✕
@@ -512,7 +528,7 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                         @if (canEditExplorer) {
                           <div class="tag-add-container">
                             @if (availableTags.length > 0) {
-                              <select class="tag-select" (change)="addItemTag(item.uuid, $event)">
+                              <select class="tag-select" (change)="addItemTag(item.rowKey, $event)">
                                 <option value="">+Tag</option>
                                 @for (tag of availableTags; track tag) {
                                   <option [value]="tag">{{ tag }}</option>
@@ -523,8 +539,8 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                               type="text"
                               class="tag-input-inline"
                               placeholder="Neu..."
-                              (keydown.enter)="addCustomTag(item.uuid, $event)"
-                              (blur)="addCustomTag(item.uuid, $event)"
+                              (keydown.enter)="addCustomTag(item.rowKey, $event)"
+                              (blur)="addCustomTag(item.rowKey, $event)"
                             />
                           </div>
                         }
@@ -548,6 +564,11 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                 <div class="preview-target-header">
                   <strong>Explorer-Item</strong>
                   <code>{{ selectedItem.unitId }}{{ selectedItem.itemId }}</code>
+                  @if (selectedItem.subId) {
+                    <span class="player-target-badge secondary">
+                      {{ itemSubIdLabel }}: {{ selectedItem.subIdDisplay || selectedItem.subId }}
+                    </span>
+                  }
                   @if (isItemExcluded(selectedItem)) {
                     <span class="excluded-item-badge">Ausgeschlossen</span>
                   }
@@ -2560,6 +2581,8 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   items: ExplorerItem[] = [];
   filteredItems: ExplorerItem[] = [];
   hasEmpiricalDifficulty = false;
+  hasPartialCredit = false;
+  itemSubIdLabel = 'Sub-ID';
   filterText = '';
   isFullscreen = false;
   sortField = DEFAULT_EXPLORER_SORT_FIELD;
@@ -2964,6 +2987,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       this.playerFocusHighlightEnabled = fc.enablePlayerFocusHighlight === true;
       this.itemExplorerPlayerTargetInfoEnabled = fc.showItemExplorerPlayerTargetInfo !== false;
       this.showOnlyItemsWithEmpiricalDifficulty = fc.showOnlyItemsWithEmpiricalDifficulty === true;
+      this.itemSubIdLabel = String(fc.itemSubIdLabel || 'Sub-ID').trim() || 'Sub-ID';
       // Explorer uses ACP-shared draft/published state instead of per-user preferences.
       this.persistUserPreferences = false;
       this.useServerPreferences = false;
@@ -2978,7 +3002,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   }
 
   // --- Reload Items ---
-  reloadItems() {
+  reloadItems(onSettled?: () => void) {
     this.itemListError = '';
 
     // Load item list from .vomd files
@@ -2990,7 +3014,12 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
         next: (result) => {
           this.allColumns = result.columns || [];
           this.columns = this.filterVisibleColumns(this.allColumns);
-          this.items = result.items || [];
+          this.items = (result.items || []).map((item: ExplorerItem) => ({
+            ...item,
+            rowKey: item.rowKey || item.uuid || `${item.unitId}_${item.itemId}`,
+          }));
+          this.itemSubIdLabel = String(result.subIdLabel || this.itemSubIdLabel).trim() || 'Sub-ID';
+          this.hasPartialCredit = this.items.some((item) => !!item.subId);
           this.hydrateItemTagsFromItems();
           this.applyExplorerStateToItems();
           this.hasEmpiricalDifficulty = this.items.some(
@@ -3001,6 +3030,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
           this.unitMetadataCache = result.unitMetadata || {};
           this.codingSchemeCache = result.codingSchemes || {};
           this.applyFilter(false); // re-apply current filters and sort
+          onSettled?.();
         },
         error: (error) => {
           console.error('Failed to load explorer item list', error);
@@ -3014,9 +3044,11 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
           this.filteredItems = [];
           this.itemTags = {};
           this.hasEmpiricalDifficulty = false;
+          this.hasPartialCredit = false;
           this.unitMetadataCache = {};
           this.codingSchemeCache = {};
           this.clearSelectedItem();
+          onSettled?.();
         },
       });
   }
@@ -3134,6 +3166,12 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     if (term) {
       const matchesGlobal =
         (item.unitId + item.itemId).toLowerCase().includes(term) ||
+        String(item.subId || '')
+          .toLowerCase()
+          .includes(term) ||
+        String(item.subIdDisplay || '')
+          .toLowerCase()
+          .includes(term) ||
         item.unitLabel.toLowerCase().includes(term) ||
         item.description.toLowerCase().includes(term) ||
         Object.values(item.metadata).some((val) => val && val.toLowerCase().includes(term));
@@ -3150,8 +3188,11 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
         if (!combined.includes(subTerm)) return false;
       } else if (colId === 'unitLabel') {
         if (!item.unitLabel.toLowerCase().includes(subTerm)) return false;
+      } else if (colId === 'subId') {
+        const subIdValue = `${item.subId || ''} ${item.subIdDisplay || ''}`.toLowerCase();
+        if (!subIdValue.includes(subTerm)) return false;
       } else if (colId === 'tags') {
-        const tags = this.itemTags[item.uuid] || [];
+        const tags = this.itemTags[item.rowKey] || [];
         if (!tags.some((t) => t.toLowerCase().includes(subTerm))) return false;
       } else if (colId === 'empiricalDifficulty') {
         if (item.empiricalDifficulty === undefined || item.empiricalDifficulty === null)
@@ -3272,8 +3313,8 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       const rank = new Map<string, number>();
       this.itemOrder.forEach((entry, idx) => rank.set(entry, idx));
       this.filteredItems.sort((a, b) => {
-        const posA = rank.has(a.uuid) ? (rank.get(a.uuid) as number) : Number.MAX_SAFE_INTEGER;
-        const posB = rank.has(b.uuid) ? (rank.get(b.uuid) as number) : Number.MAX_SAFE_INTEGER;
+        const posA = rank.get(this.getStableRowKey(a)) ?? Number.MAX_SAFE_INTEGER;
+        const posB = rank.get(this.getStableRowKey(b)) ?? Number.MAX_SAFE_INTEGER;
         return posA - posB;
       });
       this.syncSelectionAfterListMutation();
@@ -3308,7 +3349,11 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
         if (unitCmp !== 0) {
           return unitCmp;
         }
-        return this.compareSortText(a.itemId, b.itemId);
+        const itemCmp = this.compareSortText(a.itemId, b.itemId);
+        if (itemCmp !== 0) {
+          return itemCmp;
+        }
+        return this.compareSortText(a.subIdDisplay, b.subIdDisplay);
       }
 
       return 0;
@@ -3457,7 +3502,11 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
 
   // --- Item Selection ---
   selectItem(item: ExplorerItem, index: number) {
-    if (this.selectedItem?.uuid === item.uuid) {
+    item.rowKey = this.getStableRowKey(item);
+    if (
+      this.selectedItem &&
+      this.getStableRowKey(this.selectedItem) === this.getStableRowKey(item)
+    ) {
       this.selectedIndex = index;
       return;
     }
@@ -3562,40 +3611,51 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
 
   private loadResponseStateForItem(item: ExplorerItem, token: number) {
     // Build item list from filteredItems for fallback lookup
-    const itemList = this.filteredItems.map((i) => ({ itemId: i.itemId, unitId: i.unitId }));
+    const itemList = this.filteredItems.map((i) => ({
+      itemId: i.itemId,
+      unitId: i.unitId,
+      rowKey: this.getStableRowKey(i),
+    }));
+    const responseStateRequest = item.rowKey
+      ? this.api.getResponseStateWithFallback(
+          this.acpId,
+          item.itemId,
+          item.unitId,
+          itemList,
+          item.rowKey,
+        )
+      : this.api.getResponseStateWithFallback(this.acpId, item.itemId, item.unitId, itemList);
 
-    this.api
-      .getResponseStateWithFallback(this.acpId, item.itemId, item.unitId, itemList)
-      .subscribe({
-        next: (result) => {
-          if (token !== this.unitLoadToken) return;
-          if (
-            result.state &&
-            result.state.responseData &&
-            Object.keys(result.state.responseData).length > 0
-          ) {
-            this.currentResponseData = result.state.responseData;
-            this.hasResponseState = true;
-            this.isFallbackState = result.isFallback;
-          } else {
-            // No state available (direct or fallback)
-            this.currentResponseData = null;
-            this.hasResponseState = false;
-            this.isFallbackState = false;
-          }
-          this.responseStateReady = true;
-          this.startPlayerIfReady();
-        },
-        error: () => {
-          if (token !== this.unitLoadToken) return;
-          // On error, continue without state
+    responseStateRequest.subscribe({
+      next: (result) => {
+        if (token !== this.unitLoadToken) return;
+        if (
+          result.state &&
+          result.state.responseData &&
+          Object.keys(result.state.responseData).length > 0
+        ) {
+          this.currentResponseData = result.state.responseData;
+          this.hasResponseState = true;
+          this.isFallbackState = result.isFallback;
+        } else {
+          // No state available (direct or fallback)
           this.currentResponseData = null;
           this.hasResponseState = false;
           this.isFallbackState = false;
-          this.responseStateReady = true;
-          this.startPlayerIfReady();
-        },
-      });
+        }
+        this.responseStateReady = true;
+        this.startPlayerIfReady();
+      },
+      error: () => {
+        if (token !== this.unitLoadToken) return;
+        // On error, continue without state
+        this.currentResponseData = null;
+        this.hasResponseState = false;
+        this.isFallbackState = false;
+        this.responseStateReady = true;
+        this.startPlayerIfReady();
+      },
+    });
   }
 
   saveCurrentResponseState() {
@@ -3621,6 +3681,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
         this.selectedItem.itemId,
         this.selectedItem.unitId,
         this.currentResponseData,
+        this.selectedItem.rowKey,
       )
       .subscribe({
         next: () => {
@@ -3650,7 +3711,12 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     this.confirmDialogState = 'deleting';
 
     this.api
-      .deleteResponseState(this.acpId, this.selectedItem.itemId, this.selectedItem.unitId)
+      .deleteResponseState(
+        this.acpId,
+        this.selectedItem.itemId,
+        this.selectedItem.unitId,
+        this.selectedItem.rowKey,
+      )
       .subscribe({
         next: () => {
           this.hasResponseState = false;
@@ -3930,7 +3996,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     }
     const startPage = targetLocation.scrollPageIndex;
     this.previewUnavailableReason = '';
-    const sessionId = `explorer-${selectedItem.uuid || 'none'}-${this.startSessionCounter + 1}`;
+    const sessionId = `explorer-${this.getStableRowKey(selectedItem) || 'none'}-${this.startSessionCounter + 1}`;
     const usesPagedNavigation = this.pagingMode !== 'view-all' && this.pagingMode !== 'print-ids';
     const playerDefinition = this.getPlayerDefinitionContent();
 
@@ -4066,7 +4132,10 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
 
   private getEffectivePlayerTarget(item?: ExplorerItem | null): string {
     if (!item) return '';
-    if (this.selectedItem?.uuid === item.uuid) {
+    if (
+      this.selectedItem &&
+      this.getStableRowKey(this.selectedItem) === this.getStableRowKey(item)
+    ) {
       return this.selectedPreviewTarget;
     }
     return this.getPersistedOrDefaultPlayerTarget(item);
@@ -4385,7 +4454,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       ? item.itemId
       : `${item.unitId}_${item.itemId}`;
 
-    for (const candidate of [item.uuid, resolvedItemId, item.itemId]) {
+    for (const candidate of [item.rowKey, item.uuid, resolvedItemId, item.itemId]) {
       const key = String(candidate || '').trim();
       if (key) {
         return key;
@@ -4605,8 +4674,8 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   private hydrateItemTagsFromItems() {
     const tagsFromItems: Record<string, string[]> = {};
     for (const item of this.items) {
-      if (item.uuid && Array.isArray(item.tags) && item.tags.length) {
-        tagsFromItems[item.uuid] = [...item.tags];
+      if (item.rowKey && Array.isArray(item.tags) && item.tags.length) {
+        tagsFromItems[item.rowKey] = [...item.tags];
       }
     }
     this.itemTags = tagsFromItems;
@@ -4730,12 +4799,8 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     this.syncEffectiveExplorerPermissions();
     this.itemListError = '';
 
-    if (this.latestExplorerState) {
-      this.applySharedExplorerEnvelope(this.latestExplorerState);
-    }
-
+    await new Promise<void>((resolve) => this.reloadItems(resolve));
     await this.loadSharedExplorerState();
-    this.reloadItems();
     this.perspectiveSwitchBusy = false;
   }
 
@@ -4851,7 +4916,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     this.sortIsMeta = false;
     this.sortDir = 'asc';
     if (!this.itemOrder.length) {
-      this.itemOrder = this.items.map((item) => item.uuid);
+      this.itemOrder = this.items.map((item) => item.rowKey);
     }
     this.applySort();
   }
@@ -4861,9 +4926,9 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       return;
     }
     if (!this.itemOrder.length) {
-      this.itemOrder = this.items.map((item) => item.uuid);
+      this.itemOrder = this.items.map((item) => item.rowKey);
     }
-    const currentIndex = this.itemOrder.indexOf(this.selectedItem.uuid);
+    const currentIndex = this.itemOrder.indexOf(this.selectedItem.rowKey);
     if (currentIndex === -1) {
       return;
     }
@@ -5171,16 +5236,16 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
 
     this.hydrateItemTagsFromItems();
     if (Object.keys(stateTags).length) {
-      this.itemTags = stateTags;
+      this.itemTags = { ...this.itemTags, ...stateTags };
     }
 
     if (!this.itemOrder.length) {
-      this.itemOrder = this.items.map((item) => item.uuid);
+      this.itemOrder = this.items.map((item) => item.rowKey);
     } else {
-      const existing = new Set(this.items.map((item) => item.uuid));
+      const existing = new Set(this.items.map((item) => item.rowKey));
       const filteredOrder = this.itemOrder.filter((entry) => existing.has(entry));
       const missing = this.items
-        .map((item) => item.uuid)
+        .map((item) => item.rowKey)
         .filter((entry) => !filteredOrder.includes(entry));
       this.itemOrder = [...filteredOrder, ...missing];
     }
@@ -5197,7 +5262,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       ? item.itemId
       : `${item.unitId}_${item.itemId}`;
 
-    for (const candidate of [item.uuid, resolvedItemId, item.itemId]) {
+    for (const candidate of [item.rowKey, item.uuid, resolvedItemId, item.itemId]) {
       const key = String(candidate || '').trim();
       if (key) {
         keys.add(key);
@@ -5210,12 +5275,15 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     itemProperties: Record<string, Record<string, unknown>>,
     keys: string[],
   ): Record<string, unknown> | null {
-    for (const key of keys) {
+    const merged: Record<string, unknown> = {};
+    let found = false;
+    for (const key of [...keys].reverse()) {
       if (this.isRecord(itemProperties[key])) {
-        return itemProperties[key];
+        Object.assign(merged, itemProperties[key]);
+        found = true;
       }
     }
-    return null;
+    return found ? merged : null;
   }
 
   private getTagsForKeys(tagsMap: Record<string, string[]>, keys: string[]): string[] {
@@ -5466,7 +5534,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   }
 
   getItemRowId(item: ExplorerItem): string {
-    const rawId = item.uuid || `${item.unitId}_${item.itemId}`;
+    const rawId = this.getStableRowKey(item);
     return `item-explorer-row-${String(rawId).replace(/[^a-zA-Z0-9_-]/g, '-')}`;
   }
 
@@ -5579,7 +5647,11 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   private getSelectedFilteredIndex(): number {
     if (this.selectedIndex >= 0 && this.selectedIndex < this.filteredItems.length) {
       const itemAtIndex = this.filteredItems[this.selectedIndex];
-      if (itemAtIndex?.uuid === this.selectedItem?.uuid) {
+      if (
+        itemAtIndex &&
+        this.selectedItem &&
+        this.getStableRowKey(itemAtIndex) === this.getStableRowKey(this.selectedItem)
+      ) {
         return this.selectedIndex;
       }
     }
@@ -5588,7 +5660,9 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       return -1;
     }
 
-    return this.filteredItems.findIndex((item) => item.uuid === this.selectedItem?.uuid);
+    return this.filteredItems.findIndex(
+      (item) => this.getStableRowKey(item) === this.getStableRowKey(this.selectedItem),
+    );
   }
 
   private scrollActiveRowIntoView() {
@@ -5610,7 +5684,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     }
 
     const selectedIndex = this.filteredItems.findIndex(
-      (item) => item.uuid === this.selectedItem?.uuid,
+      (item) => this.getStableRowKey(item) === this.getStableRowKey(this.selectedItem),
     );
     if (selectedIndex >= 0) {
       this.selectItem(this.filteredItems[selectedIndex], selectedIndex);
@@ -5638,6 +5712,11 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     this.customPreviewTargetDraft = '';
     this.syncPreviewTargetResolution(null);
     this.resetPlayer();
+  }
+
+  private getStableRowKey(item?: ExplorerItem | null): string {
+    if (!item) return '';
+    return String(item.rowKey || item.uuid || `${item.unitId}_${item.itemId}`).trim();
   }
 
   private focusGlobalFilter() {


### PR DESCRIPTION
## Was wurde geändert?

- Die Umsetzung aus #53 wurde auf einen neuen Branch direkt von `master` übertragen.
- Die versehentlich mitgeführten Item-ID-Format-Abhängigkeiten aus #52 wurden entfernt.
- Partial-Credit-/Sub-ID-Zeilen behalten eigene empirische Schwierigkeiten und stabile Row-Keys.
- Sub-ID-Bezeichnung und Anzeigenamen bleiben ACP-spezifisch konfigurierbar.
- Auswahl, Sortierung, Tags, Ausschlüsse, Vorschauziele und gespeicherte Antwortzustände sind pro Zeile getrennt.
- Draft/Publish, Importe und Datenbankmigrationen unterstützen die stabilen Zeilenschlüssel.

## Warum?

PR #53 wurde versehentlich in den Feature-Branch von #52 statt direkt nach `master` gemergt. Dadurch war Issue #43 zwar geschlossen, die Umsetzung aber nicht im Hauptzweig. Dieser PR stellt den vorgesehenen Zielbranch wieder her und hält den Umfang unabhängig von #52.

## Auswirkungen

- PR #52 enthält wieder ausschließlich Item-ID-Formate und Kompetenzbereichsfilter.
- Dieser PR enthält ausschließlich die Partial-Credit- und Row-Key-Funktionalität aus #43.
- Bestehende einfache Items behalten ihre bisherige Darstellung und werden auf stabile Standardschlüssel abgebildet.

## Validierung

- Backend: 41 Test-Suites, 472 Tests
- Frontend: 24 Testdateien, 307 Tests
- Backend- und Frontend-Build
- Backend- und Frontend-ESLint
- Backend- und Frontend-Prettier
- Diff-Prüfung ohne Whitespace-Fehler

Ersetzt den irrtümlich auf den Branch von #52 gemergten PR #53.

Closes #43