### PR TITLE
Persönliche Item-Arbeitsdaten im Item-Explorer

### DIFF
--- a/backend/src/acp/acp.service.spec.ts
+++ b/backend/src/acp/acp.service.spec.ts
@@ -70,6 +70,11 @@ describe("AcpService", () => {
       findOne: jest.fn().mockResolvedValue(null),
       remove: jest.fn().mockResolvedValue(undefined),
     };
+    credentialRepo.manager = {
+      transaction: jest.fn(async (callback) =>
+        callback({ getRepository: () => credentialRepo }),
+      ),
+    };
     settingsRepo = {
       findOne: jest.fn().mockResolvedValue(null),
     };
@@ -354,6 +359,54 @@ describe("AcpService", () => {
       ).rejects.toThrow(BadRequestException);
     });
 
+    it("retains credential access dates during feature-only updates", async () => {
+      const validFrom = new Date("2026-01-01T00:00:00.000Z");
+      const validUntil = new Date("2026-02-01T00:00:00.000Z");
+      accessConfigRepo.findOne.mockResolvedValue({
+        acpId: "acp-1",
+        accessModel: AccessModel.CREDENTIALS_LIST,
+        allowRegistered: false,
+        featureConfig: {},
+        validFrom,
+        validUntil,
+      });
+
+      await service.updateAccessConfig("acp-1", {
+        accessModel: "CREDENTIALS_LIST",
+        featureConfig: { enablePersonalItemData: true },
+      });
+
+      expect(accessConfigRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessModel: AccessModel.CREDENTIALS_LIST,
+          validFrom,
+          validUntil,
+          featureConfig: expect.objectContaining({
+            enablePersonalItemData: true,
+          }),
+        }),
+      );
+    });
+
+    it("requires a new validity window when switching to credential access", async () => {
+      accessConfigRepo.findOne.mockResolvedValue({
+        acpId: "acp-1",
+        accessModel: AccessModel.PUBLIC,
+        allowRegistered: false,
+        featureConfig: {},
+        validFrom: new Date("2025-01-01T00:00:00.000Z"),
+        validUntil: new Date("2025-02-01T00:00:00.000Z"),
+      });
+
+      await expect(
+        service.updateAccessConfig("acp-1", {
+          accessModel: "CREDENTIALS_LIST",
+        }),
+      ).rejects.toThrow(
+        "Credential-based access requires validFrom and validUntil",
+      );
+    });
+
     it("updates existing access config values", async () => {
       acpRepo.findOne.mockResolvedValue(mockAcp);
       accessConfigRepo.findOne.mockResolvedValue({
@@ -372,8 +425,8 @@ describe("AcpService", () => {
         expect.objectContaining({
           accessModel: "PUBLIC",
           allowRegistered: true,
-          validFrom: undefined,
-          validUntil: undefined,
+          validFrom: null,
+          validUntil: null,
         }),
       );
     });
@@ -607,9 +660,9 @@ describe("AcpService", () => {
         skipped: 0,
         duplicates: [],
       });
-      expect(credentialRepo.delete).toHaveBeenCalledWith({
-        accessConfigId: "cfg-1",
-      });
+      expect(credentialRepo.remove).toHaveBeenCalledWith([
+        expect.objectContaining({ id: "cred-1", username: "existing" }),
+      ]);
 
       const append = await service.uploadCredentials(
         "acp-1",
@@ -633,6 +686,96 @@ describe("AcpService", () => {
       );
       expect(upsert.updated).toBe(1);
       expect(upsert.added).toBe(1);
+    });
+
+    it("preserves stable credential ids during replace uploads", async () => {
+      accessConfigRepo.findOne.mockResolvedValue({
+        id: "cfg-1",
+        accessModel: AccessModel.CREDENTIALS_LIST,
+      });
+      credentialRepo.find.mockResolvedValue([
+        { id: "cred-1", username: "existing", passwordHash: "old" },
+      ]);
+
+      const result = await service.uploadCredentials(
+        "acp-1",
+        [{ username: "existing", password: "new-password" }],
+        "replace",
+      );
+
+      expect(result).toEqual({
+        added: 0,
+        updated: 1,
+        skipped: 0,
+        duplicates: [],
+      });
+      expect(credentialRepo.save).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: "cred-1",
+          username: "existing",
+          passwordHash: "hashed",
+        }),
+      ]);
+      expect(credentialRepo.remove).not.toHaveBeenCalled();
+    });
+
+    it("removes duplicate existing usernames during replace uploads", async () => {
+      accessConfigRepo.findOne.mockResolvedValue({
+        id: "cfg-1",
+        accessModel: AccessModel.CREDENTIALS_LIST,
+      });
+      credentialRepo.find.mockResolvedValue([
+        { id: "cred-1", username: "existing", passwordHash: "old-a" },
+        { id: "cred-2", username: "existing", passwordHash: "old-b" },
+      ]);
+
+      const result = await service.uploadCredentials(
+        "acp-1",
+        [{ username: "existing", password: "new-password" }],
+        "replace",
+      );
+
+      expect(result).toEqual({
+        added: 0,
+        updated: 1,
+        skipped: 0,
+        duplicates: [],
+      });
+      expect(credentialRepo.save).toHaveBeenCalledWith([
+        expect.objectContaining({ id: "cred-1", passwordHash: "hashed" }),
+      ]);
+      expect(credentialRepo.remove).toHaveBeenCalledWith([
+        expect.objectContaining({ id: "cred-2" }),
+      ]);
+    });
+
+    it("does not hash credentials skipped by append uploads", async () => {
+      accessConfigRepo.findOne.mockResolvedValue({
+        id: "cfg-1",
+        accessModel: AccessModel.CREDENTIALS_LIST,
+      });
+      credentialRepo.find.mockResolvedValue([
+        { id: "cred-1", username: "existing", passwordHash: "old" },
+      ]);
+      const hash = jest.mocked(bcrypt.hash);
+
+      const result = await service.uploadCredentials(
+        "acp-1",
+        [
+          { username: "existing", password: "must-not-be-hashed" },
+          { username: "new-user", password: "new-password" },
+        ],
+        "append",
+      );
+
+      expect(result).toEqual({
+        added: 1,
+        updated: 0,
+        skipped: 1,
+        duplicates: [],
+      });
+      expect(hash).toHaveBeenCalledTimes(1);
+      expect(hash).toHaveBeenCalledWith("new-password", 12);
     });
 
     it("handles duplicate usernames within upload payload", async () => {

--- a/backend/src/acp/acp.service.ts
+++ b/backend/src/acp/acp.service.ts
@@ -272,16 +272,33 @@ export class AcpService {
   ): Promise<AcpAccessConfig> {
     await this.findById(acpId);
 
+    let config = await this.accessConfigRepository.findOne({
+      where: { acpId },
+    });
+    const canRetainCredentialValidity =
+      config?.accessModel === AccessModel.CREDENTIALS_LIST &&
+      dto.accessModel === AccessModel.CREDENTIALS_LIST;
+    const existingValidFrom = canRetainCredentialValidity
+      ? config?.validFrom
+      : undefined;
+    const existingValidUntil = canRetainCredentialValidity
+      ? config?.validUntil
+      : undefined;
+    const validFrom = dto.validFrom
+      ? new Date(dto.validFrom)
+      : existingValidFrom;
+    const validUntil = dto.validUntil
+      ? new Date(dto.validUntil)
+      : existingValidUntil;
+
     // Validate time limit for CREDENTIALS_LIST
     if (dto.accessModel === "CREDENTIALS_LIST") {
-      if (!dto.validFrom || !dto.validUntil) {
+      if (!validFrom || !validUntil) {
         throw new BadRequestException(
           "Credential-based access requires validFrom and validUntil",
         );
       }
 
-      const validFrom = new Date(dto.validFrom);
-      const validUntil = new Date(dto.validUntil);
       if (
         Number.isNaN(validFrom.getTime()) ||
         Number.isNaN(validUntil.getTime())
@@ -303,9 +320,6 @@ export class AcpService {
       }
     }
 
-    let config = await this.accessConfigRepository.findOne({
-      where: { acpId },
-    });
     if (config) {
       config.accessModel = dto.accessModel as AccessModel;
       if (dto.allowRegistered !== undefined)
@@ -313,13 +327,9 @@ export class AcpService {
       if (dto.featureConfig)
         config.featureConfig = normalizeFeatureConfig(dto.featureConfig);
       config.validFrom =
-        dto.accessModel === "CREDENTIALS_LIST" && dto.validFrom
-          ? new Date(dto.validFrom)
-          : undefined;
+        dto.accessModel === "CREDENTIALS_LIST" ? validFrom : null;
       config.validUntil =
-        dto.accessModel === "CREDENTIALS_LIST" && dto.validUntil
-          ? new Date(dto.validUntil)
-          : undefined;
+        dto.accessModel === "CREDENTIALS_LIST" ? validUntil : null;
     } else {
       config = this.accessConfigRepository.create({
         acpId,
@@ -329,14 +339,8 @@ export class AcpService {
           [PLAYER_FOCUS_HIGHLIGHT_FEATURE_KEY]: false,
           ...(dto.featureConfig || {}),
         }),
-        validFrom:
-          dto.accessModel === "CREDENTIALS_LIST" && dto.validFrom
-            ? new Date(dto.validFrom)
-            : undefined,
-        validUntil:
-          dto.accessModel === "CREDENTIALS_LIST" && dto.validUntil
-            ? new Date(dto.validUntil)
-            : undefined,
+        validFrom: dto.accessModel === "CREDENTIALS_LIST" ? validFrom : null,
+        validUntil: dto.accessModel === "CREDENTIALS_LIST" ? validUntil : null,
       });
     }
 
@@ -384,93 +388,125 @@ export class AcpService {
       );
     }
 
-    // Get existing credentials for comparison
-    const existingCreds = await this.credentialRepository.find({
-      where: { accessConfigId: config.id },
-    });
-    const existingMap = new Map(existingCreds.map((c) => [c.username, c]));
-
-    let added = 0;
-    let updated = 0;
-    let skipped = 0;
     const duplicates: string[] = [];
     const seenInUpload = new Set<string>();
-
-    // Check for duplicates within the upload itself
-    for (const cred of credentials) {
+    const uniqueCredentials = credentials.filter((cred) => {
       if (seenInUpload.has(cred.username)) {
-        duplicates.push(cred.username);
-        continue;
+        if (!duplicates.includes(cred.username)) duplicates.push(cred.username);
+        return false;
       }
       seenInUpload.add(cred.username);
+      return true;
+    });
+    const existingAppendUsernames =
+      mode === "append"
+        ? new Set(
+            (
+              await this.credentialRepository.find({
+                where: { accessConfigId: config.id },
+                select: ["username"],
+              })
+            ).map((credential) => credential.username),
+          )
+        : new Set<string>();
+    const credentialsToHash =
+      mode === "append"
+        ? uniqueCredentials.filter(
+            (credential) => !existingAppendUsernames.has(credential.username),
+          )
+        : uniqueCredentials;
+    const passwordHashes = await this.hashCredentials(credentialsToHash);
 
-      const existing = existingMap.get(cred.username);
-
-      if (mode === "replace") {
-        // Replace: just collect for recreation
-        continue;
-      } else if (mode === "append") {
-        // Append: skip if exists
-        if (existing) {
-          skipped++;
-          continue;
-        }
-      } else if (mode === "upsert") {
-        // Upsert: update if exists
-        if (existing) {
-          const passwordHash = await bcrypt.hash(cred.password, 12);
-          existing.passwordHash = passwordHash;
-          await this.credentialRepository.save(existing);
-          updated++;
-          continue;
+    return this.credentialRepository.manager.transaction(async (manager) => {
+      const credentialRepository = manager.getRepository(AcpCredential);
+      const existingCredentials = await credentialRepository.find({
+        where: { accessConfigId: config.id },
+        order: { id: "ASC" },
+      });
+      const existingByUsername = new Map<string, AcpCredential>();
+      const duplicateCredentials: AcpCredential[] = [];
+      for (const credential of existingCredentials) {
+        if (existingByUsername.has(credential.username)) {
+          duplicateCredentials.push(credential);
+        } else {
+          existingByUsername.set(credential.username, credential);
         }
       }
+      let added = 0;
+      let updated = 0;
+      let skipped = 0;
+      const credentialsToSave: AcpCredential[] = [];
 
-      added++;
-    }
+      for (const credential of uniqueCredentials) {
+        const existing = existingByUsername.get(credential.username);
+        if (existing && mode === "append") {
+          skipped += 1;
+          continue;
+        }
 
-    if (mode === "replace") {
-      // Delete all existing
-      await this.credentialRepository.delete({ accessConfigId: config.id });
+        const passwordHash =
+          passwordHashes.get(credential.username) ||
+          (await bcrypt.hash(credential.password, 12));
 
-      // Create new credentials
-      const entities = await Promise.all(
-        credentials.map(async (cred) => {
-          const passwordHash = await bcrypt.hash(cred.password, 12);
-          return this.credentialRepository.create({
+        if (existing) {
+          existing.passwordHash = passwordHash;
+          credentialsToSave.push(existing);
+          updated += 1;
+          continue;
+        }
+
+        credentialsToSave.push(
+          credentialRepository.create({
             accessConfigId: config.id,
-            username: cred.username,
+            username: credential.username,
             passwordHash,
-          });
-        }),
-      );
+          }),
+        );
+        added += 1;
+      }
 
-      await this.credentialRepository.save(entities);
-      added = entities.length;
-    } else {
-      // For append/upsert: create only new credentials
-      const newCreds = credentials.filter((cred) => {
-        if (duplicates.includes(cred.username)) return false;
-        if (mode === "append" && existingMap.has(cred.username)) return false;
-        if (mode === "upsert" && existingMap.has(cred.username)) return false;
-        return true;
-      });
+      if (credentialsToSave.length) {
+        await credentialRepository.save(credentialsToSave);
+      }
 
-      const entities = await Promise.all(
-        newCreds.map(async (cred) => {
-          const passwordHash = await bcrypt.hash(cred.password, 12);
-          return this.credentialRepository.create({
-            accessConfigId: config.id,
-            username: cred.username,
-            passwordHash,
-          });
-        }),
-      );
+      if (mode === "replace") {
+        const incomingUsernames = new Set(
+          uniqueCredentials.map((credential) => credential.username),
+        );
+        const removedCredentials = existingCredentials.filter(
+          (credential) =>
+            duplicateCredentials.includes(credential) ||
+            !incomingUsernames.has(credential.username),
+        );
+        if (removedCredentials.length) {
+          await credentialRepository.remove(removedCredentials);
+        }
+      } else if (duplicateCredentials.length) {
+        await credentialRepository.remove(duplicateCredentials);
+      }
 
-      await this.credentialRepository.save(entities);
-    }
+      return { added, updated, skipped, duplicates };
+    });
+  }
 
-    return { added, updated, skipped, duplicates };
+  private async hashCredentials(
+    credentials: CredentialEntryDto[],
+  ): Promise<Map<string, string>> {
+    const passwordHashes = new Map<string, string>();
+    let nextIndex = 0;
+    const workerCount = Math.min(4, credentials.length);
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (nextIndex < credentials.length) {
+        const credential = credentials[nextIndex];
+        nextIndex += 1;
+        passwordHashes.set(
+          credential.username,
+          await bcrypt.hash(credential.password, 12),
+        );
+      }
+    });
+    await Promise.all(workers);
+    return passwordHashes;
   }
 
   async getCredentials(acpId: string): Promise<CredentialResponseDto[]> {

--- a/backend/src/acp/feature-config.utils.spec.ts
+++ b/backend/src/acp/feature-config.utils.spec.ts
@@ -1,6 +1,41 @@
 import { normalizeFeatureConfig } from "./feature-config.utils";
 
 describe("normalizeFeatureConfig", () => {
+  it("normalizes personal item working-data configuration", () => {
+    expect(
+      normalizeFeatureConfig({
+        enablePersonalItemData: true,
+        personalItemCategoryLabel: " Stufe ",
+        personalItemCategoryValues: ["I", " I ", "II", ""],
+        personalItemTagLabel: " Sichtung ",
+        personalItemTags: [
+          { label: "Prüfen", color: "#ABCDEF" },
+          { label: "Prüfen", color: "#000000" },
+          { label: "Offen", color: "invalid" },
+        ],
+      }),
+    ).toMatchObject({
+      enablePersonalItemData: true,
+      personalItemCategoryLabel: "Stufe",
+      personalItemCategoryValues: ["I", "II"],
+      personalItemTagLabel: "Sichtung",
+      personalItemTags: [
+        { label: "Prüfen", color: "#abcdef" },
+        { label: "Offen", color: "#3498db" },
+      ],
+    });
+  });
+
+  it("limits every personal item category value", () => {
+    const longValue = "x".repeat(250);
+
+    const normalized = normalizeFeatureConfig({
+      personalItemCategoryValues: [longValue, `${"x".repeat(200)}duplicate`],
+    });
+
+    expect(normalized.personalItemCategoryValues).toEqual(["x".repeat(200)]);
+  });
+
   it("defaults player focus highlight to disabled when the flag is missing", () => {
     const normalized = normalizeFeatureConfig({
       enableItemList: true,

--- a/backend/src/acp/feature-config.utils.ts
+++ b/backend/src/acp/feature-config.utils.ts
@@ -20,6 +20,28 @@ function asStringArray(value: unknown): string[] {
     .filter((entry) => entry.length > 0);
 }
 
+function normalizePersonalItemTags(
+  value: unknown,
+): Array<{ label: string; color: string }> {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const tags: Array<{ label: string; color: string }> = [];
+  for (const entry of value) {
+    const record = asRecord(entry);
+    const label =
+      typeof record.label === "string" ? record.label.trim().slice(0, 100) : "";
+    if (!label || seen.has(label)) continue;
+    const color =
+      typeof record.color === "string" &&
+      /^#[0-9a-f]{6}$/i.test(record.color.trim())
+        ? record.color.trim().toLowerCase()
+        : "#3498db";
+    seen.add(label);
+    tags.push({ label, color });
+  }
+  return tags.slice(0, 50);
+}
+
 function normalizeStringMap(value: unknown): Record<string, string> {
   const source = asRecord(value);
   const normalized: Record<string, string> = {};
@@ -73,6 +95,28 @@ export function normalizeFeatureConfig(featureConfig: unknown): UnknownRecord {
 
   normalized.enablePlayerFocusHighlight =
     source.enablePlayerFocusHighlight === true;
+
+  normalized.enablePersonalItemData = source.enablePersonalItemData === true;
+  normalized.personalItemCategoryLabel =
+    typeof source.personalItemCategoryLabel === "string" &&
+    source.personalItemCategoryLabel.trim()
+      ? source.personalItemCategoryLabel.trim().slice(0, 100)
+      : "Kompetenzstufe";
+  normalized.personalItemCategoryValues = Array.from(
+    new Set(
+      asStringArray(source.personalItemCategoryValues).map((value) =>
+        value.slice(0, 200),
+      ),
+    ),
+  ).slice(0, 50);
+  normalized.personalItemTagLabel =
+    typeof source.personalItemTagLabel === "string" &&
+    source.personalItemTagLabel.trim()
+      ? source.personalItemTagLabel.trim().slice(0, 100)
+      : "Markierungen";
+  normalized.personalItemTags = normalizePersonalItemTags(
+    source.personalItemTags,
+  );
 
   normalized.itemSubIdLabel =
     typeof source.itemSubIdLabel === "string" &&

--- a/backend/src/database/database-compatibility.spec.ts
+++ b/backend/src/database/database-compatibility.spec.ts
@@ -66,4 +66,59 @@ describe("prepareSchemaForSynchronization", () => {
     );
     expect(queryRunner.release).toHaveBeenCalledTimes(1);
   });
+
+  it("backfills stable credential preference ids before synchronization", async () => {
+    const { dataSource, queryRunner } = createDataSource(false);
+    (queryRunner.hasTable as jest.Mock).mockImplementation(
+      async (table: string) =>
+        table === "acp_item_preferences" ||
+        table === "acp_credentials" ||
+        table === "acp_access_configs",
+    );
+
+    await prepareSchemaForSynchronization(dataSource);
+
+    const statements = (queryRunner.query as jest.Mock).mock.calls.map(
+      ([statement]) => statement as string,
+    );
+    expect(
+      statements.some((statement) =>
+        statement.includes('ADD COLUMN IF NOT EXISTS "credential_id"'),
+      ),
+    ).toBe(true);
+    expect(
+      statements.some(
+        (statement) =>
+          statement.includes('SET "credential_id" = credential."id"') &&
+          statement.includes(
+            'preference."credential_username" = credential."username"',
+          ),
+      ),
+    ).toBe(true);
+    expect(
+      statements.some(
+        (statement) =>
+          statement.includes('DELETE FROM "acp_item_preferences"') &&
+          statement.includes('"credential_id" IS NULL') &&
+          statement.includes('"credential_username" IS NOT NULL'),
+      ),
+    ).toBe(true);
+    expect(
+      statements.some((statement) =>
+        statement.includes(
+          'CREATE UNIQUE INDEX IF NOT EXISTS "IDX_acp_credentials_unique_username"',
+        ),
+      ),
+    ).toBe(true);
+    const createTemporaryTableIndex = statements.findIndex((statement) =>
+      statement.includes(
+        'CREATE TEMPORARY TABLE "acp_credential_dedup_map_1783903000000"',
+      ),
+    );
+    const dropTemporaryTableIndex = statements.findIndex((statement) =>
+      statement.includes('DROP TABLE "acp_credential_dedup_map_1783903000000"'),
+    );
+    expect(createTemporaryTableIndex).toBeGreaterThanOrEqual(0);
+    expect(dropTemporaryTableIndex).toBeGreaterThan(createTemporaryTableIndex);
+  });
 });

--- a/backend/src/database/database-compatibility.ts
+++ b/backend/src/database/database-compatibility.ts
@@ -1,6 +1,8 @@
 import { DataSource, DataSourceOptions } from "typeorm";
 import { AddItemResponseStateRowKey1783900000000 } from "./migrations/1783900000000-AddItemResponseStateRowKey";
 import { ReconcileItemExplorerState1783901000000 } from "./migrations/1783901000000-ReconcileItemExplorerState";
+import { ScopeItemPreferencesToCredentialId1783902000000 } from "./migrations/1783902000000-ScopeItemPreferencesToCredentialId";
+import { DeduplicateAcpCredentials1783903000000 } from "./migrations/1783903000000-DeduplicateAcpCredentials";
 
 /**
  * Prepare schemas that were previously maintained through TypeORM synchronize.
@@ -24,6 +26,16 @@ export async function prepareSchemaForSynchronization(
       (await queryRunner.hasTable("acp_item_explorer_state"))
     ) {
       await new ReconcileItemExplorerState1783901000000().up(queryRunner);
+    }
+    if (
+      (await queryRunner.hasTable("acp_item_preferences")) &&
+      (await queryRunner.hasTable("acp_credentials")) &&
+      (await queryRunner.hasTable("acp_access_configs"))
+    ) {
+      await new ScopeItemPreferencesToCredentialId1783902000000().up(
+        queryRunner,
+      );
+      await new DeduplicateAcpCredentials1783903000000().up(queryRunner);
     }
   } finally {
     await queryRunner.release();

--- a/backend/src/database/entities/acp-access-config.entity.ts
+++ b/backend/src/database/entities/acp-access-config.entity.ts
@@ -34,10 +34,10 @@ export class AcpAccessConfig {
   featureConfig!: Record<string, unknown>;
 
   @Column({ name: "valid_from", type: "timestamptz", nullable: true })
-  validFrom?: Date;
+  validFrom?: Date | null;
 
   @Column({ name: "valid_until", type: "timestamptz", nullable: true })
-  validUntil?: Date;
+  validUntil?: Date | null;
 
   @ManyToOne(() => Acp, (acp) => acp.accessConfigs, { onDelete: "CASCADE" })
   @JoinColumn({ name: "acp_id" })

--- a/backend/src/database/entities/acp-credential.entity.ts
+++ b/backend/src/database/entities/acp-credential.entity.ts
@@ -1,5 +1,6 @@
 import {
   Entity,
+  Index,
   PrimaryGeneratedColumn,
   Column,
   ManyToOne,
@@ -8,6 +9,9 @@ import {
 import { AcpAccessConfig } from "./acp-access-config.entity";
 
 @Entity("acp_credentials")
+@Index("IDX_acp_credentials_unique_username", ["accessConfigId", "username"], {
+  unique: true,
+})
 export class AcpCredential {
   @PrimaryGeneratedColumn("uuid")
   id!: string;

--- a/backend/src/database/entities/acp-item-preference.entity.ts
+++ b/backend/src/database/entities/acp-item-preference.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -9,8 +10,18 @@ import {
 } from "typeorm";
 import { Acp } from "./acp.entity";
 import { User } from "./user.entity";
+import { AcpCredential } from "./acp-credential.entity";
 
 @Entity("acp_item_preferences")
+@Index("IDX_acp_item_preferences_unique_user", ["acpId", "viewId", "userId"], {
+  unique: true,
+  where: '"user_id" IS NOT NULL',
+})
+@Index(
+  "IDX_acp_item_preferences_unique_credential",
+  ["acpId", "viewId", "credentialId"],
+  { unique: true, where: '"credential_id" IS NOT NULL' },
+)
 export class AcpItemPreference {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
@@ -26,6 +37,9 @@ export class AcpItemPreference {
 
   @Column({ name: "credential_username", type: "varchar", nullable: true })
   credentialUsername?: string | null;
+
+  @Column({ name: "credential_id", type: "uuid", nullable: true })
+  credentialId?: string | null;
 
   @Column({ type: "jsonb", default: {} })
   preferences!: Record<string, unknown>;
@@ -43,4 +57,11 @@ export class AcpItemPreference {
   @ManyToOne(() => User, { onDelete: "SET NULL", nullable: true })
   @JoinColumn({ name: "user_id" })
   user?: User;
+
+  @ManyToOne(() => AcpCredential, { onDelete: "CASCADE", nullable: true })
+  @JoinColumn({
+    name: "credential_id",
+    foreignKeyConstraintName: "FK_acp_item_preferences_credential",
+  })
+  credential?: AcpCredential;
 }

--- a/backend/src/database/migrations/1783902000000-ScopeItemPreferencesToCredentialId.ts
+++ b/backend/src/database/migrations/1783902000000-ScopeItemPreferencesToCredentialId.ts
@@ -1,0 +1,92 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ScopeItemPreferencesToCredentialId1783902000000 implements MigrationInterface {
+  name = "ScopeItemPreferencesToCredentialId1783902000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable("acp_item_preferences"))) return;
+
+    await queryRunner.query(`
+      ALTER TABLE "acp_item_preferences"
+      ADD COLUMN IF NOT EXISTS "credential_id" uuid
+    `);
+
+    await queryRunner.query(`
+      DELETE FROM "acp_item_preferences" older
+      USING "acp_item_preferences" newer
+      WHERE older."user_id" IS NOT NULL
+        AND older."acp_id" = newer."acp_id"
+        AND older."view_id" = newer."view_id"
+        AND older."user_id" = newer."user_id"
+        AND (older."updated_at", older."id") < (newer."updated_at", newer."id")
+    `);
+    await queryRunner.query(`
+      UPDATE "acp_item_preferences" preference
+      SET "credential_id" = credential."id"
+      FROM "acp_credentials" credential
+      INNER JOIN "acp_access_configs" access_config
+        ON access_config."id" = credential."access_config_id"
+      WHERE preference."credential_id" IS NULL
+        AND preference."user_id" IS NULL
+        AND preference."acp_id" = access_config."acp_id"
+        AND preference."credential_username" = credential."username"
+    `);
+
+    await queryRunner.query(`
+      DELETE FROM "acp_item_preferences"
+      WHERE "user_id" IS NULL
+        AND "credential_id" IS NULL
+        AND "credential_username" IS NOT NULL
+    `);
+
+    await queryRunner.query(`
+      DELETE FROM "acp_item_preferences" older
+      USING "acp_item_preferences" newer
+      WHERE older."credential_id" IS NOT NULL
+        AND older."acp_id" = newer."acp_id"
+        AND older."view_id" = newer."view_id"
+        AND older."credential_id" = newer."credential_id"
+        AND (older."updated_at", older."id") < (newer."updated_at", newer."id")
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "acp_item_preferences"
+      DROP CONSTRAINT IF EXISTS "FK_acp_item_preferences_credential"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "acp_item_preferences"
+      ADD CONSTRAINT "FK_acp_item_preferences_credential"
+      FOREIGN KEY ("credential_id") REFERENCES "acp_credentials"("id")
+      ON DELETE CASCADE ON UPDATE NO ACTION
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_acp_item_preferences_unique_user"
+      ON "acp_item_preferences" ("acp_id", "view_id", "user_id")
+      WHERE "user_id" IS NOT NULL
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_acp_item_preferences_unique_credential"
+      ON "acp_item_preferences" ("acp_id", "view_id", "credential_id")
+      WHERE "credential_id" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable("acp_item_preferences"))) return;
+
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_acp_item_preferences_unique_credential"',
+    );
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_acp_item_preferences_unique_user"',
+    );
+    await queryRunner.query(`
+      ALTER TABLE "acp_item_preferences"
+      DROP CONSTRAINT IF EXISTS "FK_acp_item_preferences_credential"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "acp_item_preferences" DROP COLUMN IF EXISTS "credential_id"
+    `);
+  }
+}

--- a/backend/src/database/migrations/1783903000000-DeduplicateAcpCredentials.ts
+++ b/backend/src/database/migrations/1783903000000-DeduplicateAcpCredentials.ts
@@ -1,0 +1,73 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DeduplicateAcpCredentials1783903000000 implements MigrationInterface {
+  name = "DeduplicateAcpCredentials1783903000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable("acp_credentials"))) return;
+    const hasItemPreferences = await queryRunner.hasTable(
+      "acp_item_preferences",
+    );
+    const canonicalOrder = hasItemPreferences
+      ? `EXISTS (
+              SELECT 1
+              FROM "acp_item_preferences" preference
+              WHERE preference."credential_id" = credential."id"
+            ) DESC,
+            credential."id" ASC`
+      : `credential."id" ASC`;
+
+    await queryRunner.query(`
+      CREATE TEMPORARY TABLE "acp_credential_dedup_map_1783903000000" AS
+      SELECT
+        credential."id" AS "credential_id",
+        FIRST_VALUE(credential."id") OVER (
+          PARTITION BY credential."access_config_id", credential."username"
+          ORDER BY ${canonicalOrder}
+        ) AS "canonical_id"
+      FROM "acp_credentials" credential
+    `);
+
+    if (hasItemPreferences) {
+      await queryRunner.query(`
+        DELETE FROM "acp_item_preferences" older
+        USING "acp_item_preferences" newer,
+              "acp_credential_dedup_map_1783903000000" older_map,
+              "acp_credential_dedup_map_1783903000000" newer_map
+        WHERE older."credential_id" = older_map."credential_id"
+          AND newer."credential_id" = newer_map."credential_id"
+          AND older_map."canonical_id" = newer_map."canonical_id"
+          AND older."acp_id" = newer."acp_id"
+          AND older."view_id" = newer."view_id"
+          AND (older."updated_at", older."id") < (newer."updated_at", newer."id")
+      `);
+      await queryRunner.query(`
+        UPDATE "acp_item_preferences" preference
+        SET "credential_id" = dedup."canonical_id"
+        FROM "acp_credential_dedup_map_1783903000000" dedup
+        WHERE preference."credential_id" = dedup."credential_id"
+          AND dedup."credential_id" <> dedup."canonical_id"
+      `);
+    }
+
+    await queryRunner.query(`
+      DELETE FROM "acp_credentials" credential
+      USING "acp_credential_dedup_map_1783903000000" dedup
+      WHERE credential."id" = dedup."credential_id"
+        AND dedup."credential_id" <> dedup."canonical_id"
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_acp_credentials_unique_username"
+      ON "acp_credentials" ("access_config_id", "username")
+    `);
+    await queryRunner.query(
+      'DROP TABLE "acp_credential_dedup_map_1783903000000"',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "IDX_acp_credentials_unique_username"',
+    );
+  }
+}

--- a/backend/src/files/unit-parser.service.spec.ts
+++ b/backend/src/files/unit-parser.service.spec.ts
@@ -451,4 +451,36 @@ describe("UnitParserService", () => {
       }),
     ]);
   });
+
+  it("caches valid row keys and invalidates them when source files change", async () => {
+    const getItemList = jest
+      .spyOn(service, "getItemListFromFiles")
+      .mockResolvedValue({
+        columns: [],
+        items: [{ rowKey: "uuid-1::1" } as any],
+        subIdLabel: "Sub-ID",
+        subIdLabels: {},
+        unitMetadata: {},
+        codingSchemes: {},
+      });
+    const options = {
+      itemPropertiesOverride: {
+        "uuid-1::1": { subId: "1" },
+      },
+    };
+
+    await expect(
+      service.getItemRowKeysFromFiles("acp-1", options),
+    ).resolves.toEqual(new Set(["uuid-1::1"]));
+    await service.getItemRowKeysFromFiles("acp-1", options);
+    expect(getItemList).toHaveBeenCalledTimes(1);
+
+    fileRepo.find.mockResolvedValue(
+      files.map((file, index) =>
+        index === 0 ? { ...file, checksum: "changed" } : file,
+      ),
+    );
+    await service.getItemRowKeysFromFiles("acp-1", options);
+    expect(getItemList).toHaveBeenCalledTimes(2);
+  });
 });

--- a/backend/src/files/unit-parser.service.ts
+++ b/backend/src/files/unit-parser.service.ts
@@ -78,6 +78,11 @@ interface PartialCreditRow {
   properties: Record<string, unknown>;
 }
 
+interface ItemRowKeyCacheEntry {
+  signature: string;
+  rowKeys: ReadonlySet<string>;
+}
+
 export interface IndexSyncReport {
   unitsAdded: number;
   unitsUpdated: number;
@@ -97,6 +102,8 @@ export interface IndexDependencyCleanupReport {
 @Injectable()
 export class UnitParserService {
   private readonly logger = new Logger(UnitParserService.name);
+  private readonly itemRowKeyCache = new Map<string, ItemRowKeyCacheEntry>();
+  private readonly maxItemRowKeyCacheEntries = 100;
 
   constructor(
     @InjectRepository(AcpFile)
@@ -755,6 +762,59 @@ export class UnitParserService {
       unitMetadata,
       codingSchemes,
     };
+  }
+
+  /**
+   * Resolve the row keys that can currently be shown in the Item Explorer.
+   * The cache signature follows both uploaded file revisions and the active
+   * Explorer item-property keys, which are what create partial-credit rows.
+   */
+  async getItemRowKeysFromFiles(
+    acpId: string,
+    options: {
+      itemPropertiesOverride?: Record<string, Record<string, unknown>>;
+    } = {},
+  ): Promise<ReadonlySet<string>> {
+    const [files, acp] = await Promise.all([
+      this.fileRepository.find({ where: { acpId } }),
+      this.acpRepository.findOne({ where: { id: acpId } }),
+    ]);
+    const itemProperties =
+      options.itemPropertiesOverride || acp?.itemProperties || {};
+    const signature = JSON.stringify({
+      files: files
+        .map((file) => [
+          file.id,
+          file.originalName,
+          file.checksum || "",
+          String(file.fileSize || ""),
+          file.uploadedAt instanceof Date
+            ? file.uploadedAt.toISOString()
+            : String(file.uploadedAt || ""),
+        ])
+        .sort(([left], [right]) => String(left).localeCompare(String(right))),
+      itemPropertyKeys: Object.keys(itemProperties).sort(),
+    });
+    const cacheKey = `${acpId}:${signature}`;
+    const cached = this.itemRowKeyCache.get(cacheKey);
+    if (cached?.signature === signature) {
+      return cached.rowKeys;
+    }
+
+    const itemList = await this.getItemListFromFiles(acpId, options);
+    const rowKeys = new Set(
+      itemList.items
+        .map((item) => String(item.rowKey || "").trim())
+        .filter(Boolean),
+    );
+    if (this.itemRowKeyCache.size >= this.maxItemRowKeyCacheEntries) {
+      const oldestKey = this.itemRowKeyCache.keys().next().value as
+        | string
+        | undefined;
+      if (oldestKey) this.itemRowKeyCache.delete(oldestKey);
+    }
+    this.itemRowKeyCache.set(cacheKey, { signature, rowKeys });
+    return rowKeys;
   }
 
   private resolveItemProperties(

--- a/backend/src/views/personal-item-preferences.query.ts
+++ b/backend/src/views/personal-item-preferences.query.ts
@@ -1,0 +1,67 @@
+export type PreferenceIdentityColumn = "user_id" | "credential_id";
+
+export function buildPatchPersonalItemPreferenceRowQuery(
+  identityColumn: PreferenceIdentityColumn,
+): string {
+  const identityPredicate =
+    identityColumn === "user_id"
+      ? '"user_id" IS NOT NULL'
+      : '"credential_id" IS NOT NULL';
+
+  return `
+    INSERT INTO "acp_item_preferences" (
+      "id", "acp_id", "view_id", "user_id", "credential_id",
+      "credential_username", "preferences", "created_at", "updated_at"
+    )
+    VALUES (
+      uuid_generate_v4(), $1, $2, $3, $4, $5, $6::jsonb, now(), now()
+    )
+    ON CONFLICT ("acp_id", "view_id", "${identityColumn}")
+      WHERE ${identityPredicate}
+    DO UPDATE SET
+      "preferences" = jsonb_set(
+        COALESCE("acp_item_preferences"."preferences", '{}'::jsonb),
+        '{rowData}',
+        CASE
+          WHEN $7::jsonb IS NULL THEN
+            CASE
+              WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
+                THEN ("acp_item_preferences"."preferences"->'rowData') - $8::text
+              ELSE '{}'::jsonb
+            END
+          ELSE
+            CASE
+              WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
+                THEN "acp_item_preferences"."preferences"->'rowData'
+              ELSE '{}'::jsonb
+            END || jsonb_build_object($8::text, $7::jsonb)
+        END,
+        true
+      ),
+      "credential_username" = CASE
+        WHEN EXCLUDED."credential_id" IS NOT NULL
+          THEN EXCLUDED."credential_username"
+        ELSE "acp_item_preferences"."credential_username"
+      END,
+      "updated_at" = now()
+    WHERE $7::jsonb IS NULL
+      OR (
+        CASE
+          WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
+            THEN "acp_item_preferences"."preferences"->'rowData'
+          ELSE '{}'::jsonb
+        END
+      ) ? $8::text
+      OR (
+        SELECT count(*)
+        FROM jsonb_object_keys(
+          CASE
+            WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
+              THEN "acp_item_preferences"."preferences"->'rowData'
+            ELSE '{}'::jsonb
+          END
+        )
+      ) < $9
+    RETURNING 1 AS "updated"
+  `;
+}

--- a/backend/src/views/views.controller.spec.ts
+++ b/backend/src/views/views.controller.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException } from "@nestjs/common";
+import { BadRequestException, ForbiddenException } from "@nestjs/common";
 import { ViewsController } from "./views.controller";
 
 describe("ViewsController", () => {
@@ -32,6 +32,9 @@ describe("ViewsController", () => {
       saveItemPreferences: jest
         .fn()
         .mockResolvedValue({ ui: { q: 2 }, tags: { item1: ["B"] } }),
+      patchPersonalItemPreferenceRow: jest.fn().mockResolvedValue({
+        rowData: { "uuid::1": { note: "mine" } },
+      }),
       getTaskSequence: jest
         .fn()
         .mockResolvedValue({ id: "seq-1", units: [{ id: "unit-1" }] }),
@@ -205,6 +208,171 @@ describe("ViewsController", () => {
       ),
     ).resolves.toEqual({ ui: { q: 2 }, tags: { item1: ["B"] } });
   });
+
+  it("rejects full-map personal Explorer saves", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: {
+        persistUserPreferences: false,
+        enablePersonalItemData: true,
+      },
+    });
+
+    await expect(
+      controller.saveItemPreferences(
+        "acp-1",
+        { viewId: "item-explorer", rowData: { "uuid::1": { note: "mine" } } },
+        { user: { sub: "u-1" } },
+      ),
+    ).rejects.toThrow(BadRequestException);
+    expect(viewsService.saveItemPreferences).not.toHaveBeenCalled();
+  });
+
+  it.each(["item-explorer", " item-explorer "])(
+    "rejects generic %s saves even when row data is omitted",
+    async (viewId) => {
+      viewsService.getAcpStartPage.mockResolvedValue({
+        featureConfig: {
+          persistUserPreferences: true,
+          enablePersonalItemData: true,
+        },
+      });
+
+      await expect(
+        controller.saveItemPreferences(
+          "acp-1",
+          { viewId, ui: { filter: "mine" } },
+          { user: { sub: "u-1" } },
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(viewsService.saveItemPreferences).not.toHaveBeenCalled();
+    },
+  );
+
+  it("patches one personal Explorer row when the feature is enabled", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: {
+        persistUserPreferences: false,
+        enablePersonalItemData: true,
+      },
+    });
+
+    await controller.patchPersonalItemRow(
+      "acp-1",
+      {
+        rowKey: "uuid::1",
+        rowData: { note: "mine" },
+        perspective: "read-only",
+      },
+      { user: { sub: "u-1" } },
+    );
+
+    expect(viewsService.patchPersonalItemPreferenceRow).toHaveBeenCalledWith(
+      "acp-1",
+      { sub: "u-1" },
+      "uuid::1",
+      { note: "mine" },
+      "item-explorer",
+      false,
+    );
+  });
+
+  it("uses the manager draft when validating personal item rows", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: { enablePersonalItemData: true },
+    });
+
+    await controller.patchPersonalItemRow(
+      "acp-1",
+      {
+        rowKey: "uuid::draft",
+        rowData: { note: "mine" },
+        perspective: "editor",
+      },
+      { user: { sub: "u-1" }, acpAccessLevel: "MANAGER" },
+    );
+
+    expect(viewsService.patchPersonalItemPreferenceRow).toHaveBeenCalledWith(
+      "acp-1",
+      { sub: "u-1" },
+      "uuid::draft",
+      { note: "mine" },
+      "item-explorer",
+      true,
+    );
+  });
+
+  it("uses published state for a manager read-only preview", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: { enablePersonalItemData: true },
+    });
+
+    await controller.patchPersonalItemRow(
+      "acp-1",
+      {
+        rowKey: "uuid::published",
+        rowData: { note: "mine" },
+        perspective: "read-only",
+      },
+      { user: { sub: "u-1" }, acpAccessLevel: "MANAGER" },
+    );
+
+    expect(viewsService.patchPersonalItemPreferenceRow).toHaveBeenCalledWith(
+      "acp-1",
+      { sub: "u-1" },
+      "uuid::published",
+      { note: "mine" },
+      "item-explorer",
+      false,
+    );
+  });
+
+  it("does not allow credentials to select the editor state", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: { enablePersonalItemData: true },
+    });
+
+    await controller.patchPersonalItemRow(
+      "acp-1",
+      {
+        rowKey: "uuid::published",
+        rowData: { note: "mine" },
+        perspective: "editor",
+      },
+      { user: { sub: "credential-1" }, acpAccessLevel: "CREDENTIAL" },
+    );
+
+    expect(viewsService.patchPersonalItemPreferenceRow).toHaveBeenCalledWith(
+      "acp-1",
+      { sub: "credential-1" },
+      "uuid::published",
+      { note: "mine" },
+      "item-explorer",
+      false,
+    );
+  });
+
+  it.each([true, false])(
+    "rejects personal row patches when only general persistence is %s",
+    async (persistUserPreferences) => {
+      viewsService.getAcpStartPage.mockResolvedValue({
+        featureConfig: {
+          persistUserPreferences,
+          enablePersonalItemData: false,
+        },
+      });
+
+      await expect(
+        controller.patchPersonalItemRow(
+          "acp-1",
+          { rowKey: "uuid::1", rowData: { note: "mine" } },
+          { user: { sub: "u-1" } },
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(
+        viewsService.patchPersonalItemPreferenceRow,
+      ).not.toHaveBeenCalled();
+    },
+  );
 
   it("returns empty preferences on save when persistence is disabled", async () => {
     viewsService.getAcpStartPage.mockResolvedValueOnce({

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -1,9 +1,11 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   ForbiddenException,
   Get,
   Param,
+  Patch,
   Put,
   Query,
   Request,
@@ -13,10 +15,11 @@ import {
 import {
   ApiBody,
   ApiOperation,
+  ApiProperty,
   ApiPropertyOptional,
   ApiTags,
 } from "@nestjs/swagger";
-import { IsObject, IsOptional, IsString } from "class-validator";
+import { IsIn, IsObject, IsOptional, IsString } from "class-validator";
 import { Response } from "express";
 import { ViewsService } from "./views.service";
 import { AcpAccessGuard } from "../auth/guards/acp-access.guard";
@@ -60,6 +63,34 @@ class SaveItemPreferencesDto {
   @IsOptional()
   @IsObject()
   rowData?: Record<string, Record<string, unknown>>;
+}
+
+class PatchPersonalItemRowDto {
+  @ApiProperty({
+    description: "Stable item row key",
+    example: "item-uuid::1",
+  })
+  @IsString()
+  rowKey!: string;
+
+  @ApiPropertyOptional({
+    description: "Personal row data, or null to remove the row",
+    type: "object",
+    nullable: true,
+    additionalProperties: true,
+  })
+  @IsOptional()
+  @IsObject()
+  rowData?: Record<string, unknown> | null;
+
+  @ApiPropertyOptional({
+    description: "Explorer state used to render the item row",
+    enum: ["editor", "read-only"],
+    default: "read-only",
+  })
+  @IsOptional()
+  @IsIn(["editor", "read-only"])
+  perspective?: "editor" | "read-only";
 }
 
 @ApiTags("Public Views")
@@ -175,11 +206,16 @@ export class ViewsController {
     @Request() req: any,
     @Query("viewId") viewId?: string,
   ) {
-    if (!(await this.isPreferencePersistenceEnabled(acpId))) {
+    const normalizedViewId = this.normalizePreferenceViewId(viewId);
+    if (!(await this.isPreferencePersistenceEnabled(acpId, normalizedViewId))) {
       return { ui: {}, tags: {}, rowData: {} };
     }
 
-    return this.viewsService.getItemPreferences(acpId, req?.user, viewId);
+    return this.viewsService.getItemPreferences(
+      acpId,
+      req?.user,
+      normalizedViewId,
+    );
   }
 
   @Put("acp/:acpId/items/preferences")
@@ -191,7 +227,13 @@ export class ViewsController {
     @Body() dto: SaveItemPreferencesDto,
     @Request() req: any,
   ) {
-    if (!(await this.isPreferencePersistenceEnabled(acpId))) {
+    const normalizedViewId = this.normalizePreferenceViewId(dto.viewId);
+    if (normalizedViewId === "item-explorer") {
+      throw new BadRequestException(
+        "Item Explorer preferences must be saved through their dedicated endpoints",
+      );
+    }
+    if (!(await this.isPreferencePersistenceEnabled(acpId, normalizedViewId))) {
       return { ui: {}, tags: {}, rowData: {} };
     }
 
@@ -203,7 +245,33 @@ export class ViewsController {
         tags: dto.tags,
         rowData: dto.rowData,
       },
-      dto.viewId,
+      normalizedViewId,
+    );
+  }
+
+  @Patch("acp/:acpId/items/preferences/row-data")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "Patch personal working data for one item row" })
+  @ApiBody({ type: PatchPersonalItemRowDto })
+  async patchPersonalItemRow(
+    @Param("acpId") acpId: string,
+    @Body() dto: PatchPersonalItemRowDto,
+    @Request() req: any,
+  ) {
+    if (!(await this.isPersonalItemDataEnabled(acpId))) {
+      throw new ForbiddenException(
+        "Personal item data is not enabled for this ACP",
+      );
+    }
+
+    return this.viewsService.patchPersonalItemPreferenceRow(
+      acpId,
+      req?.user,
+      dto.rowKey,
+      dto.rowData ?? null,
+      "item-explorer",
+      (req?.acpAccessLevel === "MANAGER" || req?.acpAccessLevel === "ADMIN") &&
+        dto.perspective === "editor",
     );
   }
 
@@ -266,12 +334,31 @@ export class ViewsController {
 
   private async isPreferencePersistenceEnabled(
     acpId: string,
+    viewId?: string,
   ): Promise<boolean> {
     const data = await this.viewsService.getAcpStartPage(acpId);
     const featureConfig = (data?.featureConfig || {}) as Record<
       string,
       unknown
     >;
-    return Boolean(featureConfig.persistUserPreferences);
+    return (
+      Boolean(featureConfig.persistUserPreferences) ||
+      (viewId === "item-explorer" &&
+        Boolean(featureConfig.enablePersonalItemData))
+    );
+  }
+
+  private async isPersonalItemDataEnabled(acpId: string): Promise<boolean> {
+    const data = await this.viewsService.getAcpStartPage(acpId);
+    const featureConfig = (data?.featureConfig || {}) as Record<
+      string,
+      unknown
+    >;
+    return featureConfig.enablePersonalItemData === true;
+  }
+
+  private normalizePreferenceViewId(viewId?: string): string {
+    const normalized = String(viewId || "").trim();
+    return normalized ? normalized.slice(0, 120) : "item-list";
   }
 }

--- a/backend/src/views/views.module.ts
+++ b/backend/src/views/views.module.ts
@@ -12,6 +12,7 @@ import {
 } from "../database/entities";
 import { AuthModule } from "../auth/auth.module";
 import { ItemExplorerModule } from "../item-explorer/item-explorer.module";
+import { FilesModule } from "../files/files.module";
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { ItemExplorerModule } from "../item-explorer/item-explorer.module";
     ]),
     AuthModule,
     ItemExplorerModule,
+    FilesModule,
   ],
   controllers: [ViewsController],
   providers: [ViewsService],

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -649,7 +649,7 @@ describe("ViewsService", () => {
     );
     expect(itemPreferenceRepository.query).toHaveBeenCalledWith(
       expect.stringMatching(
-        /jsonb_build_object\(\$8, \$7::jsonb\)[\s\S]*RETURNING 1 AS "updated"/,
+        /\("acp_item_preferences"\."preferences"->'rowData'\) - \$8::text[\s\S]*jsonb_build_object\(\$8::text, \$7::jsonb\)[\s\S]*\? \$8::text[\s\S]*RETURNING 1 AS "updated"/,
       ),
       expect.arrayContaining([
         "acp-1",

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -1,6 +1,9 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
+import { BadRequestException, UnauthorizedException } from "@nestjs/common";
 import { ViewsService } from "./views.service";
+import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
+import { UnitParserService } from "../files/unit-parser.service";
 import {
   Acp,
   AcpAccessConfig,
@@ -19,7 +22,10 @@ describe("ViewsService", () => {
     findOne: jest.Mock;
     create: jest.Mock;
     save: jest.Mock;
+    query: jest.Mock;
   };
+  let itemExplorerStateService: { getStateForViewer: jest.Mock };
+  let unitParserService: { getItemRowKeysFromFiles: jest.Mock };
 
   beforeEach(async () => {
     acpRepository = { findOne: jest.fn() };
@@ -30,6 +36,17 @@ describe("ViewsService", () => {
       findOne: jest.fn(),
       create: jest.fn().mockImplementation((value) => value),
       save: jest.fn().mockImplementation(async (value) => value),
+      query: jest.fn(),
+    };
+    itemExplorerStateService = {
+      getStateForViewer: jest.fn().mockResolvedValue({
+        activeState: { itemProperties: {} },
+      }),
+    };
+    unitParserService = {
+      getItemRowKeysFromFiles: jest
+        .fn()
+        .mockResolvedValue(new Set(["uuid-1::1", "uuid-2::1"])),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -49,6 +66,11 @@ describe("ViewsService", () => {
           provide: getRepositoryToken(AcpItemPreference),
           useValue: itemPreferenceRepository,
         },
+        {
+          provide: ItemExplorerStateService,
+          useValue: itemExplorerStateService,
+        },
+        { provide: UnitParserService, useValue: unitParserService },
       ],
     }).compile();
 
@@ -211,12 +233,52 @@ describe("ViewsService", () => {
     });
   });
 
-  it("saves preferences scoped by credential username", async () => {
-    itemPreferenceRepository.findOne.mockResolvedValue(null);
+  it("requires a stable identity for personal item preferences", async () => {
+    await expect(
+      service.getItemPreferences("acp-1", null, "item-explorer"),
+    ).rejects.toThrow(UnauthorizedException);
+    await expect(
+      service.patchPersonalItemPreferenceRow(
+        "acp-1",
+        { type: "credential", username: "legacy-reader" },
+        "uuid::1",
+        { note: "not saved" },
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(itemPreferenceRepository.query).not.toHaveBeenCalled();
+  });
 
+  it("does not fall back to an orphaned username for stable credentials", async () => {
+    itemPreferenceRepository.findOne.mockImplementation(async ({ where }) =>
+      where.credentialId
+        ? null
+        : {
+            credentialUsername: "reader-a",
+            preferences: { rowData: { "uuid::1": { note: "old secret" } } },
+          },
+    );
+
+    await expect(
+      service.getItemPreferences(
+        "acp-1",
+        { type: "credential", sub: "credential-new", username: "reader-a" },
+        "item-explorer",
+      ),
+    ).resolves.toEqual({ ui: {}, tags: {}, rowData: {} });
+    expect(itemPreferenceRepository.findOne).toHaveBeenCalledTimes(1);
+    expect(itemPreferenceRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        acpId: "acp-1",
+        viewId: "item-explorer",
+        credentialId: "credential-new",
+      },
+    });
+  });
+
+  it("saves preferences scoped by stable credential id", async () => {
     const saved = await service.saveItemPreferences(
       "acp-1",
-      { type: "credential", username: "reader-a" },
+      { type: "credential", sub: "credential-1", username: "reader-a" },
       {
         ui: {
           filterText: "xyz",
@@ -237,14 +299,21 @@ describe("ViewsService", () => {
       },
       rowData: {},
     });
-    expect(itemPreferenceRepository.save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        acpId: "acp-1",
-        viewId: "item-explorer",
-        userId: null,
-        credentialUsername: "reader-a",
-      }),
+    expect(itemPreferenceRepository.query).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'ON CONFLICT ("acp_id", "view_id", "credential_id")',
+      ),
+      [
+        "acp-1",
+        "item-explorer",
+        null,
+        "credential-1",
+        "reader-a",
+        JSON.stringify(saved),
+      ],
     );
+    expect(itemPreferenceRepository.findOne).not.toHaveBeenCalled();
+    expect(itemPreferenceRepository.save).not.toHaveBeenCalled();
   });
 
   it("returns default public settings when app settings are missing", async () => {
@@ -510,16 +579,8 @@ describe("ViewsService", () => {
     expect(itemPreferenceRepository.save).not.toHaveBeenCalled();
   });
 
-  it("updates existing preference records for authenticated users", async () => {
-    itemPreferenceRepository.findOne.mockResolvedValue({
-      id: "pref-1",
-      acpId: "acp-1",
-      viewId: "item-list",
-      userId: "user-1",
-      preferences: {},
-    });
-
-    await service.saveItemPreferences(
+  it("upserts preference records atomically for authenticated users", async () => {
+    const saved = await service.saveItemPreferences(
       "acp-1",
       { sub: "user-1", type: "oidc" },
       {
@@ -529,28 +590,27 @@ describe("ViewsService", () => {
       "item-list",
     );
 
-    expect(itemPreferenceRepository.create).not.toHaveBeenCalled();
-    expect(itemPreferenceRepository.save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: "pref-1",
-        preferences: {
-          ui: { sortBy: "name" },
-          tags: { itemA: ["A", "B"] },
-          rowData: {},
-        },
-      }),
+    expect(itemPreferenceRepository.query).toHaveBeenCalledWith(
+      expect.stringContaining('ON CONFLICT ("acp_id", "view_id", "user_id")'),
+      ["acp-1", "item-list", "user-1", null, null, JSON.stringify(saved)],
     );
+    expect(itemPreferenceRepository.findOne).not.toHaveBeenCalled();
+    expect(itemPreferenceRepository.create).not.toHaveBeenCalled();
+    expect(itemPreferenceRepository.save).not.toHaveBeenCalled();
   });
 
   it("persists personal working data by stable row key", async () => {
-    itemPreferenceRepository.findOne.mockResolvedValue(null);
-
     const saved = await service.saveItemPreferences(
       "acp-1",
       { sub: "user-1", type: "oidc" },
       {
         rowData: {
-          "uuid-1::1": { category: "A", note: "Notiz" },
+          "uuid-1::1": {
+            category: " A ",
+            tags: ["Prüfen", " Prüfen ", ""],
+            note: "Notiz\r\nzweite Zeile",
+            formatted: "<strong>ignored</strong>",
+          },
           "  ": { category: "ignored" },
         },
       },
@@ -558,7 +618,94 @@ describe("ViewsService", () => {
     );
 
     expect(saved.rowData).toEqual({
-      "uuid-1::1": { category: "A", note: "Notiz" },
+      "uuid-1::1": {
+        category: "A",
+        tags: ["Prüfen"],
+        note: "Notiz\nzweite Zeile",
+      },
     });
+  });
+
+  it("patches one personal row atomically without replacing other rows", async () => {
+    itemPreferenceRepository.query.mockResolvedValue([{ updated: 1 }]);
+
+    const result = await service.patchPersonalItemPreferenceRow(
+      "acp-1",
+      { sub: "user-1", type: "oidc" },
+      "uuid-2::1",
+      { category: " II ", formatted: "ignored" },
+    );
+
+    expect(result.rowData).toEqual({
+      "uuid-2::1": { category: "II" },
+    });
+    expect(itemExplorerStateService.getStateForViewer).toHaveBeenCalledWith(
+      "acp-1",
+      false,
+    );
+    expect(unitParserService.getItemRowKeysFromFiles).toHaveBeenCalledWith(
+      "acp-1",
+      { itemPropertiesOverride: {} },
+    );
+    expect(itemPreferenceRepository.query).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /jsonb_build_object\(\$8, \$7::jsonb\)[\s\S]*RETURNING 1 AS "updated"/,
+      ),
+      expect.arrayContaining([
+        "acp-1",
+        "item-explorer",
+        "user-1",
+        null,
+        null,
+        expect.any(String),
+        JSON.stringify({ category: "II" }),
+        "uuid-2::1",
+        10_000,
+      ]),
+    );
+  });
+
+  it("rejects personal data for a row that does not exist in the ACP", async () => {
+    unitParserService.getItemRowKeysFromFiles.mockResolvedValue(
+      new Set(["uuid-1::1"]),
+    );
+
+    await expect(
+      service.patchPersonalItemPreferenceRow(
+        "acp-1",
+        { sub: "user-1", type: "oidc" },
+        "invented-row",
+        { note: "unbounded" },
+      ),
+    ).rejects.toThrow(BadRequestException);
+    expect(itemPreferenceRepository.query).not.toHaveBeenCalled();
+  });
+
+  it("allows deleting a stale row without resolving the current item list", async () => {
+    itemPreferenceRepository.query.mockResolvedValue([{ updated: 1 }]);
+
+    await expect(
+      service.patchPersonalItemPreferenceRow(
+        "acp-1",
+        { sub: "user-1", type: "oidc" },
+        "removed-row",
+        null,
+      ),
+    ).resolves.toEqual({ rowData: {} });
+    expect(itemExplorerStateService.getStateForViewer).not.toHaveBeenCalled();
+    expect(unitParserService.getItemRowKeysFromFiles).not.toHaveBeenCalled();
+  });
+
+  it("rejects adding a new row after the personal row limit is reached", async () => {
+    itemPreferenceRepository.query.mockResolvedValue([]);
+
+    await expect(
+      service.patchPersonalItemPreferenceRow(
+        "acp-1",
+        { sub: "user-1", type: "oidc" },
+        "uuid-1::1",
+        { note: "one too many" },
+      ),
+    ).rejects.toThrow("Personal item data is limited to 10000 rows");
   });
 });

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -1,4 +1,8 @@
-import { Injectable } from "@nestjs/common";
+import {
+  BadRequestException,
+  Injectable,
+  UnauthorizedException,
+} from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import {
@@ -16,6 +20,10 @@ import {
   toRuntimeAcpIndex,
 } from "../acp/acp-index.utils";
 import { normalizeFeatureConfig } from "../acp/feature-config.utils";
+import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
+import { UnitParserService } from "../files/unit-parser.service";
+
+const MAX_PERSONAL_ITEM_ROWS = 10_000;
 
 export interface ItemPreferencesPayload {
   [key: string]: unknown;
@@ -26,6 +34,7 @@ export interface ItemPreferencesPayload {
 
 interface PreferenceIdentity {
   userId?: string;
+  credentialId?: string;
   credentialUsername?: string;
 }
 
@@ -42,6 +51,8 @@ export class ViewsService {
     private readonly settingsRepository: Repository<AppSettings>,
     @InjectRepository(AcpItemPreference)
     private readonly itemPreferenceRepository: Repository<AcpItemPreference>,
+    private readonly itemExplorerStateService: ItemExplorerStateService,
+    private readonly unitParserService: UnitParserService,
   ) {}
 
   /**
@@ -340,12 +351,26 @@ export class ViewsService {
     user: any,
     viewId?: string,
   ): Promise<ItemPreferencesPayload> {
+    const normalizedViewId = this.normalizeViewId(viewId);
     const identity = this.resolvePreferenceIdentity(user);
     if (!identity) {
+      if (normalizedViewId === "item-explorer") {
+        throw new UnauthorizedException(
+          "Authentication is required for personal item data",
+        );
+      }
       return { ui: {}, tags: {}, rowData: {} };
     }
+    if (
+      normalizedViewId === "item-explorer" &&
+      !identity.userId &&
+      !identity.credentialId
+    ) {
+      throw new UnauthorizedException(
+        "A stable identity is required for personal item data",
+      );
+    }
 
-    const normalizedViewId = this.normalizeViewId(viewId);
     const record = await this.findPreferenceRecord(
       acpId,
       normalizedViewId,
@@ -367,6 +392,16 @@ export class ViewsService {
     }
 
     const normalizedViewId = this.normalizeViewId(viewId);
+    if (identity.userId || identity.credentialId) {
+      await this.upsertItemPreferences(
+        acpId,
+        normalizedViewId,
+        identity,
+        normalized,
+      );
+      return normalized;
+    }
+
     let record = await this.findPreferenceRecord(
       acpId,
       normalizedViewId,
@@ -378,6 +413,7 @@ export class ViewsService {
         acpId,
         viewId: normalizedViewId,
         userId: identity.userId || null,
+        credentialId: identity.credentialId || null,
         credentialUsername: identity.credentialUsername || null,
       });
     }
@@ -385,6 +421,194 @@ export class ViewsService {
     record.preferences = normalized;
     await this.itemPreferenceRepository.save(record);
     return normalized;
+  }
+
+  async patchPersonalItemPreferenceRow(
+    acpId: string,
+    user: any,
+    rawRowKey: string,
+    rawRowData: Record<string, unknown> | null,
+    viewId = "item-explorer",
+    canEditExplorerState = false,
+  ): Promise<Pick<ItemPreferencesPayload, "rowData">> {
+    const rowKey = String(rawRowKey || "").trim();
+    if (!rowKey || rowKey.length > 500) {
+      throw new BadRequestException("A valid item row key is required");
+    }
+
+    const normalizedRow = rawRowData
+      ? this.normalizeRowData({ [rowKey]: rawRowData })[rowKey] || null
+      : null;
+    const identity = this.resolvePreferenceIdentity(user);
+    if (!identity || (!identity.userId && !identity.credentialId)) {
+      throw new UnauthorizedException(
+        "A stable identity is required for personal item data",
+      );
+    }
+
+    if (normalizedRow) {
+      await this.assertKnownPersonalItemRow(
+        acpId,
+        rowKey,
+        canEditExplorerState,
+      );
+    }
+
+    const normalizedViewId = this.normalizeViewId(viewId);
+    const identityColumn = identity.userId ? "user_id" : "credential_id";
+    const identityPredicate = identity.userId
+      ? '"user_id" IS NOT NULL'
+      : '"credential_id" IS NOT NULL';
+    const initialPreferences: ItemPreferencesPayload = {
+      ui: {},
+      tags: {},
+      rowData: normalizedRow ? { [rowKey]: normalizedRow } : {},
+    };
+    const rowDataJson = normalizedRow ? JSON.stringify(normalizedRow) : null;
+
+    const rows = await this.itemPreferenceRepository.query(
+      `
+        INSERT INTO "acp_item_preferences" (
+          "id", "acp_id", "view_id", "user_id", "credential_id",
+          "credential_username", "preferences", "created_at", "updated_at"
+        )
+        VALUES (
+          uuid_generate_v4(), $1, $2, $3, $4, $5, $6::jsonb, now(), now()
+        )
+        ON CONFLICT ("acp_id", "view_id", "${identityColumn}")
+          WHERE ${identityPredicate}
+        DO UPDATE SET
+          "preferences" = jsonb_set(
+            COALESCE("acp_item_preferences"."preferences", '{}'::jsonb),
+            '{rowData}',
+            CASE
+              WHEN $7::jsonb IS NULL THEN
+                CASE
+                  WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
+                    THEN "acp_item_preferences"."preferences"->'rowData' - $8
+                  ELSE '{}'::jsonb
+                END
+              ELSE
+                CASE
+                  WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
+                    THEN "acp_item_preferences"."preferences"->'rowData'
+                  ELSE '{}'::jsonb
+                END || jsonb_build_object($8, $7::jsonb)
+            END,
+            true
+          ),
+          "credential_username" = CASE
+            WHEN EXCLUDED."credential_id" IS NOT NULL
+              THEN EXCLUDED."credential_username"
+            ELSE "acp_item_preferences"."credential_username"
+          END,
+          "updated_at" = now()
+        WHERE $7::jsonb IS NULL
+          OR (
+            CASE
+              WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
+                THEN "acp_item_preferences"."preferences"->'rowData'
+              ELSE '{}'::jsonb
+            END
+          ) ? $8
+          OR (
+            SELECT count(*)
+            FROM jsonb_object_keys(
+              CASE
+                WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
+                  THEN "acp_item_preferences"."preferences"->'rowData'
+                ELSE '{}'::jsonb
+              END
+            )
+          ) < $9
+        RETURNING 1 AS "updated"
+      `,
+      [
+        acpId,
+        normalizedViewId,
+        identity.userId || null,
+        identity.credentialId || null,
+        identity.credentialUsername || null,
+        JSON.stringify(initialPreferences),
+        rowDataJson,
+        rowKey,
+        MAX_PERSONAL_ITEM_ROWS,
+      ],
+    );
+
+    if (!rows[0]) {
+      throw new BadRequestException(
+        `Personal item data is limited to ${MAX_PERSONAL_ITEM_ROWS} rows`,
+      );
+    }
+
+    return {
+      rowData: normalizedRow ? { [rowKey]: normalizedRow } : {},
+    };
+  }
+
+  private async upsertItemPreferences(
+    acpId: string,
+    viewId: string,
+    identity: PreferenceIdentity,
+    preferences: ItemPreferencesPayload,
+  ): Promise<void> {
+    const identityColumn = identity.userId ? "user_id" : "credential_id";
+    const identityPredicate = identity.userId
+      ? '"user_id" IS NOT NULL'
+      : '"credential_id" IS NOT NULL';
+
+    await this.itemPreferenceRepository.query(
+      `
+        INSERT INTO "acp_item_preferences" (
+          "id", "acp_id", "view_id", "user_id", "credential_id",
+          "credential_username", "preferences", "created_at", "updated_at"
+        )
+        VALUES (
+          uuid_generate_v4(), $1, $2, $3, $4, $5, $6::jsonb, now(), now()
+        )
+        ON CONFLICT ("acp_id", "view_id", "${identityColumn}")
+          WHERE ${identityPredicate}
+        DO UPDATE SET
+          "preferences" = EXCLUDED."preferences",
+          "credential_username" = CASE
+            WHEN EXCLUDED."credential_id" IS NOT NULL
+              THEN EXCLUDED."credential_username"
+            ELSE "acp_item_preferences"."credential_username"
+          END,
+          "updated_at" = now()
+      `,
+      [
+        acpId,
+        viewId,
+        identity.userId || null,
+        identity.credentialId || null,
+        identity.credentialUsername || null,
+        JSON.stringify(preferences),
+      ],
+    );
+  }
+
+  private async assertKnownPersonalItemRow(
+    acpId: string,
+    rowKey: string,
+    canEditExplorerState: boolean,
+  ): Promise<void> {
+    const explorerState = await this.itemExplorerStateService.getStateForViewer(
+      acpId,
+      canEditExplorerState,
+    );
+    const validRowKeys = await this.unitParserService.getItemRowKeysFromFiles(
+      acpId,
+      {
+        itemPropertiesOverride: explorerState.activeState.itemProperties,
+      },
+    );
+    if (!validRowKeys.has(rowKey)) {
+      throw new BadRequestException(
+        "Personal item data can only be saved for an existing item row",
+      );
+    }
   }
 
   private getModuleReferenceId(moduleRef: unknown): string | null {
@@ -415,6 +639,10 @@ export class ViewsService {
 
     if (user.type === "credential" && typeof user.username === "string") {
       const credentialUsername = user.username.trim();
+      const credentialId = typeof user.sub === "string" ? user.sub.trim() : "";
+      if (credentialId.length > 0) {
+        return { credentialId, credentialUsername };
+      }
       if (credentialUsername.length > 0) {
         return { credentialUsername };
       }
@@ -438,6 +666,16 @@ export class ViewsService {
           acpId,
           viewId,
           userId: identity.userId,
+        },
+      });
+    }
+
+    if (identity.credentialId) {
+      return this.itemPreferenceRepository.findOne({
+        where: {
+          acpId,
+          viewId,
+          credentialId: identity.credentialId,
         },
       });
     }
@@ -475,11 +713,40 @@ export class ViewsService {
     const normalized: Record<string, Record<string, unknown>> = {};
     for (const [rawRowKey, value] of Object.entries(rawRowData)) {
       const rowKey = rawRowKey.trim();
-      if (rowKey && this.isRecord(value)) {
-        normalized[rowKey] = { ...value };
-      }
+      if (!rowKey || !this.isRecord(value)) continue;
+
+      const category = this.normalizePlainText(value.category, 200);
+      const note = this.normalizePlainText(value.note, 10_000, true);
+      const tags = Array.isArray(value.tags)
+        ? Array.from(
+            new Set(
+              value.tags
+                .map((tag) => this.normalizePlainText(tag, 100))
+                .filter((tag): tag is string => Boolean(tag)),
+            ),
+          ).slice(0, 50)
+        : [];
+
+      const row: Record<string, unknown> = {};
+      if (category) row.category = category;
+      if (tags.length) row.tags = tags;
+      if (note) row.note = note;
+      if (Object.keys(row).length) normalized[rowKey] = row;
     }
     return normalized;
+  }
+
+  private normalizePlainText(
+    value: unknown,
+    maxLength: number,
+    multiline = false,
+  ): string | null {
+    if (typeof value !== "string") return null;
+    const normalized = value
+      .replace(/\r\n?/g, "\n")
+      .replace(multiline ? /[\t\f\v]+/g : /\s+/g, " ")
+      .trim();
+    return normalized ? normalized.slice(0, maxLength) : null;
   }
 
   private normalizeTags(rawTags: unknown): Record<string, string[]> {

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -22,6 +22,10 @@ import {
 import { normalizeFeatureConfig } from "../acp/feature-config.utils";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
 import { UnitParserService } from "../files/unit-parser.service";
+import {
+  buildPatchPersonalItemPreferenceRowQuery,
+  PreferenceIdentityColumn,
+} from "./personal-item-preferences.query";
 
 const MAX_PERSONAL_ITEM_ROWS = 10_000;
 
@@ -455,10 +459,9 @@ export class ViewsService {
     }
 
     const normalizedViewId = this.normalizeViewId(viewId);
-    const identityColumn = identity.userId ? "user_id" : "credential_id";
-    const identityPredicate = identity.userId
-      ? '"user_id" IS NOT NULL'
-      : '"credential_id" IS NOT NULL';
+    const identityColumn: PreferenceIdentityColumn = identity.userId
+      ? "user_id"
+      : "credential_id";
     const initialPreferences: ItemPreferencesPayload = {
       ui: {},
       tags: {},
@@ -467,62 +470,7 @@ export class ViewsService {
     const rowDataJson = normalizedRow ? JSON.stringify(normalizedRow) : null;
 
     const rows = await this.itemPreferenceRepository.query(
-      `
-        INSERT INTO "acp_item_preferences" (
-          "id", "acp_id", "view_id", "user_id", "credential_id",
-          "credential_username", "preferences", "created_at", "updated_at"
-        )
-        VALUES (
-          uuid_generate_v4(), $1, $2, $3, $4, $5, $6::jsonb, now(), now()
-        )
-        ON CONFLICT ("acp_id", "view_id", "${identityColumn}")
-          WHERE ${identityPredicate}
-        DO UPDATE SET
-          "preferences" = jsonb_set(
-            COALESCE("acp_item_preferences"."preferences", '{}'::jsonb),
-            '{rowData}',
-            CASE
-              WHEN $7::jsonb IS NULL THEN
-                CASE
-                  WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
-                    THEN "acp_item_preferences"."preferences"->'rowData' - $8
-                  ELSE '{}'::jsonb
-                END
-              ELSE
-                CASE
-                  WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
-                    THEN "acp_item_preferences"."preferences"->'rowData'
-                  ELSE '{}'::jsonb
-                END || jsonb_build_object($8, $7::jsonb)
-            END,
-            true
-          ),
-          "credential_username" = CASE
-            WHEN EXCLUDED."credential_id" IS NOT NULL
-              THEN EXCLUDED."credential_username"
-            ELSE "acp_item_preferences"."credential_username"
-          END,
-          "updated_at" = now()
-        WHERE $7::jsonb IS NULL
-          OR (
-            CASE
-              WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
-                THEN "acp_item_preferences"."preferences"->'rowData'
-              ELSE '{}'::jsonb
-            END
-          ) ? $8
-          OR (
-            SELECT count(*)
-            FROM jsonb_object_keys(
-              CASE
-                WHEN jsonb_typeof("acp_item_preferences"."preferences"->'rowData') = 'object'
-                  THEN "acp_item_preferences"."preferences"->'rowData'
-                ELSE '{}'::jsonb
-              END
-            )
-          ) < $9
-        RETURNING 1 AS "updated"
-      `,
+      buildPatchPersonalItemPreferenceRowQuery(identityColumn),
       [
         acpId,
         normalizedViewId,

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -5,7 +5,8 @@ import { getRepositoryToken } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import * as bcrypt from "bcryptjs";
 import * as request from "supertest";
-import { User } from "../src/database/entities";
+import { AcpItemPreference, User } from "../src/database/entities";
+import { buildPatchPersonalItemPreferenceRowQuery } from "../src/views/personal-item-preferences.query";
 
 if (!process.env.DB_HOST) process.env.DB_HOST = "localhost";
 if (!process.env.DB_PORT) process.env.DB_PORT = "5433";
@@ -29,6 +30,8 @@ describe("ContentPool API (e2e)", () => {
   let server: any;
   let authToken: string;
   let credentialToken: string;
+  let credentialId: string;
+  let itemPreferenceRepository: Repository<AcpItemPreference>;
 
   let acpId: string;
   let snapshotId: string;
@@ -112,6 +115,9 @@ describe("ContentPool API (e2e)", () => {
     // Create an app-admin test user directly, then issue a valid JWT for stable e2e auth.
     const userRepo = moduleFixture.get<Repository<User>>(
       getRepositoryToken(User),
+    );
+    itemPreferenceRepository = moduleFixture.get<Repository<AcpItemPreference>>(
+      getRepositoryToken(AcpItemPreference),
     );
     const jwtService = moduleFixture.get<JwtService>(JwtService);
 
@@ -230,7 +236,7 @@ describe("ContentPool API (e2e)", () => {
       })
       .expect(200);
 
-    await request(server)
+    const credentialRes = await request(server)
       .post(`/api/acp/${acpId}/access/credentials/single`)
       .set("Authorization", `Bearer ${authToken}`)
       .send({
@@ -238,6 +244,7 @@ describe("ContentPool API (e2e)", () => {
         password: credentialPassword,
       })
       .expect(201);
+    credentialId = credentialRes.body.id;
 
     const loginRes = await request(server)
       .post("/api/auth/credential-login")
@@ -260,6 +267,64 @@ describe("ContentPool API (e2e)", () => {
       .get(`/api/view/acp/${acpId}/items`)
       .set("Authorization", `Bearer ${credentialToken}`)
       .expect(200);
+  });
+
+  it("executes personal row insert, conflict update, and delete in PostgreSQL", async () => {
+    const rowKey = "e2e-row-1";
+    const query = buildPatchPersonalItemPreferenceRowQuery("credential_id");
+    const executePatch = async (rowData: Record<string, unknown> | null) =>
+      itemPreferenceRepository.query(query, [
+        acpId,
+        "item-explorer",
+        null,
+        credentialId,
+        credentialUsername,
+        JSON.stringify({
+          ui: {},
+          tags: {},
+          rowData: rowData ? { [rowKey]: rowData } : {},
+        }),
+        rowData ? JSON.stringify(rowData) : null,
+        rowKey,
+        10_000,
+      ]);
+
+    const insertedRow = { category: "Offen", note: "erste Fassung" };
+    await executePatch(insertedRow);
+
+    let record = await itemPreferenceRepository.findOneByOrFail({
+      acpId,
+      viewId: "item-explorer",
+      credentialId,
+    });
+    expect(record.preferences).toEqual({
+      ui: {},
+      tags: {},
+      rowData: { [rowKey]: insertedRow },
+    });
+
+    const updatedRow = { category: "Erledigt", note: "zweite Fassung" };
+    await executePatch(updatedRow);
+
+    record = await itemPreferenceRepository.findOneByOrFail({
+      acpId,
+      viewId: "item-explorer",
+      credentialId,
+    });
+    expect(record.preferences).toEqual({
+      ui: {},
+      tags: {},
+      rowData: { [rowKey]: updatedRow },
+    });
+
+    await executePatch(null);
+
+    record = await itemPreferenceRepository.findOneByOrFail({
+      acpId,
+      viewId: "item-explorer",
+      credentialId,
+    });
+    expect(record.preferences).toEqual({ ui: {}, tags: {}, rowData: {} });
   });
 
   it("covers comment export", async () => {

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -81,6 +81,9 @@ Key fields:
 - `passwordHash`
 
 These credentials are not normal application users and are not stored in the `users` table.
+The pair of `accessConfigId` and `username` is unique. Legacy duplicate rows are reconciled before
+the constraint is created, retaining one stable credential ID and the newest personal preference
+per view.
 
 ### `AcpFile`
 
@@ -143,9 +146,15 @@ need to persist answer-like data while browsing.
 This table stores persisted viewer preferences for item-oriented pages. It supports both:
 
 - authenticated user IDs,
-- credential-based usernames.
+- stable credential IDs (with the username retained for legacy compatibility and diagnostics).
 
-The payload is JSONB and can hold UI state and item tags per view.
+The payload is JSONB and can hold UI state, item tags, and personal row data per view. Personal row
+data is restricted to a category, a string-array of tags, and a plain-text note. Partial-credit item
+rows use their full stable row key, including the Sub-ID component.
+
+Personal rows are updated atomically inside the JSONB document. Credential-list replacement keeps
+the IDs of credentials whose usernames remain present, preserving their personal preferences while
+still deleting preferences for credentials that are actually removed.
 
 ### `AcpItemExplorerState`
 

--- a/docs/features/item-explorer.md
+++ b/docs/features/item-explorer.md
@@ -160,6 +160,41 @@ The explorer normalizes tags and exposes them in the UI so managers can:
 
 Read-only tag availability still depends on feature flags.
 
+## Personal Working Data
+
+When `enablePersonalItemData` is enabled, every authenticated user and every credential login can
+maintain three private fields for each Explorer row:
+
+- one category (commonly a competence level),
+- zero or more configured colored markers,
+- one plain-text note.
+
+ACP managers configure the category label and allowed values as well as marker labels and colors in
+the access configuration. Notes use a plain textarea and are never interpreted as Markdown or HTML.
+Clearing a field removes it from the stored row data.
+
+Personal working data is stored separately from the shared draft/published Explorer state in
+`acp_item_preferences`, under the `item-explorer` view. Normal users are scoped by user ID and
+credential logins by their stable credential ID. Consequently, publishing, discarding, or previewing
+the shared Explorer draft never exposes or modifies another person's working data. The personal
+controls remain usable from both manager and read-only perspectives.
+
+Personal column filters are local to the current browser view and are excluded from the shared
+Explorer UI state. Row edits use an atomic row-level endpoint, so saves from different browser tabs
+cannot replace unrelated rows. The Explorer keeps failed edits pending, exposes the save error, and
+blocks navigation until the pending personal changes have been saved successfully. If the session
+expires during a save, pending rows are suspended in session storage with an application-session
+memory fallback and hidden. They are merged back after the same stable identity signs in again, but
+discarded when a different identity signs in.
+
+The backend accepts non-empty personal data only for row keys that exist in the active Explorer
+item list. Managers are validated against the draft and read-only or credential viewers against the
+published state. Stale rows can still be deleted after their source item disappears. Each personal
+preference record is additionally limited to 10,000 rows.
+
+The map is keyed by the stable row key, so partial-credit rows of the same item keep independent
+categories, markers, and notes.
+
 ## Empirical Difficulty Import
 
 Managers can upload empirical difficulty CSV data through item endpoints.

--- a/frontend/src/app/acp-manager/access-config/access-config.component.spec.ts
+++ b/frontend/src/app/acp-manager/access-config/access-config.component.spec.ts
@@ -281,4 +281,55 @@ describe('AccessConfigComponent', () => {
       }),
     );
   });
+
+  it('persists personal item categories and colored tags', () => {
+    const component = new AccessConfigComponent(route as any, api as any);
+    component.acpId = 'acp-1';
+    component.featureConfig = {
+      enablePersonalItemData: true,
+      personalItemCategoryLabel: 'Kompetenzstufe',
+      personalItemTagLabel: 'Sichtung',
+    };
+    component.personalItemCategoryValues = [' I ', 'II', 'I'];
+    component.personalItemTags = [
+      { label: ' Prüfen ', color: '#ff0000' },
+      { label: '', color: '#000000' },
+    ];
+
+    component.saveFeatures();
+
+    expect(api.updateAccessConfig).toHaveBeenCalledWith(
+      'acp-1',
+      expect.objectContaining({
+        featureConfig: expect.objectContaining({
+          enablePersonalItemData: true,
+          personalItemCategoryLabel: 'Kompetenzstufe',
+          personalItemCategoryValues: ['I', 'II'],
+          personalItemTagLabel: 'Sichtung',
+          personalItemTags: [{ label: 'Prüfen', color: '#ff0000' }],
+        }),
+      }),
+    );
+  });
+
+  it('includes the existing validity window when saving credential features', () => {
+    const component = new AccessConfigComponent(route as any, api as any);
+    component.acpId = 'acp-1';
+    component.accessModel = 'CREDENTIALS_LIST';
+    component.validFrom = '2026-07-13T10:00';
+    component.validUntil = '2026-08-13T10:00';
+    component.featureConfig = { enablePersonalItemData: true };
+
+    component.saveFeatures();
+
+    expect(api.updateAccessConfig).toHaveBeenCalledWith(
+      'acp-1',
+      expect.objectContaining({
+        accessModel: 'CREDENTIALS_LIST',
+        validFrom: new Date(2026, 6, 13, 10, 0).toISOString(),
+        validUntil: new Date(2026, 7, 13, 10, 0).toISOString(),
+        featureConfig: expect.objectContaining({ enablePersonalItemData: true }),
+      }),
+    );
+  });
 });

--- a/frontend/src/app/acp-manager/access-config/access-config.component.ts
+++ b/frontend/src/app/acp-manager/access-config/access-config.component.ts
@@ -495,6 +495,94 @@ import { AcpManagerContextComponent } from '../shared/acp-manager-context.compon
         }
 
         <label class="feature-toggle">
+          <input type="checkbox" [(ngModel)]="featureConfig[enablePersonalItemDataKey]" />
+          <span>Persönliche Arbeitsdaten im Item-Explorer aktivieren</span>
+        </label>
+        @if (featureConfig[enablePersonalItemDataKey]) {
+          <div class="indent-section personal-data-config">
+            <label class="help-text" for="personal-item-category-label">
+              Bezeichnung der Kategorie
+            </label>
+            <input
+              id="personal-item-category-label"
+              class="tag-input"
+              type="text"
+              [(ngModel)]="featureConfig[personalItemCategoryLabelKey]"
+              placeholder="Kompetenzstufe"
+            />
+
+            <label class="help-text" style="margin-top: 10px;">Mögliche Kategorien</label>
+            <div class="tags-editor">
+              @for (value of personalItemCategoryValues; track $index) {
+                <div class="tag-add">
+                  <input
+                    class="tag-input"
+                    type="text"
+                    [(ngModel)]="personalItemCategoryValues[$index]"
+                    placeholder="z. B. Stufe I"
+                  />
+                  <button
+                    class="tag-remove"
+                    type="button"
+                    (click)="removePersonalItemCategoryValue($index)"
+                  >
+                    ✕
+                  </button>
+                </div>
+              }
+              <button
+                class="btn btn-outline btn-sm"
+                type="button"
+                (click)="addPersonalItemCategoryValue()"
+              >
+                + Kategorie
+              </button>
+            </div>
+
+            <label class="help-text" for="personal-item-tag-label" style="margin-top: 10px;">
+              Bezeichnung der Markierungen
+            </label>
+            <input
+              id="personal-item-tag-label"
+              class="tag-input"
+              type="text"
+              [(ngModel)]="featureConfig[personalItemTagLabelKey]"
+              placeholder="Markierungen"
+            />
+
+            <label class="help-text" style="margin-top: 10px;">Markierungen und Farben</label>
+            <div class="tags-editor">
+              @for (tag of personalItemTags; track $index) {
+                <div class="tag-add personal-tag-config-row">
+                  <input
+                    class="tag-color-input"
+                    type="color"
+                    [(ngModel)]="tag.color"
+                    [attr.aria-label]="'Farbe für ' + (tag.label || 'Markierung')"
+                  />
+                  <input
+                    class="tag-input"
+                    type="text"
+                    [(ngModel)]="tag.label"
+                    placeholder="z. B. Rückfrage"
+                  />
+                  <button class="tag-remove" type="button" (click)="removePersonalItemTag($index)">
+                    ✕
+                  </button>
+                </div>
+              }
+              <button class="btn btn-outline btn-sm" type="button" (click)="addPersonalItemTag()">
+                + Markierung
+              </button>
+            </div>
+            <span class="help-text">
+              Kategorien, Markierungen und Notizen sind immer persönlich und werden nicht im
+              ACP-Entwurf veröffentlicht.
+            </span>
+          </div>
+        }
+
+        <label class="feature-toggle">
           <input type="checkbox" [(ngModel)]="featureConfig['persistUserPreferences']" />
           <span>Nutzer-Einstellungen speichern (nur bei Anmeldung)</span>
         </label>
@@ -651,6 +739,26 @@ import { AcpManagerContextComponent } from '../shared/acp-manager-context.compon
         align-items: center;
         margin: 8px 0;
       }
+      .personal-data-config {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      .personal-data-config > .tag-input,
+      .personal-data-config > .tags-editor {
+        width: 100%;
+      }
+      .personal-tag-config-row {
+        align-items: center;
+      }
+      .tag-color-input {
+        width: 42px;
+        height: 32px;
+        padding: 2px;
+        border: 1px solid var(--color-border);
+        border-radius: 4px;
+        background: var(--color-surface);
+      }
       .tag-item {
         display: flex;
         align-items: center;
@@ -741,6 +849,11 @@ export class AccessConfigComponent implements OnInit {
   readonly showItemExplorerPlayerTargetInfoKey = 'showItemExplorerPlayerTargetInfo';
   readonly itemSubIdLabelKey = 'itemSubIdLabel';
   readonly itemSubIdLabelsKey = 'itemSubIdLabels';
+  readonly enablePersonalItemDataKey = 'enablePersonalItemData';
+  readonly personalItemCategoryLabelKey = 'personalItemCategoryLabel';
+  readonly personalItemCategoryValuesKey = 'personalItemCategoryValues';
+  readonly personalItemTagLabelKey = 'personalItemTagLabel';
+  readonly personalItemTagsKey = 'personalItemTags';
 
   acpId = '';
   accessModel: AccessModel = 'PRIVATE';
@@ -755,6 +868,8 @@ export class AccessConfigComponent implements OnInit {
   availableTags: string[] = [];
   newTag = '';
   itemSubIdLabelEntries: Array<{ value: string; label: string }> = [];
+  personalItemCategoryValues: string[] = [];
+  personalItemTags: Array<{ label: string; color: string }> = [];
   accessSaved = false;
   featuresSaved = false;
   credentials: Credential[] = [];
@@ -880,6 +995,19 @@ export class AccessConfigComponent implements OnInit {
         this.itemSubIdLabelEntries = Object.entries(
           (this.featureConfig[this.itemSubIdLabelsKey] as Record<string, string>) || {},
         ).map(([value, label]) => ({ value, label }));
+        this.personalItemCategoryValues = Array.isArray(
+          this.featureConfig[this.personalItemCategoryValuesKey],
+        )
+          ? [...this.featureConfig[this.personalItemCategoryValuesKey]]
+          : [];
+        this.personalItemTags = Array.isArray(this.featureConfig[this.personalItemTagsKey])
+          ? this.featureConfig[this.personalItemTagsKey].map((tag: any) => ({
+              label: String(tag?.label || ''),
+              color: /^#[0-9a-f]{6}$/i.test(String(tag?.color || ''))
+                ? String(tag.color)
+                : '#3498db',
+            }))
+          : [];
       },
     });
   }
@@ -965,25 +1093,44 @@ export class AccessConfigComponent implements OnInit {
         .filter((entry) => entry.value && entry.label)
         .map((entry) => [entry.value, entry.label]),
     );
+    this.featureConfig[this.personalItemCategoryValuesKey] = Array.from(
+      new Set(this.personalItemCategoryValues.map((value) => value.trim()).filter(Boolean)),
+    );
+    this.featureConfig[this.personalItemTagsKey] = this.personalItemTags
+      .map((tag) => ({ label: tag.label.trim(), color: tag.color }))
+      .filter((tag) => tag.label);
     this.featureConfig['commentTargets'] = this.commentTargets;
     this.featureConfig['availableTags'] = this.availableTags;
-    this.api
-      .updateAccessConfig(this.acpId, {
-        accessModel: this.accessModel,
-        allowRegistered: this.allowRegistered,
-        featureConfig: this.featureConfig,
-      })
-      .subscribe({
-        next: () => {
-          this.featuresSaved = true;
-          setTimeout(() => (this.featuresSaved = false), 3000);
-        },
-      });
+    const data: any = {
+      accessModel: this.accessModel,
+      allowRegistered: this.allowRegistered,
+      featureConfig: this.featureConfig,
+    };
+    if (this.accessModel === 'CREDENTIALS_LIST' && this.validFrom && this.validUntil) {
+      data.validFrom = this.dateTimeLocalToIso(this.validFrom);
+      data.validUntil = this.dateTimeLocalToIso(this.validUntil);
+    }
+    this.api.updateAccessConfig(this.acpId, data).subscribe({
+      next: () => {
+        this.featuresSaved = true;
+        setTimeout(() => (this.featuresSaved = false), 3000);
+      },
+    });
   }
 
   private applyFeatureConfigDefaults() {
     const itemSubIdLabel = String(this.featureConfig[this.itemSubIdLabelKey] || '').trim();
     this.featureConfig[this.itemSubIdLabelKey] = itemSubIdLabel || 'Sub-ID';
+    this.featureConfig[this.enablePersonalItemDataKey] =
+      this.featureConfig[this.enablePersonalItemDataKey] === true;
+    const personalCategoryLabel = String(
+      this.featureConfig[this.personalItemCategoryLabelKey] || '',
+    ).trim();
+    this.featureConfig[this.personalItemCategoryLabelKey] =
+      personalCategoryLabel || 'Kompetenzstufe';
+    const personalTagLabel = String(this.featureConfig[this.personalItemTagLabelKey] || '').trim();
+    this.featureConfig[this.personalItemTagLabelKey] = personalTagLabel || 'Markierungen';
+
     const showAudioVideoCodingVariables = this.featureConfig[this.showAudioVideoCodingVariablesKey];
     this.featureConfig[this.showAudioVideoCodingVariablesKey] =
       showAudioVideoCodingVariables !== false;
@@ -1004,6 +1151,22 @@ export class AccessConfigComponent implements OnInit {
     } else {
       this.commentTargets.push(target);
     }
+  }
+
+  addPersonalItemCategoryValue() {
+    this.personalItemCategoryValues.push('');
+  }
+
+  removePersonalItemCategoryValue(index: number) {
+    this.personalItemCategoryValues.splice(index, 1);
+  }
+
+  addPersonalItemTag() {
+    this.personalItemTags.push({ label: '', color: '#3498db' });
+  }
+
+  removePersonalItemTag(index: number) {
+    this.personalItemTags.splice(index, 1);
   }
 
   addTag() {

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AppComponent } from './app';
+
+describe('AppComponent', () => {
+  it('logs out only after guarded navigation succeeds', async () => {
+    const calls: string[] = [];
+    const auth = {
+      logout: vi.fn(() => calls.push('logout')),
+    };
+    const router = {
+      navigate: vi.fn(async () => {
+        calls.push('navigate');
+        return true;
+      }),
+    };
+    const component = new AppComponent(auth as any, router as any, {} as any);
+
+    await component.logout();
+
+    expect(calls).toEqual(['navigate', 'logout']);
+  });
+
+  it('keeps the session when guarded navigation is cancelled', async () => {
+    const auth = { logout: vi.fn() };
+    const router = { navigate: vi.fn().mockResolvedValue(false) };
+    const component = new AppComponent(auth as any, router as any, {} as any);
+
+    await component.logout();
+
+    expect(auth.logout).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -184,9 +184,11 @@ export class AppComponent implements OnInit, OnDestroy {
     document.removeEventListener('visibilitychange', this.visibilityChangeListener);
   }
 
-  logout() {
-    this.auth.logout();
-    this.router.navigate(['/login']);
+  async logout() {
+    const navigated = await this.router.navigate(['/login']);
+    if (navigated) {
+      this.auth.logout();
+    }
   }
 
   changePassword() {

--- a/frontend/src/app/core/models/api.models.ts
+++ b/frontend/src/app/core/models/api.models.ts
@@ -377,6 +377,11 @@ export interface FeatureConfig {
   showItemExplorerPlayerTargetInfo?: boolean;
   itemSubIdLabel?: string;
   itemSubIdLabels?: Record<string, string>;
+  enablePersonalItemData?: boolean;
+  personalItemCategoryLabel?: string;
+  personalItemCategoryValues?: string[];
+  personalItemTagLabel?: string;
+  personalItemTags?: Array<{ label: string; color: string }>;
   availableTags?: string[];
   persistUserPreferences?: boolean;
 }

--- a/frontend/src/app/core/services/api.service.spec.ts
+++ b/frontend/src/app/core/services/api.service.spec.ts
@@ -891,6 +891,22 @@ describe('ApiService', () => {
       });
     });
 
+    it('should patch one personal item preference row', () => {
+      const rowData = { category: 'II', note: 'Persönlich' };
+      httpClientMock.patch.mockReturnValue(of({ rowData: { 'uuid::1': rowData } }));
+
+      service
+        .patchViewItemPreferenceRow('acp1', 'uuid::1', rowData, 'read-only')
+        .subscribe((result) => {
+          expect(result.rowData).toEqual({ 'uuid::1': rowData });
+        });
+
+      expect(httpClientMock.patch).toHaveBeenCalledWith(
+        '/api/view/acp/acp1/items/preferences/row-data',
+        { rowKey: 'uuid::1', rowData, perspective: 'read-only' },
+      );
+    });
+
     it('should get view sequences', () => {
       httpClientMock.get.mockReturnValue(of([]));
 

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -437,6 +437,17 @@ export class ApiService {
       ...data,
     });
   }
+  patchViewItemPreferenceRow(
+    acpId: string,
+    rowKey: string,
+    rowData: Record<string, unknown> | null,
+    perspective: ItemExplorerPerspective,
+  ): Observable<ItemViewPreferences> {
+    return this.http.patch<ItemViewPreferences>(
+      `${this.API}/view/acp/${acpId}/items/preferences/row-data`,
+      { rowKey, rowData, perspective },
+    );
+  }
   getViewSequences(acpId: string): Observable<any[]> {
     return this.http.get<any[]>(`${this.API}/view/acp/${acpId}/sequences`);
   }

--- a/frontend/src/app/core/services/auth.service.oidc.spec.ts
+++ b/frontend/src/app/core/services/auth.service.oidc.spec.ts
@@ -3,6 +3,7 @@ import { firstValueFrom, of, throwError } from 'rxjs';
 import type { LoginResponse, OidcConfig, UserProfile } from '../models/api.models';
 import { AuthService } from './auth.service';
 import { BYPASS_APP_AUTH } from '../interceptors/auth-context.tokens';
+import { PendingPersonalSessionStorageService } from './pending-personal-session-storage.service';
 
 describe('AuthService OIDC and Crypto Paths', () => {
   let service: AuthService;
@@ -95,7 +96,7 @@ describe('AuthService OIDC and Crypto Paths', () => {
       }),
     };
 
-    service = new AuthService(httpClientMock as any);
+    service = new AuthService(httpClientMock as any, new PendingPersonalSessionStorageService());
   });
 
   afterEach(() => {

--- a/frontend/src/app/core/services/auth.service.spec.ts
+++ b/frontend/src/app/core/services/auth.service.spec.ts
@@ -105,6 +105,26 @@ describe('AuthService', () => {
       expect(service.currentUser).toEqual(mockUserProfile);
     });
 
+    it('should restore credential tokens without loading a user profile', () => {
+      const credentialToken = createJwt('credential-1', 'credential', 'acp1');
+      localStorage.setItem('cp_token', credentialToken);
+      localStorage.setItem('cp_auth_type', 'oidc');
+      localStorage.setItem('cp_oidc_id_token', 'stale-id-token');
+      localStorage.setItem('cp_oidc_access_token', 'stale-access-token');
+      localStorage.setItem('cp_oidc_refresh_token', 'stale-refresh-token');
+
+      service.initFromStorage();
+
+      expect(httpClientMock.get).not.toHaveBeenCalled();
+      expect(localStorage.getItem('cp_token')).toBe(credentialToken);
+      expect(localStorage.getItem('cp_auth_type')).toBe('credential');
+      expect(localStorage.getItem('cp_oidc_id_token')).toBeNull();
+      expect(localStorage.getItem('cp_oidc_access_token')).toBeNull();
+      expect(localStorage.getItem('cp_oidc_refresh_token')).toBeNull();
+      expect(service.isLoggedIn).toBe(true);
+      expect(service.currentUser).toBeNull();
+    });
+
     it('should skip profile load when no token exists in storage', () => {
       localStorage.removeItem('cp_token');
 
@@ -221,6 +241,7 @@ describe('AuthService', () => {
       service.credentialLogin('acp1', 'user', 'pass').subscribe((res) => {
         expect(res).toEqual(response);
         expect(localStorage.getItem('cp_token')).toBe('cred-token');
+        expect(localStorage.getItem('cp_auth_type')).toBe('credential');
       });
 
       expect(httpClientMock.post).toHaveBeenCalledWith('/api/auth/credential-login', {
@@ -228,6 +249,28 @@ describe('AuthService', () => {
         username: 'user',
         password: 'pass',
       });
+    });
+
+    it('should replace a previous OIDC session on credential login', () => {
+      const credentialToken = createJwt('credential-1', 'credential', 'acp1');
+      localStorage.setItem('cp_auth_type', 'oidc');
+      localStorage.setItem('cp_oidc_id_token', 'id-token');
+      localStorage.setItem('cp_oidc_access_token', 'access-token');
+      localStorage.setItem('cp_oidc_refresh_token', 'refresh-token');
+      httpClientMock.post.mockReturnValue(
+        of({
+          accessToken: credentialToken,
+          acpId: 'acp1',
+          username: 'reader',
+        } satisfies CredentialLoginResponse),
+      );
+
+      service.credentialLogin('acp1', 'reader', 'pass').subscribe();
+
+      expect(localStorage.getItem('cp_auth_type')).toBe('credential');
+      expect(localStorage.getItem('cp_oidc_id_token')).toBeNull();
+      expect(localStorage.getItem('cp_oidc_access_token')).toBeNull();
+      expect(localStorage.getItem('cp_oidc_refresh_token')).toBeNull();
     });
 
     it('discards snapshots owned by another identity without an active explorer', () => {

--- a/frontend/src/app/core/services/auth.service.spec.ts
+++ b/frontend/src/app/core/services/auth.service.spec.ts
@@ -2,6 +2,22 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { of, throwError } from 'rxjs';
 import { AuthService } from './auth.service';
 import type { LoginResponse, CredentialLoginResponse, UserProfile } from '../models/api.models';
+import { PendingPersonalSessionStorageService } from './pending-personal-session-storage.service';
+
+function createJwt(sub: string, type = 'user', acpId = ''): string {
+  const payload = btoa(
+    JSON.stringify({
+      sub,
+      type,
+      acpId,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }),
+  )
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `header.${payload}.signature`;
+}
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -13,6 +29,7 @@ describe('AuthService', () => {
     postMessage: ReturnType<typeof vi.fn>;
     onmessage: ((event: MessageEvent) => void) | null;
   };
+  let pendingPersonalSessionStorage: PendingPersonalSessionStorageService;
 
   const mockUserProfile: UserProfile = {
     id: '1',
@@ -47,7 +64,8 @@ describe('AuthService', () => {
       post: vi.fn().mockReturnValue(of({})),
       get: vi.fn().mockReturnValue(of(mockUserProfile)),
     };
-    service = new AuthService(httpClientMock as any);
+    pendingPersonalSessionStorage = new PendingPersonalSessionStorageService();
+    service = new AuthService(httpClientMock as any, pendingPersonalSessionStorage);
   });
 
   afterEach(() => {
@@ -68,7 +86,10 @@ describe('AuthService', () => {
         get: vi.fn().mockReturnValue(of(mockUserProfile)),
       };
 
-      const constructedService = new AuthService(localHttpMock as any);
+      const constructedService = new AuthService(
+        localHttpMock as any,
+        pendingPersonalSessionStorage,
+      );
 
       expect(localHttpMock.get).not.toHaveBeenCalled();
       expect(constructedService.currentUser).toBeNull();
@@ -207,6 +228,29 @@ describe('AuthService', () => {
         username: 'user',
         password: 'pass',
       });
+    });
+
+    it('discards snapshots owned by another identity without an active explorer', () => {
+      const userAToken = createJwt('user-a');
+      const credentialBToken = createJwt('credential-b', 'credential', 'acp2');
+      const userAIdentity = pendingPersonalSessionStorage.resolveIdentityFromToken(userAToken);
+      pendingPersonalSessionStorage.set(
+        'cp_item_explorer_pending_personal:acp1',
+        JSON.stringify({ identity: userAIdentity, updates: [] }),
+      );
+      httpClientMock.post.mockReturnValue(
+        of({
+          accessToken: credentialBToken,
+          acpId: 'acp2',
+          username: 'reader-b',
+        } satisfies CredentialLoginResponse),
+      );
+
+      service.credentialLogin('acp2', 'reader-b', 'pass').subscribe();
+
+      expect(
+        pendingPersonalSessionStorage.get('cp_item_explorer_pending_personal:acp1'),
+      ).toBeNull();
     });
   });
 

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -9,6 +9,7 @@ import {
   AuthContext,
 } from '../models/api.models';
 import { BYPASS_APP_AUTH } from '../interceptors/auth-context.tokens';
+import { PendingPersonalSessionStorageService } from './pending-personal-session-storage.service';
 
 interface OidcTokenResponse {
   access_token: string;
@@ -16,7 +17,10 @@ interface OidcTokenResponse {
   refresh_token?: string;
 }
 
-type AuthChannelMessage = { type: 'logout' } | { type: 'oidc_session_updated' };
+type AuthChannelMessage =
+  | { type: 'logout' }
+  | { type: 'oidc_session_updated' }
+  | { type: 'app_session_updated' };
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -35,14 +39,24 @@ export class AuthService {
   private oidcRefreshTimeout: ReturnType<typeof setTimeout> | null = null;
   private oidcRefreshPromise: Promise<void> | null = null;
   private currentUserSubject = new BehaviorSubject<UserProfile | null>(null);
+  private readonly tokenStorageListener = (event: StorageEvent) => {
+    if (event.key === this.tokenKey && event.newValue) {
+      this.pendingPersonalSessionStorage.activateIdentityFromToken(event.newValue);
+    }
+  };
 
   currentUser$ = this.currentUserSubject.asObservable();
 
-  constructor(private http: HttpClient) {
+  constructor(
+    private http: HttpClient,
+    private pendingPersonalSessionStorage: PendingPersonalSessionStorageService,
+  ) {
     this.initBroadcastChannel();
+    window.addEventListener('storage', this.tokenStorageListener);
   }
 
   initFromStorage(): void {
+    this.pendingPersonalSessionStorage.activateIdentityFromToken(this.getToken());
     if (this.isOidcUser && this.hasStoredOidcSession()) {
       void this.restoreOidcSession();
       return;
@@ -64,6 +78,11 @@ export class AuthService {
 
         if (event.data?.type === 'oidc_session_updated') {
           this.scheduleOidcTokenRefresh();
+          return;
+        }
+
+        if (event.data?.type === 'app_session_updated') {
+          this.pendingPersonalSessionStorage.activateIdentityFromToken(this.getToken());
         }
       };
     }
@@ -211,7 +230,7 @@ export class AuthService {
       .post<LoginResponse>(`${this.API}/oidc-callback`, { idToken: tokenForBackend })
       .pipe(
         tap((res) => {
-          localStorage.setItem(this.tokenKey, res.accessToken);
+          this.storeApplicationToken(res.accessToken);
           if (accessToken) {
             localStorage.setItem(this.ACCESS_TOKEN_KEY, accessToken);
           } else {
@@ -266,7 +285,7 @@ export class AuthService {
   login(username: string, password: string): Observable<LoginResponse> {
     return this.http.post<LoginResponse>(`${this.API}/login`, { username, password }).pipe(
       tap((res) => {
-        localStorage.setItem(this.tokenKey, res.accessToken);
+        this.storeApplicationToken(res.accessToken);
         this.loadProfile();
       }),
     );
@@ -281,7 +300,7 @@ export class AuthService {
       .post<CredentialLoginResponse>(`${this.API}/credential-login`, { acpId, username, password })
       .pipe(
         tap((res) => {
-          localStorage.setItem(this.tokenKey, res.accessToken);
+          this.storeApplicationToken(res.accessToken);
         }),
       );
   }
@@ -358,7 +377,7 @@ export class AuthService {
   syncOidcRoles(idToken: string): Observable<UserProfile> {
     return this.http.post<LoginResponse>(`${this.API}/sync-oidc-roles`, { idToken }).pipe(
       tap((res) => {
-        localStorage.setItem(this.tokenKey, res.accessToken);
+        this.storeApplicationToken(res.accessToken);
       }),
       map((res) => this.normalizeUserProfile(res.user)),
     );
@@ -544,6 +563,12 @@ export class AuthService {
       clearTimeout(this.oidcRefreshTimeout);
       this.oidcRefreshTimeout = null;
     }
+  }
+
+  private storeApplicationToken(token: string): void {
+    localStorage.setItem(this.tokenKey, token);
+    this.pendingPersonalSessionStorage.activateIdentityFromToken(token);
+    this.broadcastAuthEvent({ type: 'app_session_updated' });
   }
 
   private getPrimaryOidcToken(): string | null {

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -56,13 +56,20 @@ export class AuthService {
   }
 
   initFromStorage(): void {
-    this.pendingPersonalSessionStorage.activateIdentityFromToken(this.getToken());
+    const token = this.getToken();
+    this.pendingPersonalSessionStorage.activateIdentityFromToken(token);
+
+    if (this.isCredentialToken(token)) {
+      this.switchApplicationSession('credential');
+      return;
+    }
+
     if (this.isOidcUser && this.hasStoredOidcSession()) {
       void this.restoreOidcSession();
       return;
     }
 
-    if (this.getToken()) {
+    if (token) {
       this.loadProfile();
     }
   }
@@ -285,6 +292,7 @@ export class AuthService {
   login(username: string, password: string): Observable<LoginResponse> {
     return this.http.post<LoginResponse>(`${this.API}/login`, { username, password }).pipe(
       tap((res) => {
+        this.switchApplicationSession('local');
         this.storeApplicationToken(res.accessToken);
         this.loadProfile();
       }),
@@ -300,6 +308,7 @@ export class AuthService {
       .post<CredentialLoginResponse>(`${this.API}/credential-login`, { acpId, username, password })
       .pipe(
         tap((res) => {
+          this.switchApplicationSession('credential');
           this.storeApplicationToken(res.accessToken);
         }),
       );
@@ -571,6 +580,26 @@ export class AuthService {
     this.broadcastAuthEvent({ type: 'app_session_updated' });
   }
 
+  private switchApplicationSession(authType: 'local' | 'credential'): void {
+    this.clearOidcRefreshTimer();
+    this.clearStoredOidcSession();
+    localStorage.setItem(this.AUTH_TYPE_KEY, authType);
+    this.currentUserSubject.next(null);
+  }
+
+  private clearStoredOidcSession(): void {
+    localStorage.removeItem(this.ID_TOKEN_KEY);
+    localStorage.removeItem(this.ACCESS_TOKEN_KEY);
+    localStorage.removeItem(this.REFRESH_TOKEN_KEY);
+    sessionStorage.removeItem(this.OIDC_REDIRECT_KEY);
+    sessionStorage.removeItem(this.OIDC_STATE_KEY);
+    sessionStorage.removeItem(this.OIDC_CODE_VERIFIER_KEY);
+  }
+
+  private isCredentialToken(token: string | null): boolean {
+    return this.getTokenPayload(token)?.['type'] === 'credential';
+  }
+
   private getPrimaryOidcToken(): string | null {
     return localStorage.getItem(this.ACCESS_TOKEN_KEY) || localStorage.getItem(this.ID_TOKEN_KEY);
   }
@@ -593,6 +622,15 @@ export class AuthService {
   }
 
   private getTokenExpiry(token: string | null): number | null {
+    const payload = this.getTokenPayload(token);
+    if (typeof payload?.['exp'] !== 'number') {
+      return null;
+    }
+
+    return payload['exp'] * 1000;
+  }
+
+  private getTokenPayload(token: string | null): Record<string, unknown> | null {
     if (!token) {
       return null;
     }
@@ -603,12 +641,7 @@ export class AuthService {
     }
 
     try {
-      const payload = JSON.parse(this.base64UrlDecode(parts[1])) as { exp?: number };
-      if (typeof payload.exp !== 'number') {
-        return null;
-      }
-
-      return payload.exp * 1000;
+      return JSON.parse(this.base64UrlDecode(parts[1])) as Record<string, unknown>;
     } catch {
       return null;
     }

--- a/frontend/src/app/core/services/pending-personal-session-storage.service.spec.ts
+++ b/frontend/src/app/core/services/pending-personal-session-storage.service.spec.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PendingPersonalSessionStorageService } from './pending-personal-session-storage.service';
+
+function createJwt(sub: string, type = 'user', acpId = ''): string {
+  const payload = btoa(
+    JSON.stringify({
+      sub,
+      type,
+      acpId,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }),
+  )
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `header.${payload}.signature`;
+}
+
+describe('PendingPersonalSessionStorageService', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('uses its in-memory copy when session storage is unavailable', () => {
+    sessionStorage.setItem('pending', '{"value":"old"}');
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage unavailable', 'QuotaExceededError');
+    });
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage unavailable', 'SecurityError');
+    });
+    const service = new PendingPersonalSessionStorageService();
+
+    service.set('pending', '{"value":1}');
+
+    expect(service.get('pending')).toBe('{"value":1}');
+    service.remove('pending');
+    expect(service.get('pending')).toBeNull();
+  });
+
+  it('removes snapshots owned by another activated identity', () => {
+    const service = new PendingPersonalSessionStorageService();
+    const userAIdentity = service.resolveIdentityFromToken(createJwt('user-a'));
+    const userBToken = createJwt('user-b');
+    const userBIdentity = service.resolveIdentityFromToken(userBToken);
+    const userAKey = 'cp_item_explorer_pending_personal:acp-a';
+    const userBKey = 'cp_item_explorer_pending_personal:acp-b';
+    service.set(userAKey, JSON.stringify({ identity: userAIdentity, updates: [] }));
+    service.set(userBKey, JSON.stringify({ identity: userBIdentity, updates: [] }));
+
+    service.activateIdentityFromToken(userBToken);
+
+    expect(service.get(userAKey)).toBeNull();
+    expect(service.get(userBKey)).not.toBeNull();
+  });
+
+  it('keeps a local-user snapshot when the same user activates an OIDC session', () => {
+    const service = new PendingPersonalSessionStorageService();
+    const localUserToken = createJwt('user-a', 'user');
+    const oidcUserToken = createJwt('user-a', 'oidc');
+    const snapshotKey = 'cp_item_explorer_pending_personal:acp-a';
+    service.set(
+      snapshotKey,
+      JSON.stringify({
+        identity: service.resolveIdentityFromToken(localUserToken),
+        updates: [],
+      }),
+    );
+
+    service.activateIdentityFromToken(oidcUserToken);
+
+    expect(service.get(snapshotKey)).not.toBeNull();
+    expect(service.resolveIdentityFromToken(localUserToken)).toBe(
+      service.resolveIdentityFromToken(oidcUserToken),
+    );
+  });
+
+  it('removes a local-user snapshot when a different OIDC user activates', () => {
+    const service = new PendingPersonalSessionStorageService();
+    const localUserToken = createJwt('user-a', 'user');
+    const oidcUserToken = createJwt('user-b', 'oidc');
+    const snapshotKey = 'cp_item_explorer_pending_personal:acp-a';
+    service.set(
+      snapshotKey,
+      JSON.stringify({
+        identity: service.resolveIdentityFromToken(localUserToken),
+        updates: [],
+      }),
+    );
+
+    service.activateIdentityFromToken(oidcUserToken);
+
+    expect(service.get(snapshotKey)).toBeNull();
+  });
+
+  it('keeps credential identities separated by ACP', () => {
+    const service = new PendingPersonalSessionStorageService();
+
+    expect(
+      service.resolveIdentityFromToken(createJwt('credential-1', 'credential', 'acp-a')),
+    ).not.toBe(service.resolveIdentityFromToken(createJwt('credential-1', 'credential', 'acp-b')));
+  });
+});

--- a/frontend/src/app/core/services/pending-personal-session-storage.service.ts
+++ b/frontend/src/app/core/services/pending-personal-session-storage.service.ts
@@ -1,0 +1,103 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class PendingPersonalSessionStorageService {
+  private readonly snapshotKeyPrefix = 'cp_item_explorer_pending_personal:';
+  private readonly memoryFallback = new Map<string, string | null>();
+
+  resolveIdentityFromToken(token: string | null): string | null {
+    if (!token) return null;
+    const payloadPart = token.split('.')[1];
+    if (!payloadPart) return null;
+
+    try {
+      const base64 = payloadPart.replace(/-/g, '+').replace(/_/g, '/');
+      const paddedBase64 = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+      const payload = JSON.parse(atob(paddedBase64)) as Record<string, unknown>;
+      const sub = typeof payload['sub'] === 'string' ? payload['sub'].trim() : '';
+      if (!sub) return null;
+      if (typeof payload['exp'] === 'number' && payload['exp'] * 1000 <= Date.now()) {
+        return null;
+      }
+      if (payload['type'] === 'credential') {
+        return JSON.stringify([
+          'credential',
+          sub,
+          typeof payload['acpId'] === 'string' ? payload['acpId'] : '',
+        ]);
+      }
+      return JSON.stringify(['user', sub, '']);
+    } catch {
+      return null;
+    }
+  }
+
+  activateIdentityFromToken(token: string | null): void {
+    const identity = this.resolveIdentityFromToken(token);
+    if (!identity) return;
+
+    for (const key of this.snapshotKeys()) {
+      const raw = this.get(key);
+      if (!raw || this.snapshotIdentity(raw) !== identity) {
+        this.remove(key);
+      }
+    }
+  }
+
+  set(key: string, value: string): void {
+    this.memoryFallback.set(key, value);
+    try {
+      sessionStorage.setItem(key, value);
+    } catch {
+      // The in-memory copy survives route changes in the current application session.
+    }
+  }
+
+  get(key: string): string | null {
+    if (this.memoryFallback.has(key)) {
+      return this.memoryFallback.get(key) ?? null;
+    }
+    try {
+      const stored = sessionStorage.getItem(key);
+      if (stored !== null) return stored;
+    } catch {
+      // Fall through to the in-memory copy.
+    }
+    return this.memoryFallback.get(key) ?? null;
+  }
+
+  remove(key: string): void {
+    try {
+      sessionStorage.removeItem(key);
+      this.memoryFallback.delete(key);
+    } catch {
+      this.memoryFallback.set(key, null);
+    }
+  }
+
+  private snapshotKeys(): Set<string> {
+    const keys = new Set(
+      Array.from(this.memoryFallback.keys()).filter((key) =>
+        key.startsWith(this.snapshotKeyPrefix),
+      ),
+    );
+    try {
+      for (let index = 0; index < sessionStorage.length; index += 1) {
+        const key = sessionStorage.key(index);
+        if (key?.startsWith(this.snapshotKeyPrefix)) keys.add(key);
+      }
+    } catch {
+      // The in-memory keys remain available when session storage cannot be enumerated.
+    }
+    return keys;
+  }
+
+  private snapshotIdentity(raw: string): string | null {
+    try {
+      const parsed = JSON.parse(raw) as { identity?: unknown };
+      return typeof parsed.identity === 'string' ? parsed.identity : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -1,7 +1,23 @@
-import { describe, it, expect, vi } from 'vitest';
-import { of } from 'rxjs';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { of, Subject, throwError } from 'rxjs';
 import { ItemExplorerComponent } from './item-explorer.component';
 import { VoudService } from '../../core/services/voud.service';
+import { PendingPersonalSessionStorageService } from '../../core/services/pending-personal-session-storage.service';
+
+function createJwt(sub: string, type = 'user', acpId = ''): string {
+  const payload = btoa(
+    JSON.stringify({
+      sub,
+      type,
+      acpId,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }),
+  )
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `header.${payload}.signature`;
+}
 
 function createComponent(options?: {
   getStartPage?: (definition: string, variableId: string) => number | undefined;
@@ -19,6 +35,7 @@ function createComponent(options?: {
   stripConditionalVisibility?: (definition: string) => string;
   api?: Record<string, unknown>;
   authService?: Record<string, unknown>;
+  pendingPersonalSessionStorage?: PendingPersonalSessionStorageService;
 }) {
   const route = { snapshot: { paramMap: { get: () => 'acp-1' } } };
   const router = { navigate: () => Promise.resolve(true) };
@@ -44,20 +61,30 @@ function createComponent(options?: {
     stripConditionalVisibility:
       options?.stripConditionalVisibility || ((definition: string) => definition),
   };
+  const authOverrides = options?.authService || {};
+  const defaultToken = authOverrides['isLoggedIn'] === true ? createJwt('test-user') : null;
   const authService = {
     hasAcpRole: () => false,
     isAdmin: false,
-    ...(options?.authService || {}),
+    isLoggedIn: false,
+    currentUser$: of(null),
+    getToken: () => defaultToken,
+    ...authOverrides,
   };
 
-  return new ItemExplorerComponent(
+  const component = new ItemExplorerComponent(
     route as any,
     router as any,
     api as any,
     sanitizer as any,
     voudService as any,
     authService as any,
+    options?.pendingPersonalSessionStorage || new PendingPersonalSessionStorageService(),
   );
+  (component as any).personalDataSessionIdentity = (
+    component as any
+  ).resolvePersonalItemDataSessionIdentity();
+  return component;
 }
 
 function createExplorerEnvelope(
@@ -109,6 +136,378 @@ function createExplorerEnvelope(
 }
 
 describe('ItemExplorerComponent', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('stores personal category, colored tags and plain-text notes by row key', () => {
+    const patchViewItemPreferenceRow = vi.fn().mockReturnValue(
+      of({
+        rowData: {
+          'uuid-1::2': {
+            category: 'II',
+            tags: ['Prüfen'],
+            note: 'Nur Text',
+          },
+        },
+      }),
+    );
+    const component = createComponent({
+      api: { patchViewItemPreferenceRow },
+      authService: { isLoggedIn: true },
+    });
+    component.acpId = 'acp-1';
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.personalItemTags = [{ label: 'Prüfen', color: '#ff0000' }];
+
+    component.setPersonalItemCategory('uuid-1::2', 'II');
+    component.addPersonalItemTagToRow('uuid-1::2', {
+      target: { value: 'Prüfen' },
+    } as any);
+    component.setPersonalItemNote('uuid-1::2', 'Nur Text');
+    component.flushPersonalItemDataSave();
+
+    expect(patchViewItemPreferenceRow).toHaveBeenCalledWith(
+      'acp-1',
+      'uuid-1::2',
+      {
+        category: 'II',
+        tags: ['Prüfen'],
+        note: 'Nur Text',
+      },
+      'read-only',
+    );
+    expect(component.getPersonalTagColor('Prüfen')).toBe('#ff0000');
+  });
+
+  it('does not expose personal working-data controls to anonymous visitors', () => {
+    const component = createComponent({ authService: { isLoggedIn: false } });
+    component.enablePersonalItemData = true;
+
+    expect(component.showPersonalItemData).toBe(false);
+  });
+
+  it('saves manager personal data against the current editor perspective', () => {
+    const patchViewItemPreferenceRow = vi.fn().mockReturnValue(of({ rowData: {} }));
+    const component = createComponent({
+      api: { patchViewItemPreferenceRow },
+      authService: { isLoggedIn: true },
+    });
+    component.acpId = 'acp-1';
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.hasExplorerEditPermission = true;
+    component.viewPerspective = 'editor';
+
+    component.setPersonalItemNote('uuid-1', 'Draft-Notiz');
+    component.flushPersonalItemDataSave();
+
+    expect(patchViewItemPreferenceRow).toHaveBeenCalledWith(
+      'acp-1',
+      'uuid-1',
+      { note: 'Draft-Notiz' },
+      'editor',
+    );
+  });
+
+  it('keeps the queued perspective when it changes before the debounce is flushed', () => {
+    const patchViewItemPreferenceRow = vi.fn().mockReturnValue(of({ rowData: {} }));
+    const component = createComponent({
+      api: { patchViewItemPreferenceRow },
+      authService: { isLoggedIn: true },
+    });
+    component.acpId = 'acp-1';
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.hasExplorerEditPermission = true;
+    component.viewPerspective = 'editor';
+
+    component.setPersonalItemNote('uuid-draft', 'Draft-Notiz');
+    component.viewPerspective = 'read-only';
+    component.flushPersonalItemDataSave();
+
+    expect(patchViewItemPreferenceRow).toHaveBeenCalledWith(
+      'acp-1',
+      'uuid-draft',
+      { note: 'Draft-Notiz' },
+      'editor',
+    );
+  });
+
+  it('blocks personal edits while the perspective is switching', () => {
+    const component = createComponent({
+      api: { patchViewItemPreferenceRow: vi.fn().mockReturnValue(of({ rowData: {} })) },
+      authService: { isLoggedIn: true },
+    });
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.perspectiveSwitchBusy = true;
+
+    component.setPersonalItemNote('uuid-1', 'Nicht übernehmen');
+
+    expect(component.canChangePersonalItemData).toBe(false);
+    expect(component.personalItemData).toEqual({});
+    expect((component as any).pendingPersonalRowUpdates.size).toBe(0);
+  });
+
+  it('keeps personal filters out of the shared Explorer UI state', () => {
+    const component = createComponent({ authService: { isLoggedIn: true } });
+    component.columnFilters = {
+      unitLabel: 'Mathematik',
+      personalNote: 'vertraulich',
+    };
+    component.personalColumnFilters = { personalNote: 'vertraulich' };
+
+    expect((component as any).buildUiPreferences().columnFilters).toEqual({
+      unitLabel: 'Mathematik',
+    });
+
+    (component as any).applyUiPreferences({
+      columnFilters: { unitLabel: 'Deutsch', personalCategory: 'III' },
+    });
+    expect(component.columnFilters).toEqual({ unitLabel: 'Deutsch' });
+    expect(component.personalColumnFilters).toEqual({ personalNote: 'vertraulich' });
+  });
+
+  it('disables personal edits after a load failure without clearing known data', () => {
+    const patchViewItemPreferenceRow = vi.fn();
+    const component = createComponent({
+      api: {
+        getViewItemPreferences: vi.fn().mockReturnValue(throwError(() => new Error('offline'))),
+        patchViewItemPreferenceRow,
+      },
+      authService: { isLoggedIn: true },
+    });
+    component.enablePersonalItemData = true;
+    component.personalItemData = { 'uuid::1': { note: 'bestehend' } };
+
+    (component as any).loadPersonalItemData();
+    component.setPersonalItemNote('uuid::1', 'überschrieben');
+
+    expect(component.personalDataLoadState).toBe('error');
+    expect(component.personalItemData).toEqual({ 'uuid::1': { note: 'bestehend' } });
+    expect(patchViewItemPreferenceRow).not.toHaveBeenCalled();
+  });
+
+  it('blocks navigation while a personal autosave keeps failing', async () => {
+    const component = createComponent({
+      api: {
+        patchViewItemPreferenceRow: vi.fn().mockReturnValue(throwError(() => new Error('offline'))),
+      },
+      authService: { isLoggedIn: true },
+    });
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.setPersonalItemNote('uuid::1', 'ungespeichert');
+    component.flushPersonalItemDataSave();
+
+    expect(component.personalDataSaveState).toBe('error');
+    await expect(component.canDeactivate()).resolves.toBe(false);
+  });
+
+  it('does not wait indefinitely when pending personal data can no longer be saved', async () => {
+    const component = createComponent({
+      api: { patchViewItemPreferenceRow: vi.fn().mockReturnValue(of({ rowData: {} })) },
+      authService: { isLoggedIn: true },
+    });
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.setPersonalItemNote('uuid::1', 'ungespeichert');
+    (component as any).personalDataSessionIdentity = null;
+
+    await expect(component.canDeactivate()).resolves.toBe(false);
+    component.ngOnDestroy();
+  });
+
+  it('clears personal data before loading a different session identity', () => {
+    let token = createJwt('user-a');
+    const secondLoad = new Subject<any>();
+    const getViewItemPreferences = vi
+      .fn()
+      .mockReturnValueOnce(of({ rowData: { 'uuid::1': { note: 'Nur A' } } }))
+      .mockReturnValueOnce(secondLoad);
+    const component = createComponent({
+      api: { getViewItemPreferences },
+      authService: {
+        isLoggedIn: true,
+        getToken: () => token,
+      },
+    });
+    component.enablePersonalItemData = true;
+    (component as any).syncPersonalItemDataSession();
+    expect(component.personalItemData).toEqual({ 'uuid::1': { note: 'Nur A' } });
+
+    token = createJwt('user-b');
+    (component as any).authStorageListener({ key: 'cp_token' } as StorageEvent);
+
+    expect(component.personalItemData).toEqual({});
+    expect(component.personalDataLoadState).toBe('loading');
+
+    secondLoad.next({ rowData: { 'uuid::1': { note: 'Nur B' } } });
+    secondLoad.complete();
+    expect(component.personalItemData).toEqual({ 'uuid::1': { note: 'Nur B' } });
+  });
+
+  it('restores pending personal changes after the same identity logs in again', () => {
+    let token: string | null = createJwt('user-a');
+    const patchViewItemPreferenceRow = vi.fn().mockReturnValue(of({ rowData: {} }));
+    const component = createComponent({
+      api: {
+        getViewItemPreferences: vi
+          .fn()
+          .mockReturnValue(of({ rowData: { 'uuid::1': { note: 'Serverwert' } } })),
+        patchViewItemPreferenceRow,
+      },
+      authService: {
+        isLoggedIn: true,
+        getToken: () => token,
+      },
+    });
+    component.acpId = 'acp-1';
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.hasExplorerEditPermission = true;
+    component.viewPerspective = 'read-only';
+    component.setPersonalItemNote('uuid::1', 'Noch nicht gespeichert');
+
+    token = null;
+    (component as any).authStorageListener({ key: 'cp_token' } as StorageEvent);
+    expect(component.personalItemData).toEqual({});
+
+    token = createJwt('user-a');
+    (component as any).authStorageListener({ key: 'cp_token' } as StorageEvent);
+
+    expect(component.personalItemData).toEqual({
+      'uuid::1': { note: 'Noch nicht gespeichert' },
+    });
+    expect((component as any).pendingPersonalRowUpdates.size).toBe(1);
+    expect(component.personalDataSaveState).toBe('pending');
+    component.viewPerspective = 'editor';
+    component.flushPersonalItemDataSave();
+    expect(patchViewItemPreferenceRow).toHaveBeenCalledWith(
+      'acp-1',
+      'uuid::1',
+      { note: 'Noch nicht gespeichert' },
+      'read-only',
+    );
+    component.ngOnDestroy();
+  });
+
+  it('restores pending changes from memory when session storage is unavailable', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage unavailable', 'QuotaExceededError');
+    });
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage unavailable', 'SecurityError');
+    });
+    const removeItem = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('Storage unavailable', 'SecurityError');
+    });
+    const pendingStorage = new PendingPersonalSessionStorageService();
+    let firstToken: string | null = createJwt('user-a');
+    const firstComponent = createComponent({
+      api: { patchViewItemPreferenceRow: vi.fn().mockReturnValue(of({ rowData: {} })) },
+      authService: {
+        isLoggedIn: true,
+        getToken: () => firstToken,
+      },
+      pendingPersonalSessionStorage: pendingStorage,
+    });
+    firstComponent.acpId = 'acp-1';
+    firstComponent.enablePersonalItemData = true;
+    firstComponent.personalDataLoadState = 'loaded';
+    firstComponent.setPersonalItemNote('uuid::1', 'Fallback-Notiz');
+    firstToken = null;
+    (firstComponent as any).authStorageListener({ key: 'cp_token' } as StorageEvent);
+    firstComponent.ngOnDestroy();
+
+    const secondComponent = createComponent({
+      api: {
+        getViewItemPreferences: vi.fn().mockReturnValue(of({ rowData: {} })),
+        patchViewItemPreferenceRow: vi.fn().mockReturnValue(of({ rowData: {} })),
+      },
+      authService: {
+        isLoggedIn: true,
+        getToken: () => createJwt('user-a'),
+      },
+      pendingPersonalSessionStorage: pendingStorage,
+    });
+    secondComponent.acpId = 'acp-1';
+    secondComponent.enablePersonalItemData = true;
+    (secondComponent as any).syncPersonalItemDataSession();
+
+    expect(secondComponent.personalItemData).toEqual({
+      'uuid::1': { note: 'Fallback-Notiz' },
+    });
+    expect((secondComponent as any).pendingPersonalRowUpdates.size).toBe(1);
+    secondComponent.ngOnDestroy();
+    setItem.mockRestore();
+    getItem.mockRestore();
+    removeItem.mockRestore();
+  });
+
+  it('discards suspended personal changes when a different identity logs in', () => {
+    let token: string | null = createJwt('user-a');
+    const component = createComponent({
+      api: {
+        getViewItemPreferences: vi
+          .fn()
+          .mockReturnValue(of({ rowData: { 'uuid::1': { note: 'Nur B' } } })),
+        patchViewItemPreferenceRow: vi.fn().mockReturnValue(of({ rowData: {} })),
+      },
+      authService: {
+        isLoggedIn: true,
+        getToken: () => token,
+      },
+    });
+    component.acpId = 'acp-1';
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.setPersonalItemNote('uuid::1', 'Nur A');
+
+    token = null;
+    (component as any).authStorageListener({ key: 'cp_token' } as StorageEvent);
+    token = createJwt('user-b');
+    (component as any).authStorageListener({ key: 'cp_token' } as StorageEvent);
+
+    expect(component.personalItemData).toEqual({ 'uuid::1': { note: 'Nur B' } });
+    expect((component as any).pendingPersonalRowUpdates.size).toBe(0);
+    expect(sessionStorage.getItem('cp_item_explorer_pending_personal:acp-1')).toBeNull();
+    component.ngOnDestroy();
+  });
+
+  it('reapplies an active personal note filter when a note changes', () => {
+    const component = createComponent({
+      api: { patchViewItemPreferenceRow: vi.fn().mockReturnValue(of({ rowData: {} })) },
+      authService: { isLoggedIn: true },
+    });
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.personalColumnFilters = { personalNote: 'prüfen' };
+    component.items = [
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid',
+        rowKey: 'uuid::1',
+        subId: '1',
+        subIdDisplay: '',
+        unitId: 'UNIT_1',
+        unitLabel: 'Unit 1',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+    ];
+    component.applyFilter(false);
+    expect(component.filteredItems).toEqual([]);
+
+    component.setPersonalItemNote('uuid::1', 'Später prüfen');
+
+    expect(component.filteredItems).toEqual(component.items);
+    component.flushPersonalItemDataSave();
+  });
+
   it('defaults to sorting by task label', () => {
     const component = createComponent();
 

--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -306,6 +306,40 @@ describe('ItemExplorerComponent', () => {
     await expect(component.canDeactivate()).resolves.toBe(false);
   });
 
+  it('allows navigation after failed personal changes are explicitly discarded', () => {
+    const getViewItemPreferences = vi.fn().mockReturnValue(
+      of({
+        rowData: {
+          'uuid::1': { note: 'Gespeicherter Stand' },
+        },
+      }),
+    );
+    const component = createComponent({
+      api: {
+        getViewItemPreferences,
+        patchViewItemPreferenceRow: vi.fn().mockReturnValue(throwError(() => new Error('offline'))),
+      },
+      authService: { isLoggedIn: true },
+    });
+    component.acpId = 'acp-1';
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.setPersonalItemNote('uuid::1', 'Ungespeicherter Stand');
+    component.flushPersonalItemDataSave();
+
+    component.openDiscardPersonalItemDataDialog();
+    expect(component.showDiscardPersonalItemDataDialog).toBe(true);
+
+    component.confirmDiscardPersonalItemDataChanges();
+
+    expect((component as any).pendingPersonalRowUpdates.size).toBe(0);
+    expect(component.personalItemData).toEqual({
+      'uuid::1': { note: 'Gespeicherter Stand' },
+    });
+    expect(getViewItemPreferences).toHaveBeenCalledWith('acp-1', 'item-explorer');
+    expect(component.canDeactivate()).toBe(true);
+  });
+
   it('does not wait indefinitely when pending personal data can no longer be saved', async () => {
     const component = createComponent({
       api: { patchViewItemPreferenceRow: vi.fn().mockReturnValue(of({ rowData: {} })) },

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -10,11 +10,12 @@ import {
   rewriteGeoGebraAssetUrls,
 } from '../../core/utils/geogebra-player-html.util';
 import { AuthService } from '../../core/services/auth.service';
+import { PendingPersonalSessionStorageService } from '../../core/services/pending-personal-session-storage.service';
 import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/breadcrumb.component';
 import { SplitPaneComponent } from '../../shared/components/split-pane.component';
 import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog.component';
 import { CodingSchemeTextFactory, CodingAsText } from '@iqb/responses';
-import { firstValueFrom } from 'rxjs';
+import { finalize, firstValueFrom, Subscription } from 'rxjs';
 import {
   ItemExplorerChangeLogEntry,
   ItemExplorerSharedState,
@@ -49,6 +50,32 @@ interface MetadataSettings {
   visible: string[];
   order: string[];
 }
+
+interface PersonalItemTagConfig {
+  label: string;
+  color: string;
+}
+
+interface PersonalItemRowData {
+  [key: string]: unknown;
+  category?: string;
+  tags?: string[];
+  note?: string;
+}
+
+interface PendingPersonalRowUpdate {
+  version: number;
+  rowData: PersonalItemRowData | null;
+  perspective: ItemExplorerPerspective;
+}
+
+interface SuspendedPersonalSession {
+  identity: string;
+  updates: Array<[string, PendingPersonalRowUpdate]>;
+}
+
+type PersonalDataLoadState = 'idle' | 'loading' | 'loaded' | 'error';
+type PersonalDataSaveState = 'idle' | 'pending' | 'saving' | 'saved' | 'error';
 
 interface PreviewTargetOption {
   id: string;
@@ -366,6 +393,37 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                 <kbd>Pos1</kbd>/<kbd>Ende</kbd> Sprung, <kbd>Strg/Cmd + S</kbd> speichern
               </div>
             }
+            @if (showPersonalItemData) {
+              <div class="personal-data-status" aria-live="polite">
+                @if (personalDataLoadState === 'loading') {
+                  Persönliche Arbeitsdaten werden geladen …
+                } @else if (personalDataLoadState === 'error') {
+                  <span class="personal-data-error">{{ personalDataError }}</span>
+                  <button
+                    class="btn btn-outline btn-sm"
+                    type="button"
+                    (click)="retryPersonalItemDataLoad()"
+                  >
+                    Erneut laden
+                  </button>
+                } @else if (
+                  personalDataSaveState === 'saving' || personalDataSaveState === 'pending'
+                ) {
+                  Persönliche Änderungen werden gespeichert …
+                } @else if (personalDataSaveState === 'error') {
+                  <span class="personal-data-error">{{ personalDataError }}</span>
+                  <button
+                    class="btn btn-outline btn-sm"
+                    type="button"
+                    (click)="retryPersonalItemDataSave()"
+                  >
+                    Erneut speichern
+                  </button>
+                } @else if (personalDataSaveState === 'saved') {
+                  Persönliche Änderungen gespeichert
+                }
+              </div>
+            }
           </div>
 
           <div
@@ -402,6 +460,11 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                   }
                   @if (enableTags) {
                     <th>Tags</th>
+                  }
+                  @if (showPersonalItemData) {
+                    <th>{{ personalItemCategoryLabel }}</th>
+                    <th>{{ personalItemTagLabel }}</th>
+                    <th>Notiz</th>
                   }
                 </tr>
                 <tr class="filter-row">
@@ -459,6 +522,35 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                         [(ngModel)]="columnFilters['tags']"
                         placeholder="🔍 Tags..."
                         (input)="applyFilter()"
+                      />
+                    </th>
+                  }
+                  @if (showPersonalItemData) {
+                    <th>
+                      <input
+                        class="col-filter-input"
+                        [(ngModel)]="personalColumnFilters['personalCategory']"
+                        [placeholder]="'🔍 ' + personalItemCategoryLabel + '...'"
+                        [disabled]="personalDataLoadState !== 'loaded'"
+                        (input)="applyFilter(false)"
+                      />
+                    </th>
+                    <th>
+                      <input
+                        class="col-filter-input"
+                        [(ngModel)]="personalColumnFilters['personalTags']"
+                        [placeholder]="'🔍 ' + personalItemTagLabel + '...'"
+                        [disabled]="personalDataLoadState !== 'loaded'"
+                        (input)="applyFilter(false)"
+                      />
+                    </th>
+                    <th>
+                      <input
+                        class="col-filter-input"
+                        [(ngModel)]="personalColumnFilters['personalNote']"
+                        placeholder="🔍 Notiz..."
+                        [disabled]="personalDataLoadState !== 'loaded'"
+                        (input)="applyFilter(false)"
                       />
                     </th>
                   }
@@ -544,6 +636,65 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                             />
                           </div>
                         }
+                      </td>
+                    }
+                    @if (showPersonalItemData) {
+                      <td class="personal-data-cell" (click)="$event.stopPropagation()">
+                        <select
+                          class="personal-category-select"
+                          [ngModel]="personalItemData[item.rowKey]?.category || ''"
+                          [disabled]="!canChangePersonalItemData"
+                          (ngModelChange)="setPersonalItemCategory(item.rowKey, $event)"
+                        >
+                          <option value="">–</option>
+                          @for (category of personalItemCategoryValues; track category) {
+                            <option [value]="category">{{ category }}</option>
+                          }
+                        </select>
+                      </td>
+                      <td class="personal-data-cell" (click)="$event.stopPropagation()">
+                        <div class="personal-tag-list">
+                          @for (tag of personalItemData[item.rowKey]?.tags || []; track tag) {
+                            <button
+                              type="button"
+                              class="personal-tag-badge"
+                              [style.backgroundColor]="getPersonalTagColor(tag)"
+                              [title]="tag + ' entfernen'"
+                              [disabled]="!canChangePersonalItemData"
+                              (click)="removePersonalItemTagFromRow(item.rowKey, tag)"
+                            >
+                              {{ tag }} ×
+                            </button>
+                          }
+                          @if (availablePersonalTagsForRow(item.rowKey).length > 0) {
+                            <select
+                              class="tag-select"
+                              (change)="addPersonalItemTagToRow(item.rowKey, $event)"
+                              [attr.aria-label]="personalItemTagLabel + ' hinzufügen'"
+                              [disabled]="!canChangePersonalItemData"
+                            >
+                              <option value="">+ Hinzufügen</option>
+                              @for (
+                                tag of availablePersonalTagsForRow(item.rowKey);
+                                track tag.label
+                              ) {
+                                <option [value]="tag.label">{{ tag.label }}</option>
+                              }
+                            </select>
+                          }
+                        </div>
+                      </td>
+                      <td class="personal-data-cell note-cell" (click)="$event.stopPropagation()">
+                        <textarea
+                          class="personal-note-input"
+                          rows="2"
+                          maxlength="10000"
+                          placeholder="Persönliche Notiz..."
+                          [ngModel]="personalItemData[item.rowKey]?.note || ''"
+                          [disabled]="!canChangePersonalItemData"
+                          (ngModelChange)="setPersonalItemNote(item.rowKey, $event)"
+                          (blur)="flushPersonalItemDataSave()"
+                        ></textarea>
                       </td>
                     }
                   </tr>
@@ -1560,10 +1711,6 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
         gap: 16px;
         flex-wrap: wrap;
       }
-      .item-count {
-        font-size: 0.85rem;
-        color: var(--color-text-secondary);
-      }
       .explorer-status-bar {
         margin-bottom: 12px;
         padding: 10px 14px;
@@ -1781,47 +1928,6 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
         outline: none;
         border-color: var(--color-primary-light);
         box-shadow: 0 0 0 2px rgba(41, 128, 185, 0.1);
-      }
-
-      /* Tags */
-      .tags-cell {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 4px;
-        align-items: center;
-      }
-      .tag-badge {
-        cursor: pointer;
-        font-size: 0.7rem;
-      }
-      .tag-badge:hover {
-        opacity: 0.7;
-      }
-      .tag-select {
-        padding: 2px 4px;
-        border: 1px solid var(--color-border);
-        border-radius: 4px;
-        font-size: 0.75rem;
-        background: white;
-        max-width: 80px;
-      }
-      .tag-add-container {
-        display: flex;
-        gap: 4px;
-        align-items: center;
-      }
-      .tag-input-inline {
-        width: 60px;
-        padding: 2px 6px;
-        border: 1px solid var(--color-border);
-        border-radius: 4px;
-        font-size: 0.75rem;
-        transition: width 0.2s;
-      }
-      .tag-input-inline:focus {
-        width: 100px;
-        outline: none;
-        border-color: var(--color-primary-light);
       }
 
       /* Combined ID styling */
@@ -2635,6 +2741,33 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   persistUserPreferences = false;
   useServerPreferences = false;
 
+  // Personal row-level working data (never part of the shared Explorer state)
+  enablePersonalItemData = false;
+  personalItemCategoryLabel = 'Kompetenzstufe';
+  personalItemCategoryValues: string[] = [];
+  personalItemTagLabel = 'Markierungen';
+  personalItemTags: PersonalItemTagConfig[] = [];
+  personalItemData: Record<string, PersonalItemRowData> = {};
+  personalColumnFilters: Record<string, string> = {};
+  personalDataLoadState: PersonalDataLoadState = 'idle';
+  personalDataSaveState: PersonalDataSaveState = 'idle';
+  personalDataError = '';
+  private readonly personalPreferenceViewId = 'item-explorer';
+  private readonly personalSaveDebounceMs = 350;
+  private personalSaveTimeout: ReturnType<typeof setTimeout> | null = null;
+  private personalSaveInFlight = false;
+  private personalRowUpdateVersion = 0;
+  private readonly pendingPersonalRowUpdates = new Map<string, PendingPersonalRowUpdate>();
+  private personalSaveWaiters: Array<(saved: boolean) => void> = [];
+  private personalDataSessionIdentity: string | null = null;
+  private personalDataSessionVersion = 0;
+  private authSessionSubscription: Subscription | null = null;
+  private readonly authStorageListener = (event: StorageEvent) => {
+    if (!event.key || event.key === 'cp_token') {
+      this.syncPersonalItemDataSession();
+    }
+  };
+
   private readonly draftPatchDebounceMs = 250;
   private draftPatchTimeout: ReturnType<typeof setTimeout> | null = null;
   private pendingDraftPatch: Record<string, unknown> | null = null;
@@ -2961,6 +3094,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     public sanitizer: DomSanitizer,
     private voudService: VoudService,
     private authService: AuthService,
+    private pendingPersonalSessionStorage: PendingPersonalSessionStorageService,
   ) {}
 
   ngOnInit() {
@@ -2972,6 +3106,10 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     ];
 
     window.addEventListener('message', this.messageHandler);
+    window.addEventListener('storage', this.authStorageListener);
+    this.authSessionSubscription = this.authService.currentUser$.subscribe(() => {
+      this.syncPersonalItemDataSession();
+    });
 
     // Check if user is ACP Manager
     this.checkUserRole();
@@ -2988,6 +3126,13 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       this.itemExplorerPlayerTargetInfoEnabled = fc.showItemExplorerPlayerTargetInfo !== false;
       this.showOnlyItemsWithEmpiricalDifficulty = fc.showOnlyItemsWithEmpiricalDifficulty === true;
       this.itemSubIdLabel = String(fc.itemSubIdLabel || 'Sub-ID').trim() || 'Sub-ID';
+      this.enablePersonalItemData = fc.enablePersonalItemData === true;
+      this.personalItemCategoryLabel =
+        String(fc.personalItemCategoryLabel || 'Kompetenzstufe').trim() || 'Kompetenzstufe';
+      this.personalItemCategoryValues = this.normalizeStringList(fc.personalItemCategoryValues);
+      this.personalItemTagLabel =
+        String(fc.personalItemTagLabel || 'Markierungen').trim() || 'Markierungen';
+      this.personalItemTags = this.normalizePersonalItemTagConfig(fc.personalItemTags);
       // Explorer uses ACP-shared draft/published state instead of per-user preferences.
       this.persistUserPreferences = false;
       this.useServerPreferences = false;
@@ -2995,6 +3140,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       // Load metadata column settings
       this.metadataSettings = this.resolveMetadataSettings(fc);
       this.loadSharedExplorerState();
+      this.syncPersonalItemDataSession();
       this.startPlayerIfReady();
     });
 
@@ -3055,9 +3201,17 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     window.removeEventListener('message', this.messageHandler);
+    window.removeEventListener('storage', this.authStorageListener);
+    this.authSessionSubscription?.unsubscribe();
+    this.authSessionSubscription = null;
     this.stopAutoResize();
     this.clearFocusRetryTimer();
     this.clearLegacyPageNavigationTimers();
+    if (this.personalSaveTimeout) {
+      clearTimeout(this.personalSaveTimeout);
+      this.personalSaveTimeout = null;
+      this.saveNextPersonalItemRow();
+    }
     if (this.draftPatchTimeout) {
       clearTimeout(this.draftPatchTimeout);
       this.draftPatchTimeout = null;
@@ -3070,7 +3224,8 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
 
   @HostListener('window:beforeunload', ['$event'])
   handleBeforeUnload(event: BeforeUnloadEvent) {
-    if (!this.canPublishExplorer || !this.hasPendingDraftChanges()) {
+    const hasPendingSharedDraft = this.canPublishExplorer && this.hasPendingDraftChanges();
+    if (!hasPendingSharedDraft && !this.hasPendingPersonalItemDataChanges()) {
       return;
     }
     event.preventDefault();
@@ -3117,6 +3272,19 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   }
 
   canDeactivate(): boolean | Promise<boolean> {
+    if (this.hasPendingPersonalItemDataChanges()) {
+      return this.savePersonalChangesBeforeLeaving();
+    }
+    return this.canDeactivateSharedExplorer();
+  }
+
+  private async savePersonalChangesBeforeLeaving(): Promise<boolean> {
+    const saved = await this.flushPersonalItemDataSaveAndWait();
+    if (!saved) return false;
+    return this.canDeactivateSharedExplorer();
+  }
+
+  private canDeactivateSharedExplorer(): boolean | Promise<boolean> {
     if (!this.canPublishExplorer || !this.hasPendingDraftChanges()) {
       return true;
     }
@@ -3202,6 +3370,22 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
         // Metadata column
         const val = item.metadata[colId] || '';
         if (!val.toLowerCase().includes(subTerm)) return false;
+      }
+    }
+
+    if (this.showPersonalItemData) {
+      const categoryFilter = (this.personalColumnFilters['personalCategory'] || '').toLowerCase();
+      const tagFilter = (this.personalColumnFilters['personalTags'] || '').toLowerCase();
+      const noteFilter = (this.personalColumnFilters['personalNote'] || '').toLowerCase();
+      const row = this.personalItemData[item.rowKey];
+      if (categoryFilter && !(row?.category || '').toLowerCase().includes(categoryFilter)) {
+        return false;
+      }
+      if (tagFilter && !(row?.tags || []).some((tag) => tag.toLowerCase().includes(tagFilter))) {
+        return false;
+      }
+      if (noteFilter && !(row?.note || '').toLowerCase().includes(noteFilter)) {
+        return false;
       }
     }
 
@@ -4620,7 +4804,461 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     this.playerFrame?.nativeElement?.contentWindow?.postMessage(msg, '*');
   }
 
-  // --- Tags ---
+  // --- Personal item working data ---
+  get showPersonalItemData(): boolean {
+    return this.enablePersonalItemData && this.personalDataSessionIdentity !== null;
+  }
+
+  get canEditPersonalItemData(): boolean {
+    return this.showPersonalItemData && this.personalDataLoadState === 'loaded';
+  }
+
+  get canChangePersonalItemData(): boolean {
+    return this.canEditPersonalItemData && !this.perspectiveSwitchBusy;
+  }
+
+  private loadPersonalItemData(
+    sessionIdentity = this.personalDataSessionIdentity,
+    sessionVersion = this.personalDataSessionVersion,
+  ) {
+    if (!sessionIdentity) return;
+    this.personalDataLoadState = 'loading';
+    this.personalDataError = '';
+    this.api.getViewItemPreferences(this.acpId, this.personalPreferenceViewId).subscribe({
+      next: (preferences) => {
+        if (
+          this.personalDataSessionIdentity !== sessionIdentity ||
+          this.personalDataSessionVersion !== sessionVersion
+        ) {
+          return;
+        }
+        this.personalItemData = this.normalizePersonalItemRowData(preferences?.rowData);
+        this.personalDataLoadState = 'loaded';
+        this.restorePendingPersonalSession(sessionIdentity);
+        this.applyFilter(false);
+      },
+      error: (error) => {
+        if (
+          this.personalDataSessionIdentity !== sessionIdentity ||
+          this.personalDataSessionVersion !== sessionVersion
+        ) {
+          return;
+        }
+        console.error('Failed to load personal item working data', error);
+        this.personalDataLoadState = 'error';
+        this.personalDataError =
+          'Persönliche Arbeitsdaten konnten nicht geladen werden. Bearbeitung ist deaktiviert.';
+      },
+    });
+  }
+
+  retryPersonalItemDataLoad() {
+    if (!this.showPersonalItemData || this.personalSaveInFlight) return;
+    this.loadPersonalItemData();
+  }
+
+  setPersonalItemCategory(rowKey: string, value: unknown) {
+    if (!this.canChangePersonalItemData) return;
+    const category = typeof value === 'string' ? value.trim().slice(0, 200) : '';
+    const row = this.getOrCreatePersonalItemRow(rowKey);
+    if (category) row.category = category;
+    else delete row.category;
+    this.compactPersonalItemRow(rowKey);
+    this.queuePersonalItemRowSave(rowKey);
+    this.applyFilter(false);
+  }
+
+  setPersonalItemNote(rowKey: string, value: unknown) {
+    if (!this.canChangePersonalItemData) return;
+    const note = typeof value === 'string' ? value.replace(/\r\n?/g, '\n').slice(0, 10_000) : '';
+    const row = this.getOrCreatePersonalItemRow(rowKey);
+    if (note) row.note = note;
+    else delete row.note;
+    this.compactPersonalItemRow(rowKey);
+    this.queuePersonalItemRowSave(rowKey);
+    this.applyFilter(false);
+  }
+
+  addPersonalItemTagToRow(rowKey: string, event: Event) {
+    if (!this.canChangePersonalItemData) return;
+    const select = event.target as HTMLSelectElement;
+    const tag = select.value.trim();
+    select.value = '';
+    if (!tag || !this.personalItemTags.some((entry) => entry.label === tag)) return;
+    const row = this.getOrCreatePersonalItemRow(rowKey);
+    const tags = row.tags || [];
+    if (!tags.includes(tag)) row.tags = [...tags, tag];
+    this.queuePersonalItemRowSave(rowKey);
+    this.applyFilter(false);
+  }
+
+  removePersonalItemTagFromRow(rowKey: string, tag: string) {
+    if (!this.canChangePersonalItemData) return;
+    const row = this.personalItemData[rowKey];
+    if (!row?.tags) return;
+    row.tags = row.tags.filter((entry) => entry !== tag);
+    if (!row.tags.length) delete row.tags;
+    this.compactPersonalItemRow(rowKey);
+    this.queuePersonalItemRowSave(rowKey);
+    this.applyFilter(false);
+  }
+
+  availablePersonalTagsForRow(rowKey: string): PersonalItemTagConfig[] {
+    const selected = new Set(this.personalItemData[rowKey]?.tags || []);
+    return this.personalItemTags.filter((tag) => !selected.has(tag.label));
+  }
+
+  getPersonalTagColor(label: string): string {
+    return this.personalItemTags.find((tag) => tag.label === label)?.color || '#6c757d';
+  }
+
+  flushPersonalItemDataSave() {
+    this.clearPersonalSaveTimeout();
+    this.saveNextPersonalItemRow();
+  }
+
+  retryPersonalItemDataSave() {
+    if (!this.canEditPersonalItemData || !this.pendingPersonalRowUpdates.size) return;
+    this.personalDataError = '';
+    this.personalDataSaveState = 'pending';
+    this.clearPersonalSaveTimeout();
+    this.saveNextPersonalItemRow();
+  }
+
+  private queuePersonalItemRowSave(rowKey: string) {
+    if (!this.canChangePersonalItemData) return;
+    const normalizedRow = this.normalizePersonalItemRowData({
+      [rowKey]: this.personalItemData[rowKey],
+    })[rowKey];
+    this.pendingPersonalRowUpdates.set(rowKey, {
+      version: ++this.personalRowUpdateVersion,
+      rowData: normalizedRow || null,
+      perspective: this.getPerspectiveForViewerRequests(),
+    });
+    this.personalDataSaveState = 'pending';
+    this.personalDataError = '';
+    this.clearPersonalSaveTimeout();
+    this.personalSaveTimeout = setTimeout(() => {
+      this.personalSaveTimeout = null;
+      this.saveNextPersonalItemRow();
+    }, this.personalSaveDebounceMs);
+  }
+
+  private saveNextPersonalItemRow() {
+    if (!this.canEditPersonalItemData || this.personalSaveInFlight) return;
+    const nextUpdate = this.pendingPersonalRowUpdates.entries().next().value as
+      | [string, PendingPersonalRowUpdate]
+      | undefined;
+    if (!nextUpdate) {
+      this.personalDataSaveState = 'saved';
+      this.resolvePersonalSaveWaiters(true);
+      return;
+    }
+
+    const [rowKey, update] = nextUpdate;
+    const saveSessionIdentity = this.personalDataSessionIdentity;
+    const saveSessionVersion = this.personalDataSessionVersion;
+    if (!saveSessionIdentity) return;
+    this.personalSaveInFlight = true;
+    this.personalDataSaveState = 'saving';
+    this.api
+      .patchViewItemPreferenceRow(this.acpId, rowKey, update.rowData, update.perspective)
+      .pipe(
+        finalize(() => {
+          if (
+            this.personalDataSessionIdentity !== saveSessionIdentity ||
+            this.personalDataSessionVersion !== saveSessionVersion
+          ) {
+            return;
+          }
+          this.personalSaveInFlight = false;
+          if (this.personalDataSaveState === 'error') {
+            this.resolvePersonalSaveWaiters(false);
+          } else if (this.pendingPersonalRowUpdates.size) {
+            this.saveNextPersonalItemRow();
+          } else {
+            this.personalDataSaveState = 'saved';
+            this.resolvePersonalSaveWaiters(true);
+          }
+        }),
+      )
+      .subscribe({
+        next: () => {
+          if (
+            this.personalDataSessionIdentity !== saveSessionIdentity ||
+            this.personalDataSessionVersion !== saveSessionVersion
+          ) {
+            return;
+          }
+          const current = this.pendingPersonalRowUpdates.get(rowKey);
+          if (current?.version === update.version) {
+            this.pendingPersonalRowUpdates.delete(rowKey);
+          }
+        },
+        error: (error) => {
+          if (
+            this.personalDataSessionIdentity !== saveSessionIdentity ||
+            this.personalDataSessionVersion !== saveSessionVersion
+          ) {
+            return;
+          }
+          console.error('Failed to save personal item working data', error);
+          this.personalDataSaveState = 'error';
+          this.personalDataError =
+            'Persönliche Änderungen konnten nicht gespeichert werden. Bitte erneut versuchen.';
+        },
+      });
+  }
+
+  private syncPersonalItemDataSession() {
+    const nextIdentity = this.enablePersonalItemData
+      ? this.resolvePersonalItemDataSessionIdentity()
+      : null;
+    if (nextIdentity === this.personalDataSessionIdentity) {
+      if (nextIdentity && this.personalDataLoadState === 'idle') {
+        this.loadPersonalItemData(nextIdentity);
+      }
+      return;
+    }
+
+    const previousIdentity = this.personalDataSessionIdentity;
+    if (previousIdentity && !nextIdentity) {
+      this.suspendPendingPersonalSession(previousIdentity);
+    } else if (nextIdentity && nextIdentity !== previousIdentity) {
+      this.discardPendingPersonalSessionUnlessOwnedBy(nextIdentity);
+    }
+
+    this.resetPersonalItemDataSession();
+    this.personalDataSessionIdentity = nextIdentity;
+    if (nextIdentity) {
+      this.loadPersonalItemData(nextIdentity);
+    }
+  }
+
+  private resetPersonalItemDataSession() {
+    this.personalDataSessionIdentity = null;
+    this.personalDataSessionVersion += 1;
+    this.clearPersonalSaveTimeout();
+    this.personalItemData = {};
+    this.personalColumnFilters = {};
+    this.personalDataLoadState = 'idle';
+    this.personalDataSaveState = 'idle';
+    this.personalDataError = '';
+    this.personalSaveInFlight = false;
+    this.pendingPersonalRowUpdates.clear();
+    this.resolvePersonalSaveWaiters(false);
+    this.applyFilter(false);
+  }
+
+  private suspendPendingPersonalSession(identity: string) {
+    if (!this.pendingPersonalRowUpdates.size) return;
+    const snapshot: SuspendedPersonalSession = {
+      identity,
+      updates: Array.from(this.pendingPersonalRowUpdates.entries()).map(([rowKey, update]) => [
+        rowKey,
+        {
+          version: update.version,
+          rowData: update.rowData ? structuredClone(update.rowData) : null,
+          perspective: update.perspective,
+        },
+      ]),
+    };
+    this.pendingPersonalSessionStorage.set(
+      this.personalPendingStorageKey(),
+      JSON.stringify(snapshot),
+    );
+  }
+
+  private restorePendingPersonalSession(identity: string) {
+    const snapshot = this.readPendingPersonalSession();
+    if (!snapshot) return;
+    if (snapshot.identity !== identity) {
+      this.removePendingPersonalSession();
+      return;
+    }
+
+    this.pendingPersonalRowUpdates.clear();
+    for (const [rowKey, update] of snapshot.updates) {
+      this.pendingPersonalRowUpdates.set(rowKey, update);
+      this.personalRowUpdateVersion = Math.max(this.personalRowUpdateVersion, update.version);
+      if (update.rowData) {
+        this.personalItemData[rowKey] = structuredClone(update.rowData);
+      } else {
+        delete this.personalItemData[rowKey];
+      }
+    }
+    this.removePendingPersonalSession();
+    if (this.pendingPersonalRowUpdates.size) {
+      this.personalDataSaveState = 'pending';
+      this.personalDataError = '';
+      this.clearPersonalSaveTimeout();
+      this.personalSaveTimeout = setTimeout(() => {
+        this.personalSaveTimeout = null;
+        this.saveNextPersonalItemRow();
+      }, this.personalSaveDebounceMs);
+    }
+  }
+
+  private discardPendingPersonalSessionUnlessOwnedBy(identity: string) {
+    const snapshot = this.readPendingPersonalSession();
+    if (snapshot && snapshot.identity !== identity) {
+      this.removePendingPersonalSession();
+    }
+  }
+
+  private readPendingPersonalSession(): SuspendedPersonalSession | null {
+    const raw = this.pendingPersonalSessionStorage.get(this.personalPendingStorageKey());
+    if (!raw) return null;
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<SuspendedPersonalSession>;
+      if (typeof parsed.identity !== 'string' || !Array.isArray(parsed.updates)) {
+        throw new Error('Invalid pending personal session');
+      }
+      const updates: Array<[string, PendingPersonalRowUpdate]> = [];
+      for (const entry of parsed.updates) {
+        if (!Array.isArray(entry) || entry.length !== 2 || typeof entry[0] !== 'string') continue;
+        const rawUpdate = entry[1] as Partial<PendingPersonalRowUpdate> | null;
+        if (!rawUpdate || !Number.isFinite(rawUpdate.version)) continue;
+        const rowData =
+          rawUpdate.rowData === null
+            ? null
+            : this.normalizePersonalItemRowData({ [entry[0]]: rawUpdate.rowData })[entry[0]] ||
+              null;
+        const perspective =
+          rawUpdate.perspective === 'editor' || rawUpdate.perspective === 'read-only'
+            ? rawUpdate.perspective
+            : 'read-only';
+        updates.push([entry[0], { version: Number(rawUpdate.version), rowData, perspective }]);
+      }
+      return { identity: parsed.identity, updates };
+    } catch {
+      this.removePendingPersonalSession();
+      return null;
+    }
+  }
+
+  private removePendingPersonalSession() {
+    this.pendingPersonalSessionStorage.remove(this.personalPendingStorageKey());
+  }
+
+  private personalPendingStorageKey(): string {
+    return `cp_item_explorer_pending_personal:${this.acpId}`;
+  }
+
+  private resolvePersonalItemDataSessionIdentity(): string | null {
+    return this.pendingPersonalSessionStorage.resolveIdentityFromToken(this.authService.getToken());
+  }
+
+  private flushPersonalItemDataSaveAndWait(): Promise<boolean> {
+    if (!this.hasPendingPersonalItemDataChanges()) {
+      return Promise.resolve(true);
+    }
+    if (!this.canEditPersonalItemData) {
+      return Promise.resolve(false);
+    }
+
+    const result = new Promise<boolean>((resolve) => {
+      this.personalSaveWaiters.push(resolve);
+    });
+    this.personalDataError = '';
+    if (this.pendingPersonalRowUpdates.size) {
+      this.personalDataSaveState = 'pending';
+    }
+    this.clearPersonalSaveTimeout();
+    this.saveNextPersonalItemRow();
+    return result;
+  }
+
+  private hasPendingPersonalItemDataChanges(): boolean {
+    return (
+      this.pendingPersonalRowUpdates.size > 0 ||
+      this.personalSaveInFlight ||
+      this.personalSaveTimeout !== null ||
+      this.personalDataSaveState === 'error'
+    );
+  }
+
+  private resolvePersonalSaveWaiters(saved: boolean) {
+    const waiters = this.personalSaveWaiters;
+    this.personalSaveWaiters = [];
+    waiters.forEach((resolve) => resolve(saved));
+  }
+
+  private clearPersonalSaveTimeout() {
+    if (!this.personalSaveTimeout) return;
+    clearTimeout(this.personalSaveTimeout);
+    this.personalSaveTimeout = null;
+  }
+
+  private getOrCreatePersonalItemRow(rowKey: string): PersonalItemRowData {
+    if (!this.personalItemData[rowKey]) this.personalItemData[rowKey] = {};
+    return this.personalItemData[rowKey];
+  }
+
+  private compactPersonalItemRow(rowKey: string) {
+    const row = this.personalItemData[rowKey];
+    if (row && !row.category && !row.note && !row.tags?.length) {
+      delete this.personalItemData[rowKey];
+    }
+  }
+
+  private normalizePersonalItemRowData(raw: unknown): Record<string, PersonalItemRowData> {
+    if (!this.isRecord(raw)) return {};
+    const normalized: Record<string, PersonalItemRowData> = {};
+    for (const [rawRowKey, rawValue] of Object.entries(raw)) {
+      const rowKey = rawRowKey.trim();
+      if (!rowKey || !this.isRecord(rawValue)) continue;
+      const category =
+        typeof rawValue['category'] === 'string' ? rawValue['category'].trim().slice(0, 200) : '';
+      const note =
+        typeof rawValue['note'] === 'string'
+          ? rawValue['note'].replace(/\r\n?/g, '\n').slice(0, 10_000)
+          : '';
+      const tags = this.normalizeStringList(rawValue['tags']).slice(0, 50);
+      const row: PersonalItemRowData = {};
+      if (category) row.category = category;
+      if (tags.length) row.tags = tags;
+      if (note) row.note = note;
+      if (Object.keys(row).length) normalized[rowKey] = row;
+    }
+    return normalized;
+  }
+
+  private normalizePersonalItemTagConfig(raw: unknown): PersonalItemTagConfig[] {
+    if (!Array.isArray(raw)) return [];
+    const seen = new Set<string>();
+    return raw
+      .map((entry) => {
+        const record = this.isRecord(entry) ? entry : {};
+        const label = typeof record['label'] === 'string' ? record['label'].trim() : '';
+        const colorRaw = typeof record['color'] === 'string' ? record['color'].trim() : '';
+        return {
+          label,
+          color: /^#[0-9a-f]{6}$/i.test(colorRaw) ? colorRaw : '#3498db',
+        };
+      })
+      .filter((tag) => {
+        if (!tag.label || seen.has(tag.label)) return false;
+        seen.add(tag.label);
+        return true;
+      })
+      .slice(0, 50);
+  }
+
+  private normalizeStringList(raw: unknown): string[] {
+    if (!Array.isArray(raw)) return [];
+    return Array.from(
+      new Set(
+        raw
+          .filter((value): value is string => typeof value === 'string')
+          .map((value) => value.trim())
+          .filter(Boolean),
+      ),
+    );
+  }
+
+  // --- Shared ACP tags ---
   addItemTag(uuid: string, event: Event) {
     if (!this.canEditExplorer) return;
     const tag = (event.target as HTMLSelectElement).value;
@@ -4994,12 +5632,15 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   }
 
   private buildUiPreferences(): Record<string, unknown> {
+    const sharedColumnFilters = Object.fromEntries(
+      Object.entries(this.columnFilters).filter(([key]) => !this.isPersonalColumnFilterKey(key)),
+    );
     return {
       filterText: this.filterText,
       sortField: this.sortField,
       sortIsMeta: this.sortIsMeta,
       sortDir: this.sortDir,
-      columnFilters: this.columnFilters,
+      columnFilters: sharedColumnFilters,
     };
   }
 
@@ -5027,12 +5668,15 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     this.sortDir = sortDir === 'desc' ? 'desc' : 'asc';
     this.columnFilters = this.isRecord(columnFilters)
       ? Object.fromEntries(
-          Object.entries(columnFilters).map(([key, value]) => [
-            key,
-            typeof value === 'string' ? value : '',
-          ]),
+          Object.entries(columnFilters)
+            .filter(([key]) => !this.isPersonalColumnFilterKey(key))
+            .map(([key, value]) => [key, typeof value === 'string' ? value : '']),
         )
       : {};
+  }
+
+  private isPersonalColumnFilterKey(key: string): boolean {
+    return key === 'personalCategory' || key === 'personalTags' || key === 'personalNote';
   }
 
   private saveUiPreferences() {

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -299,6 +299,20 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
         (cancelled)="closeDiscardDraftDialog()"
       />
 
+      <app-confirm-dialog
+        [open]="showDiscardPersonalItemDataDialog"
+        title="Persönliche Änderungen verwerfen"
+        message="Die nicht gespeicherten persönlichen Änderungen werden verworfen."
+        [details]="[
+          'Nicht gespeicherte Kategorien, Markierungen und Notizen gehen verloren.',
+          'Anschließend wird der zuletzt gespeicherte Stand neu geladen.',
+        ]"
+        confirmLabel="Änderungen verwerfen"
+        confirmVariant="danger"
+        (confirmed)="confirmDiscardPersonalItemDataChanges()"
+        (cancelled)="closeDiscardPersonalItemDataDialog()"
+      />
+
       @if (showLeaveWithChangesDialog) {
         <div
           class="overlay-backdrop"
@@ -418,6 +432,13 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                     (click)="retryPersonalItemDataSave()"
                   >
                     Erneut speichern
+                  </button>
+                  <button
+                    class="btn btn-outline btn-sm"
+                    type="button"
+                    (click)="openDiscardPersonalItemDataDialog()"
+                  >
+                    Änderungen verwerfen
                   </button>
                 } @else if (personalDataSaveState === 'saved') {
                   Persönliche Änderungen gespeichert
@@ -2752,6 +2773,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   personalDataLoadState: PersonalDataLoadState = 'idle';
   personalDataSaveState: PersonalDataSaveState = 'idle';
   personalDataError = '';
+  showDiscardPersonalItemDataDialog = false;
   private readonly personalPreferenceViewId = 'item-explorer';
   private readonly personalSaveDebounceMs = 350;
   private personalSaveTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -4925,6 +4947,51 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     this.saveNextPersonalItemRow();
   }
 
+  openDiscardPersonalItemDataDialog() {
+    if (
+      this.personalDataSaveState !== 'error' ||
+      this.personalSaveInFlight ||
+      !this.pendingPersonalRowUpdates.size
+    ) {
+      return;
+    }
+    this.rememberFocusBeforeOverlay();
+    this.showDiscardPersonalItemDataDialog = true;
+  }
+
+  closeDiscardPersonalItemDataDialog() {
+    this.showDiscardPersonalItemDataDialog = false;
+    this.restoreFocusAfterOverlayClose();
+  }
+
+  confirmDiscardPersonalItemDataChanges() {
+    if (
+      this.personalDataSaveState !== 'error' ||
+      this.personalSaveInFlight ||
+      !this.pendingPersonalRowUpdates.size
+    ) {
+      this.closeDiscardPersonalItemDataDialog();
+      return;
+    }
+
+    const sessionIdentity = this.personalDataSessionIdentity;
+    const sessionVersion = this.personalDataSessionVersion;
+    this.showDiscardPersonalItemDataDialog = false;
+    this.clearPersonalSaveTimeout();
+    this.pendingPersonalRowUpdates.clear();
+    this.removePendingPersonalSession();
+    this.personalItemData = {};
+    this.personalDataSaveState = 'idle';
+    this.personalDataError = '';
+    this.resolvePersonalSaveWaiters(false);
+    this.applyFilter(false);
+
+    if (sessionIdentity) {
+      this.loadPersonalItemData(sessionIdentity, sessionVersion);
+    }
+    this.restoreFocusAfterOverlayClose();
+  }
+
   private queuePersonalItemRowSave(rowKey: string) {
     if (!this.canChangePersonalItemData) return;
     const normalizedRow = this.normalizePersonalItemRowData({
@@ -5044,6 +5111,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     this.personalDataLoadState = 'idle';
     this.personalDataSaveState = 'idle';
     this.personalDataError = '';
+    this.showDiscardPersonalItemDataDialog = false;
     this.personalSaveInFlight = false;
     this.pendingPersonalRowUpdates.clear();
     this.resolvePersonalSaveWaiters(false);
@@ -6463,6 +6531,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       this.showHistoryOverlay ||
       this.showSavePreviewDialog ||
       this.showDiscardDraftDialog ||
+      this.showDiscardPersonalItemDataDialog ||
       this.showClearEmpiricalDifficultiesDialog ||
       this.showLeaveWithChangesDialog
     );
@@ -6479,6 +6548,10 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     }
     if (this.showDiscardDraftDialog) {
       this.closeDiscardDraftDialog();
+      return true;
+    }
+    if (this.showDiscardPersonalItemDataDialog) {
+      this.closeDiscardPersonalItemDataDialog();
       return true;
     }
     if (this.showSavePreviewDialog) {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -316,3 +316,119 @@ a:hover {
   gap: 12px;
   margin-bottom: 16px;
 }
+
+/* Item Explorer tags and personal row data. Kept global so the already large Explorer
+   component stylesheet stays below Angular's per-component budget. */
+app-item-explorer {
+  .item-count {
+    color: var(--color-text-secondary);
+    font-size: 0.85rem;
+  }
+
+  .tags-cell {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+  }
+
+  .tag-badge {
+    cursor: pointer;
+    font-size: 0.7rem;
+
+    &:hover {
+      opacity: 0.7;
+    }
+  }
+
+  .tag-select {
+    max-width: 80px;
+    padding: 2px 4px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: white;
+    font-size: 0.75rem;
+  }
+
+  .tag-add-container {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .tag-input-inline {
+    width: 60px;
+    padding: 2px 6px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-size: 0.75rem;
+    transition: width 0.2s;
+
+    &:focus {
+      width: 100px;
+      outline: none;
+      border-color: var(--color-primary-light);
+    }
+  }
+
+  .personal-data-cell {
+    min-width: 150px;
+    max-width: 260px !important;
+    white-space: normal !important;
+    overflow: visible !important;
+  }
+
+  .personal-data-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--color-text-secondary);
+    font-size: 0.78rem;
+  }
+
+  .personal-data-error {
+    color: var(--color-danger, #b42318);
+  }
+
+  .personal-category-select,
+  .personal-note-input {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    font: inherit;
+  }
+
+  .personal-category-select {
+    padding: 5px 7px;
+  }
+
+  .personal-note-input {
+    min-width: 190px;
+    padding: 6px 8px;
+    resize: vertical;
+    line-height: 1.3;
+  }
+
+  .personal-tag-list {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .personal-tag-badge {
+    border: 0;
+    border-radius: 999px;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.7rem;
+    padding: 3px 8px;
+
+    &:hover {
+      filter: brightness(0.9);
+    }
+  }
+}


### PR DESCRIPTION
## Zusammenfassung

Implementiert persönliche Arbeitsdaten pro Item-Zeile im Item-Explorer. Nutzer können je Item beziehungsweise Item/Sub-ID eine Kategorie, Tags und eine Plain-Text-Notiz pflegen. Die Daten sind an die jeweilige Nutzer- oder Credential-Identität gebunden und bleiben nach Reload oder erneutem Login erhalten.

## Änderungen

- Credential-spezifisches Datenmodell und Migrationen für persönliche Item-Präferenzen
- Atomare Backend-API zum Lesen, Speichern und Löschen persönlicher Arbeitsdaten
- Konfigurierbare Kategoriebezeichnung und -werte sowie Tag-Bezeichnung und -farbe im ACP
- Persönliche Kategorie-, Tag- und Notizfelder im Item-Explorer
- Autosave, Session-Wiederherstellung und Schutz vor konkurrierenden oder verspäteten Requests
- Konsistentes Verhalten für OIDC-, Credential-, Manager- und Read-only-Zugänge
- Ergänzte Architektur- und Feature-Dokumentation
- Regressionstests für Identitätstrennung, Migrationen, Autosave und Race Conditions

## Auswirkung

Persönliche Markierungen und Notizen sind nur für die jeweilige Identität sichtbar. Bestehende ACP-weite Tags und veröffentlichte Inhalte bleiben davon getrennt.

## Validierung

- Backend: 41 Testsuites, 496 Tests bestanden
- Frontend: 26 Testdateien, 332 Tests bestanden

Closes #36