### PR TITLE
Add personal Item Explorer data export

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -11,9 +11,15 @@ import {
   getGeoGebraBundleCurrentDir,
 } from "./admin/geogebra-bundle.util";
 
+const MAX_JSON_BODY_SIZE = "6mb";
+
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   const isProduction = process.env.NODE_ENV === "production";
+
+  // The personal Item Explorer export accepts up to 10,000 ordered row keys.
+  // The validated worst case is slightly above 5 MB (10,000 × 500 chars).
+  app.useBodyParser("json", { limit: MAX_JSON_BODY_SIZE });
 
   const geoGebraAssetsDir = getGeoGebraBundleCurrentDir();
   await fs.mkdir(geoGebraAssetsDir, { recursive: true });

--- a/backend/src/views/views.controller.spec.ts
+++ b/backend/src/views/views.controller.spec.ts
@@ -21,6 +21,7 @@ describe("ViewsController", () => {
           enableItemList: true,
           enableSequenceNavigation: true,
           persistUserPreferences: true,
+          enablePersonalItemData: true,
         },
       }),
       getAcpIndex: jest.fn().mockResolvedValue({ packageId: "pkg-1" }),
@@ -35,6 +36,9 @@ describe("ViewsController", () => {
       patchPersonalItemPreferenceRow: jest.fn().mockResolvedValue({
         rowData: { "uuid::1": { note: "mine" } },
       }),
+      exportPersonalItemDataXlsx: jest
+        .fn()
+        .mockResolvedValue(Buffer.from("personal-xlsx")),
       getTaskSequence: jest
         .fn()
         .mockResolvedValue({ id: "seq-1", units: [{ id: "unit-1" }] }),
@@ -349,6 +353,52 @@ describe("ViewsController", () => {
       "item-explorer",
       false,
     );
+  });
+
+  it("exports the caller's personal data using the requested Explorer order", async () => {
+    const res = { setHeader: jest.fn(), send: jest.fn() } as any;
+
+    await controller.exportPersonalItemDataXlsx(
+      "acp-1",
+      {
+        rowKeys: ["uuid-2::1", "uuid-1::1"],
+        perspective: "editor",
+      },
+      { user: { sub: "u-1" }, acpAccessLevel: "MANAGER" },
+      res,
+    );
+
+    expect(viewsService.exportPersonalItemDataXlsx).toHaveBeenCalledWith(
+      "acp-1",
+      { sub: "u-1" },
+      ["uuid-2::1", "uuid-1::1"],
+      true,
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Content-Type",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Content-Disposition",
+      'attachment; filename="personal-item-data-acp-1.xlsx"',
+    );
+    expect(res.send).toHaveBeenCalledWith(Buffer.from("personal-xlsx"));
+  });
+
+  it("blocks personal data exports when the feature is disabled", async () => {
+    viewsService.getAcpStartPage.mockResolvedValueOnce({
+      featureConfig: { enablePersonalItemData: false },
+    });
+
+    await expect(
+      controller.exportPersonalItemDataXlsx(
+        "acp-1",
+        { rowKeys: [] },
+        { user: { sub: "u-1" } },
+        {} as any,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+    expect(viewsService.exportPersonalItemDataXlsx).not.toHaveBeenCalled();
   });
 
   it.each([true, false])(

--- a/backend/src/views/views.controller.spec.ts
+++ b/backend/src/views/views.controller.spec.ts
@@ -386,8 +386,11 @@ describe("ViewsController", () => {
   });
 
   it("blocks personal data exports when the feature is disabled", async () => {
-    viewsService.getAcpStartPage.mockResolvedValueOnce({
-      featureConfig: { enablePersonalItemData: false },
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: {
+        enableItemList: true,
+        enablePersonalItemData: false,
+      },
     });
 
     await expect(
@@ -399,6 +402,49 @@ describe("ViewsController", () => {
       ),
     ).rejects.toThrow(ForbiddenException);
     expect(viewsService.exportPersonalItemDataXlsx).not.toHaveBeenCalled();
+  });
+
+  it("blocks personal data exports when the item list is disabled", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: {
+        enableItemList: false,
+        enablePersonalItemData: true,
+      },
+    });
+
+    await expect(
+      controller.exportPersonalItemDataXlsx(
+        "acp-1",
+        { rowKeys: ["uuid::1"] },
+        { user: { sub: "u-1" }, acpAccessLevel: "READ_ONLY" },
+        {} as any,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+    expect(viewsService.exportPersonalItemDataXlsx).not.toHaveBeenCalled();
+  });
+
+  it("allows managers to export when the public item list is disabled", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: {
+        enableItemList: false,
+        enablePersonalItemData: true,
+      },
+    });
+    const res = { setHeader: jest.fn(), send: jest.fn() } as any;
+
+    await controller.exportPersonalItemDataXlsx(
+      "acp-1",
+      { rowKeys: ["uuid::1"] },
+      { user: { sub: "manager-1" }, acpAccessLevel: "MANAGER" },
+      res,
+    );
+
+    expect(viewsService.exportPersonalItemDataXlsx).toHaveBeenCalledWith(
+      "acp-1",
+      { sub: "manager-1" },
+      ["uuid::1"],
+      false,
+    );
   });
 
   it.each([true, false])(

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -102,17 +102,16 @@ class PatchPersonalItemRowDto {
 }
 
 class ExportPersonalItemDataDto {
-  @ApiPropertyOptional({
+  @ApiProperty({
     description:
       "Stable item row keys in the current filtered and sorted list order",
     type: [String],
     maxItems: 10_000,
   })
-  @IsOptional()
   @IsArray()
   @ArrayMaxSize(10_000)
   @IsString({ each: true })
-  rowKeys?: string[];
+  rowKeys!: string[];
 
   @ApiPropertyOptional({
     description: "Explorer state used to render the exported item rows",
@@ -316,6 +315,9 @@ export class ViewsController {
     @Request() req: any,
     @Res() res: Response,
   ) {
+    if (!(await this.canUseFeature(acpId, req, "enableItemList", true))) {
+      throw new ForbiddenException("Item list is not enabled for this ACP");
+    }
     if (!(await this.isPersonalItemDataEnabled(acpId))) {
       throw new ForbiddenException(
         "Personal item data is not enabled for this ACP",

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -6,6 +6,7 @@ import {
   Get,
   Param,
   Patch,
+  Post,
   Put,
   Query,
   Request,
@@ -19,7 +20,14 @@ import {
   ApiPropertyOptional,
   ApiTags,
 } from "@nestjs/swagger";
-import { IsIn, IsObject, IsOptional, IsString } from "class-validator";
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsIn,
+  IsObject,
+  IsOptional,
+  IsString,
+} from "class-validator";
 import { Response } from "express";
 import { ViewsService } from "./views.service";
 import { AcpAccessGuard } from "../auth/guards/acp-access.guard";
@@ -85,6 +93,29 @@ class PatchPersonalItemRowDto {
 
   @ApiPropertyOptional({
     description: "Explorer state used to render the item row",
+    enum: ["editor", "read-only"],
+    default: "read-only",
+  })
+  @IsOptional()
+  @IsIn(["editor", "read-only"])
+  perspective?: "editor" | "read-only";
+}
+
+class ExportPersonalItemDataDto {
+  @ApiPropertyOptional({
+    description:
+      "Stable item row keys in the current filtered and sorted list order",
+    type: [String],
+    maxItems: 10_000,
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(10_000)
+  @IsString({ each: true })
+  rowKeys?: string[];
+
+  @ApiPropertyOptional({
+    description: "Explorer state used to render the exported item rows",
     enum: ["editor", "read-only"],
     default: "read-only",
   })
@@ -273,6 +304,43 @@ export class ViewsController {
       (req?.acpAccessLevel === "MANAGER" || req?.acpAccessLevel === "ADMIN") &&
         dto.perspective === "editor",
     );
+  }
+
+  @Post("acp/:acpId/items/preferences/export.xlsx")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "Export personal Item Explorer working data" })
+  @ApiBody({ type: ExportPersonalItemDataDto })
+  async exportPersonalItemDataXlsx(
+    @Param("acpId") acpId: string,
+    @Body() dto: ExportPersonalItemDataDto,
+    @Request() req: any,
+    @Res() res: Response,
+  ) {
+    if (!(await this.isPersonalItemDataEnabled(acpId))) {
+      throw new ForbiddenException(
+        "Personal item data is not enabled for this ACP",
+      );
+    }
+
+    const canEditExplorerState =
+      (req?.acpAccessLevel === "MANAGER" || req?.acpAccessLevel === "ADMIN") &&
+      dto.perspective === "editor";
+    const buffer = await this.viewsService.exportPersonalItemDataXlsx(
+      acpId,
+      req?.user,
+      dto.rowKeys,
+      canEditExplorerState,
+    );
+
+    res.setHeader(
+      "Content-Type",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    );
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="personal-item-data-${acpId}.xlsx"`,
+    );
+    res.send(buffer);
   }
 
   @Get("acp/:acpId/sequences")

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -25,7 +25,10 @@ describe("ViewsService", () => {
     query: jest.Mock;
   };
   let itemExplorerStateService: { getStateForViewer: jest.Mock };
-  let unitParserService: { getItemRowKeysFromFiles: jest.Mock };
+  let unitParserService: {
+    getItemRowKeysFromFiles: jest.Mock;
+    getItemListFromFiles: jest.Mock;
+  };
 
   beforeEach(async () => {
     acpRepository = { findOne: jest.fn() };
@@ -47,6 +50,7 @@ describe("ViewsService", () => {
       getItemRowKeysFromFiles: jest
         .fn()
         .mockResolvedValue(new Set(["uuid-1::1", "uuid-2::1"])),
+      getItemListFromFiles: jest.fn().mockResolvedValue({ items: [] }),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -246,6 +250,105 @@ describe("ViewsService", () => {
       ),
     ).rejects.toThrow(UnauthorizedException);
     expect(itemPreferenceRepository.query).not.toHaveBeenCalled();
+  });
+
+  it("exports only the current user's personal data in requested list order", async () => {
+    itemPreferenceRepository.findOne.mockResolvedValue({
+      preferences: {
+        rowData: {
+          "uuid-1::1": {
+            category: "II",
+            tags: ["Prüfen"],
+            note: "Eigene Notiz",
+          },
+        },
+      },
+    });
+    accessConfigRepository.findOne.mockResolvedValue({
+      featureConfig: {
+        personalItemTags: [{ label: "Prüfen", color: "#ff0000" }],
+      },
+    });
+    itemExplorerStateService.getStateForViewer.mockResolvedValue({
+      activeState: { itemProperties: { "uuid-1::1": { draft: true } } },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          itemId: "item-1",
+          uuid: "uuid-1",
+          rowKey: "uuid-1::1",
+          unitId: "unit-1",
+          unitLabel: "Aufgabe 1",
+          description: "",
+          variableId: "var-1",
+          metadata: {},
+          empiricalDifficulty: 0.25,
+        },
+        {
+          itemId: "item-2",
+          uuid: "uuid-2",
+          rowKey: "uuid-2::1",
+          unitId: "unit-1",
+          unitLabel: "Aufgabe 1",
+          description: "",
+          variableId: "var-2",
+          metadata: {},
+          empiricalDifficulty: 0.75,
+        },
+      ],
+    });
+
+    const buffer = await service.exportPersonalItemDataXlsx(
+      "acp-1",
+      { sub: "user-1", type: "user" },
+      ["uuid-2::1", "removed-row", "uuid-1::1"],
+      true,
+    );
+
+    expect(itemPreferenceRepository.findOne).toHaveBeenCalledWith({
+      where: {
+        acpId: "acp-1",
+        viewId: "item-explorer",
+        userId: "user-1",
+      },
+    });
+    expect(itemExplorerStateService.getStateForViewer).toHaveBeenCalledWith(
+      "acp-1",
+      true,
+    );
+    expect(unitParserService.getItemListFromFiles).toHaveBeenCalledWith(
+      "acp-1",
+      { itemPropertiesOverride: { "uuid-1::1": { draft: true } } },
+    );
+
+    const ExcelJS = await import("exceljs");
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer as any);
+    const sheet = workbook.getWorksheet("Persönliche Itemdaten");
+    expect(sheet).toBeDefined();
+    expect(sheet!.getRow(1).values).toEqual([
+      undefined,
+      "Laufende Nummer",
+      "Unit-ID",
+      "Unit-Label",
+      "Item-ID",
+      "Item-UUID",
+      "Markierung/Farbe",
+      "Notiz",
+      "Kompetenzstufe",
+      "Empirische Itemschwierigkeit",
+      "Mittlere Aufgabenschwierigkeit",
+    ]);
+    expect(sheet!.getCell("A2").value).toBe(1);
+    expect(sheet!.getCell("E2").value).toBe("uuid-2");
+    expect(sheet!.getCell("F2").value).toBeNull();
+    expect(sheet!.getCell("J2").value).toBe(0.5);
+    expect(sheet!.getCell("A3").value).toBe(2);
+    expect(sheet!.getCell("E3").value).toBe("uuid-1");
+    expect(sheet!.getCell("F3").value).toBe("Prüfen (#ff0000)");
+    expect(sheet!.getCell("G3").value).toBe("Eigene Notiz");
+    expect(sheet!.getCell("H3").value).toBe("II");
   });
 
   it("does not fall back to an orphaned username for stable credentials", async () => {

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -351,6 +351,33 @@ describe("ViewsService", () => {
     expect(sheet!.getCell("H3").value).toBe("II");
   });
 
+  it("requires an explicit filtered and sorted row order for exports", async () => {
+    await expect(
+      service.exportPersonalItemDataXlsx(
+        "acp-1",
+        { sub: "user-1", type: "user" },
+        undefined as unknown as string[],
+      ),
+    ).rejects.toThrow(BadRequestException);
+    expect(unitParserService.getItemListFromFiles).not.toHaveBeenCalled();
+  });
+
+  it("limits personal data exports to 10,000 requested rows", async () => {
+    const rowKeys = Array.from(
+      { length: 10_001 },
+      (_, index) => `uuid-${index}`,
+    );
+
+    await expect(
+      service.exportPersonalItemDataXlsx(
+        "acp-1",
+        { sub: "user-1", type: "user" },
+        rowKeys,
+      ),
+    ).rejects.toThrow("At most 10000 item rows can be exported");
+    expect(unitParserService.getItemListFromFiles).not.toHaveBeenCalled();
+  });
+
   it("does not fall back to an orphaned username for stable credentials", async () => {
     itemPreferenceRepository.findOne.mockImplementation(async ({ where }) =>
       where.credentialId

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -21,13 +21,14 @@ import {
 } from "../acp/acp-index.utils";
 import { normalizeFeatureConfig } from "../acp/feature-config.utils";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
-import { UnitParserService } from "../files/unit-parser.service";
+import { UnitParserService, VomdItemData } from "../files/unit-parser.service";
 import {
   buildPatchPersonalItemPreferenceRowQuery,
   PreferenceIdentityColumn,
 } from "./personal-item-preferences.query";
 
 const MAX_PERSONAL_ITEM_ROWS = 10_000;
+const MAX_EXPORT_ROW_KEY_LENGTH = 500;
 
 export interface ItemPreferencesPayload {
   [key: string]: unknown;
@@ -495,6 +496,68 @@ export class ViewsService {
     };
   }
 
+  async exportPersonalItemDataXlsx(
+    acpId: string,
+    user: any,
+    rawRowKeys?: string[],
+    canEditExplorerState = false,
+  ): Promise<Buffer> {
+    const rowKeys = this.normalizeExportRowKeys(rawRowKeys);
+    const [preferences, explorerState, accessConfig] = await Promise.all([
+      this.getItemPreferences(acpId, user, "item-explorer"),
+      this.itemExplorerStateService.getStateForViewer(
+        acpId,
+        canEditExplorerState,
+      ),
+      this.accessConfigRepository.findOne({ where: { acpId } }),
+    ]);
+    const itemList = await this.unitParserService.getItemListFromFiles(acpId, {
+      itemPropertiesOverride: explorerState.activeState.itemProperties,
+    });
+    const itemsByRowKey = new Map(
+      itemList.items.map((item) => [item.rowKey, item] as const),
+    );
+    const items = rowKeys
+      ? rowKeys
+          .map((rowKey) => itemsByRowKey.get(rowKey))
+          .filter((item): item is VomdItemData => Boolean(item))
+      : itemList.items;
+    const meanDifficultyByUnit = this.calculateMeanDifficultyByUnit(
+      itemList.items,
+    );
+    const personalTagColors = this.getPersonalTagColors(
+      accessConfig?.featureConfig,
+    );
+
+    const rows = items.map((item, index) => {
+      const personalRow = preferences.rowData[item.rowKey] || {};
+      const tags = Array.isArray(personalRow.tags)
+        ? personalRow.tags.map((tag) => String(tag))
+        : [];
+
+      return {
+        sequenceNumber: index + 1,
+        unitId: item.unitId,
+        unitLabel: item.unitLabel,
+        itemId: item.itemId,
+        itemUuid: item.uuid,
+        markers: this.formatPersonalMarkers(tags, personalTagColors),
+        note: typeof personalRow.note === "string" ? personalRow.note : null,
+        competenceLevel:
+          typeof personalRow.category === "string"
+            ? personalRow.category
+            : null,
+        empiricalDifficulty:
+          item.empiricalDifficulty === undefined
+            ? null
+            : item.empiricalDifficulty,
+        meanTaskDifficulty: meanDifficultyByUnit.get(item.unitId) ?? null,
+      };
+    });
+
+    return this.buildPersonalItemDataXlsx(rows);
+  }
+
   private async upsertItemPreferences(
     acpId: string,
     viewId: string,
@@ -578,6 +641,146 @@ export class ViewsService {
   private normalizeViewId(viewId?: string): string {
     const normalized = (viewId || "").trim();
     return normalized.length > 0 ? normalized.slice(0, 120) : "item-list";
+  }
+
+  private normalizeExportRowKeys(rawRowKeys?: string[]): string[] | null {
+    if (rawRowKeys === undefined) {
+      return null;
+    }
+    if (
+      !Array.isArray(rawRowKeys) ||
+      rawRowKeys.length > MAX_PERSONAL_ITEM_ROWS
+    ) {
+      throw new BadRequestException(
+        `At most ${MAX_PERSONAL_ITEM_ROWS} item rows can be exported`,
+      );
+    }
+
+    const rowKeys: string[] = [];
+    const seen = new Set<string>();
+    for (const rawRowKey of rawRowKeys) {
+      if (typeof rawRowKey !== "string") {
+        throw new BadRequestException("Export row keys must be strings");
+      }
+      const rowKey = rawRowKey.trim();
+      if (!rowKey || rowKey.length > MAX_EXPORT_ROW_KEY_LENGTH) {
+        throw new BadRequestException("A valid export row key is required");
+      }
+      if (!seen.has(rowKey)) {
+        seen.add(rowKey);
+        rowKeys.push(rowKey);
+      }
+    }
+    return rowKeys;
+  }
+
+  private calculateMeanDifficultyByUnit(
+    items: VomdItemData[],
+  ): Map<string, number> {
+    const totals = new Map<string, { sum: number; count: number }>();
+    for (const item of items) {
+      if (
+        item.empiricalDifficulty === undefined ||
+        !Number.isFinite(item.empiricalDifficulty)
+      ) {
+        continue;
+      }
+      const total = totals.get(item.unitId) || { sum: 0, count: 0 };
+      total.sum += item.empiricalDifficulty;
+      total.count += 1;
+      totals.set(item.unitId, total);
+    }
+
+    return new Map(
+      Array.from(totals.entries()).map(([unitId, total]) => [
+        unitId,
+        total.sum / total.count,
+      ]),
+    );
+  }
+
+  private getPersonalTagColors(rawFeatureConfig: unknown): Map<string, string> {
+    const featureConfig = normalizeFeatureConfig(
+      this.isRecord(rawFeatureConfig) ? rawFeatureConfig : {},
+    ) as Record<string, unknown>;
+    const tags = Array.isArray(featureConfig.personalItemTags)
+      ? featureConfig.personalItemTags
+      : [];
+    const colors = new Map<string, string>();
+
+    for (const rawTag of tags) {
+      if (!this.isRecord(rawTag)) continue;
+      const label = this.normalizePlainText(rawTag.label, 100);
+      const color = this.normalizePlainText(rawTag.color, 100);
+      if (label && color) colors.set(label, color);
+    }
+    return colors;
+  }
+
+  private formatPersonalMarkers(
+    tags: string[],
+    tagColors: Map<string, string>,
+  ): string | null {
+    if (!tags.length) return null;
+    return tags
+      .map((tag) => {
+        const color = tagColors.get(tag);
+        return color ? `${tag} (${color})` : tag;
+      })
+      .join("; ");
+  }
+
+  private async buildPersonalItemDataXlsx(
+    rows: Array<Record<string, string | number | null>>,
+  ): Promise<Buffer> {
+    const ExcelJS = await import("exceljs");
+    const workbook = new ExcelJS.Workbook();
+    workbook.creator = "IQB ContentPool";
+    workbook.created = new Date();
+
+    const sheet = workbook.addWorksheet("Persönliche Itemdaten");
+    sheet.columns = [
+      { header: "Laufende Nummer", key: "sequenceNumber", width: 18 },
+      { header: "Unit-ID", key: "unitId", width: 22 },
+      { header: "Unit-Label", key: "unitLabel", width: 30 },
+      { header: "Item-ID", key: "itemId", width: 22 },
+      { header: "Item-UUID", key: "itemUuid", width: 38 },
+      { header: "Markierung/Farbe", key: "markers", width: 32 },
+      { header: "Notiz", key: "note", width: 50 },
+      { header: "Kompetenzstufe", key: "competenceLevel", width: 22 },
+      {
+        header: "Empirische Itemschwierigkeit",
+        key: "empiricalDifficulty",
+        width: 30,
+      },
+      {
+        header: "Mittlere Aufgabenschwierigkeit",
+        key: "meanTaskDifficulty",
+        width: 32,
+      },
+    ];
+    sheet.views = [{ state: "frozen", ySplit: 1 }];
+    sheet.autoFilter = { from: "A1", to: "J1" };
+
+    const headerRow = sheet.getRow(1);
+    headerRow.font = { bold: true, color: { argb: "FFFFFFFF" } };
+    headerRow.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: "FF1A5276" },
+    };
+
+    rows.forEach((row) => sheet.addRow(row));
+    sheet.getColumn("note").alignment = { vertical: "top", wrapText: true };
+    sheet.getColumn("markers").alignment = {
+      vertical: "top",
+      wrapText: true,
+    };
+    sheet.getColumn("empiricalDifficulty").numFmt = "0.############";
+    sheet.getColumn("meanTaskDifficulty").numFmt = "0.############";
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    return Buffer.from(buffer);
   }
 
   private resolvePreferenceIdentity(user: any): PreferenceIdentity | null {

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -499,7 +499,7 @@ export class ViewsService {
   async exportPersonalItemDataXlsx(
     acpId: string,
     user: any,
-    rawRowKeys?: string[],
+    rawRowKeys: string[],
     canEditExplorerState = false,
   ): Promise<Buffer> {
     const rowKeys = this.normalizeExportRowKeys(rawRowKeys);
@@ -518,10 +518,8 @@ export class ViewsService {
       itemList.items.map((item) => [item.rowKey, item] as const),
     );
     const items = rowKeys
-      ? rowKeys
-          .map((rowKey) => itemsByRowKey.get(rowKey))
-          .filter((item): item is VomdItemData => Boolean(item))
-      : itemList.items;
+      .map((rowKey) => itemsByRowKey.get(rowKey))
+      .filter((item): item is VomdItemData => Boolean(item));
     const meanDifficultyByUnit = this.calculateMeanDifficultyByUnit(
       itemList.items,
     );
@@ -643,10 +641,7 @@ export class ViewsService {
     return normalized.length > 0 ? normalized.slice(0, 120) : "item-list";
   }
 
-  private normalizeExportRowKeys(rawRowKeys?: string[]): string[] | null {
-    if (rawRowKeys === undefined) {
-      return null;
-    }
+  private normalizeExportRowKeys(rawRowKeys: unknown): string[] {
     if (
       !Array.isArray(rawRowKeys) ||
       rawRowKeys.length > MAX_PERSONAL_ITEM_ROWS

--- a/docs/features/item-explorer.md
+++ b/docs/features/item-explorer.md
@@ -195,6 +195,13 @@ preference record is additionally limited to 10,000 rows.
 The map is keyed by the stable row key, so partial-credit rows of the same item keep independent
 categories, markers, and notes.
 
+Authenticated users can export their currently filtered and sorted Explorer list as XLSX. The
+backend resolves only the caller's own personal preference record and combines it with the active
+Explorer perspective. The export includes the visible order, unit and item identifiers, configured
+marker colors, note, competence level, empirical item difficulty, and the mean empirical difficulty
+of the unit when at least one value is available. Missing personal or difficulty values remain empty
+cells.
+
 ## Empirical Difficulty Import
 
 Managers can upload empirical difficulty CSV data through item endpoints.

--- a/frontend/src/app/core/services/api.service.spec.ts
+++ b/frontend/src/app/core/services/api.service.spec.ts
@@ -907,6 +907,23 @@ describe('ApiService', () => {
       );
     });
 
+    it('should export personal item data in the current Explorer order', () => {
+      const blob = new Blob(['xlsx']);
+      httpClientMock.post.mockReturnValue(of(blob));
+
+      service
+        .exportViewPersonalItemDataXlsx('acp1', ['uuid-2::1', 'uuid-1::1'], 'read-only')
+        .subscribe((result) => {
+          expect(result).toBe(blob);
+        });
+
+      expect(httpClientMock.post).toHaveBeenCalledWith(
+        '/api/view/acp/acp1/items/preferences/export.xlsx',
+        { rowKeys: ['uuid-2::1', 'uuid-1::1'], perspective: 'read-only' },
+        { responseType: 'blob' },
+      );
+    });
+
     it('should get view sequences', () => {
       httpClientMock.get.mockReturnValue(of([]));
 

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -448,6 +448,17 @@ export class ApiService {
       { rowKey, rowData, perspective },
     );
   }
+  exportViewPersonalItemDataXlsx(
+    acpId: string,
+    rowKeys: string[],
+    perspective: ItemExplorerPerspective,
+  ): Observable<Blob> {
+    return this.http.post(
+      `${this.API}/view/acp/${acpId}/items/preferences/export.xlsx`,
+      { rowKeys, perspective },
+      { responseType: 'blob' },
+    );
+  }
   getViewSequences(acpId: string): Observable<any[]> {
     return this.http.get<any[]>(`${this.API}/view/acp/${acpId}/sequences`);
   }

--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -181,6 +181,73 @@ describe('ItemExplorerComponent', () => {
     expect(component.getPersonalTagColor('Prüfen')).toBe('#ff0000');
   });
 
+  it('exports the filtered item order after pending personal changes are saved', async () => {
+    const patchViewItemPreferenceRow = vi.fn().mockReturnValue(of({ rowData: {} }));
+    const exportViewPersonalItemDataXlsx = vi.fn().mockReturnValue(of(new Blob(['xlsx'])));
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:export');
+    const revokeObjectUrl = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+    const component = createComponent({
+      api: { patchViewItemPreferenceRow, exportViewPersonalItemDataXlsx },
+      authService: { isLoggedIn: true },
+    });
+    component.acpId = 'acp-1';
+    component.enablePersonalItemData = true;
+    component.personalDataLoadState = 'loaded';
+    component.items = [
+      {
+        itemId: 'item-2',
+        uuid: 'uuid-2',
+        rowKey: 'uuid-2::1',
+        unitId: 'unit-1',
+        unitLabel: 'Aufgabe 1',
+        description: '',
+        variableId: 'var-2',
+        metadata: {},
+      },
+      {
+        itemId: 'item-1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1::1',
+        unitId: 'unit-1',
+        unitLabel: 'Aufgabe 1',
+        description: '',
+        variableId: 'var-1',
+        metadata: {},
+      },
+    ];
+    component.sortField = '__manual__';
+    component.itemOrder = ['uuid-2::1', 'uuid-1::1'];
+    component.filteredItems = [...component.items];
+    component.setPersonalItemNote('uuid-1::1', 'Noch zu speichern');
+
+    await component.exportPersonalItemDataXlsx();
+
+    expect(patchViewItemPreferenceRow).toHaveBeenCalledWith(
+      'acp-1',
+      'uuid-1::1',
+      { note: 'Noch zu speichern' },
+      'read-only',
+    );
+    expect(exportViewPersonalItemDataXlsx).toHaveBeenCalledWith(
+      'acp-1',
+      ['uuid-2::1', 'uuid-1::1'],
+      'read-only',
+    );
+    expect(createObjectUrl).toHaveBeenCalled();
+    expect(click).toHaveBeenCalled();
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:export');
+    expect(component.personalExportError).toBe('');
+    expect(component.personalExportInProgress).toBe(false);
+
+    component.ngOnDestroy();
+    createObjectUrl.mockRestore();
+    revokeObjectUrl.mockRestore();
+    click.mockRestore();
+  });
+
   it('does not expose personal working-data controls to anonymous visitors', () => {
     const component = createComponent({ authService: { isLoggedIn: false } });
     component.enablePersonalItemData = true;

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -152,6 +152,22 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
               {{ isReadOnlyPreview ? 'Bearbeitungsansicht' : 'READ ONLY-Vorschau' }}
             </button>
           }
+          @if (showPersonalItemData) {
+            <button
+              class="btn btn-outline btn-sm"
+              type="button"
+              (click)="exportPersonalItemDataXlsx()"
+              [disabled]="
+                personalExportInProgress ||
+                personalDataLoadState !== 'loaded' ||
+                filteredItems.length === 0 ||
+                perspectiveSwitchBusy
+              "
+              title="Aktuell gefilterte und sortierte persönliche Item-Arbeitsdaten exportieren"
+            >
+              {{ personalExportInProgress ? 'Export läuft …' : '📊 Persönliche Daten (XLSX)' }}
+            </button>
+          }
           @if (canEditExplorer) {
             <input
               type="file"
@@ -262,6 +278,12 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
       @if (itemListError) {
         <div class="alert alert-info" style="margin-bottom: 12px;">
           {{ itemListError }}
+        </div>
+      }
+
+      @if (personalExportError) {
+        <div class="alert alert-error" style="margin-bottom: 12px;" aria-live="polite">
+          {{ personalExportError }}
         </div>
       }
 
@@ -2773,6 +2795,8 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   personalDataLoadState: PersonalDataLoadState = 'idle';
   personalDataSaveState: PersonalDataSaveState = 'idle';
   personalDataError = '';
+  personalExportInProgress = false;
+  personalExportError = '';
   showDiscardPersonalItemDataDialog = false;
   private readonly personalPreferenceViewId = 'item-explorer';
   private readonly personalSaveDebounceMs = 350;
@@ -4937,6 +4961,50 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   flushPersonalItemDataSave() {
     this.clearPersonalSaveTimeout();
     this.saveNextPersonalItemRow();
+  }
+
+  async exportPersonalItemDataXlsx() {
+    if (
+      !this.showPersonalItemData ||
+      this.personalDataLoadState !== 'loaded' ||
+      !this.filteredItems.length ||
+      this.personalExportInProgress
+    ) {
+      return;
+    }
+
+    this.personalExportInProgress = true;
+    this.personalExportError = '';
+    try {
+      const saved = await this.flushPersonalItemDataSaveAndWait();
+      if (!saved) {
+        this.personalExportError =
+          'Persönliche Änderungen konnten vor dem Export nicht gespeichert werden.';
+        return;
+      }
+
+      const rowKeys = this.filteredItems.map((item) => this.getStableRowKey(item));
+      const blob = await firstValueFrom(
+        this.api.exportViewPersonalItemDataXlsx(
+          this.acpId,
+          rowKeys,
+          this.getPerspectiveForViewerRequests(),
+        ),
+      );
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `personal-item-data-${this.acpId}.xlsx`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Failed to export personal item working data', error);
+      this.personalExportError = 'Persönliche Item-Arbeitsdaten konnten nicht exportiert werden.';
+    } finally {
+      this.personalExportInProgress = false;
+    }
   }
 
   retryPersonalItemDataSave() {


### PR DESCRIPTION
## Summary

- add an authenticated XLSX endpoint that exports only the caller's personal Item Explorer working data
- preserve the currently filtered and sorted row order, including configured marker colors, notes, competence levels, empirical difficulty, and the per-unit mean difficulty
- wait for pending personal autosaves before starting the download and surface export errors in the Explorer
- document the workflow and add backend, controller, API, and component coverage

## Why

Personal markers, notes, and competence levels can now be used as tabular input for downstream analyses without exposing another user's data. Missing values remain empty cells.

## Validation

- `backend: npm test -- --runInBand` — 499 tests passed
- `frontend: npm test -- --run` — 337 tests passed
- backend and frontend production builds passed
- ESLint passed for all changed TypeScript files
- `git diff --check` passed

Closes #37
