### PR TITLE
Add ACP admin CSV export for participant item data

### DIFF
--- a/backend/src/views/views.controller.spec.ts
+++ b/backend/src/views/views.controller.spec.ts
@@ -39,6 +39,9 @@ describe("ViewsController", () => {
       exportPersonalItemDataXlsx: jest
         .fn()
         .mockResolvedValue(Buffer.from("personal-xlsx")),
+      exportAllPersonalItemDataCsv: jest
+        .fn()
+        .mockResolvedValue(Buffer.from("all-personal-csv")),
       getTaskSequence: jest
         .fn()
         .mockResolvedValue({ id: "seq-1", units: [{ id: "unit-1" }] }),
@@ -445,6 +448,62 @@ describe("ViewsController", () => {
       ["uuid::1"],
       false,
     );
+  });
+
+  it("exports all participants' data as CSV for ACP managers", async () => {
+    const res = { setHeader: jest.fn(), send: jest.fn() } as any;
+
+    await controller.exportAllPersonalItemDataCsv(
+      "acp-1",
+      { perspective: "editor" },
+      { acpAccessLevel: "MANAGER" },
+      res,
+    );
+
+    expect(viewsService.exportAllPersonalItemDataCsv).toHaveBeenCalledWith(
+      "acp-1",
+      true,
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Content-Type",
+      "text/csv; charset=utf-8",
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Content-Disposition",
+      'attachment; filename="all-participant-item-data-acp-1.csv"',
+    );
+    expect(res.send).toHaveBeenCalledWith(Buffer.from("all-personal-csv"));
+  });
+
+  it.each(["READ_ONLY", "CREDENTIAL", "PUBLIC", undefined])(
+    "blocks all-participant exports for access level %s",
+    async (acpAccessLevel) => {
+      await expect(
+        controller.exportAllPersonalItemDataCsv(
+          "acp-1",
+          {},
+          { acpAccessLevel },
+          {} as any,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(viewsService.exportAllPersonalItemDataCsv).not.toHaveBeenCalled();
+    },
+  );
+
+  it("blocks all-participant exports when personal data is disabled", async () => {
+    viewsService.getAcpStartPage.mockResolvedValueOnce({
+      featureConfig: { enablePersonalItemData: false },
+    });
+
+    await expect(
+      controller.exportAllPersonalItemDataCsv(
+        "acp-1",
+        {},
+        { acpAccessLevel: "ADMIN" },
+        {} as any,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+    expect(viewsService.exportAllPersonalItemDataCsv).not.toHaveBeenCalled();
   });
 
   it.each([true, false])(

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -123,6 +123,17 @@ class ExportPersonalItemDataDto {
   perspective?: "editor" | "read-only";
 }
 
+class ExportAllPersonalItemDataDto {
+  @ApiPropertyOptional({
+    description: "Explorer state used to resolve item metadata",
+    enum: ["editor", "read-only"],
+    default: "read-only",
+  })
+  @IsOptional()
+  @IsIn(["editor", "read-only"])
+  perspective?: "editor" | "read-only";
+}
+
 @ApiTags("Public Views")
 @Controller("view")
 export class ViewsController {
@@ -341,6 +352,41 @@ export class ViewsController {
     res.setHeader(
       "Content-Disposition",
       `attachment; filename="personal-item-data-${acpId}.xlsx"`,
+    );
+    res.send(buffer);
+  }
+
+  @Post("acp/:acpId/items/preferences/export-all.csv")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({
+    summary: "Export all participants' Item Explorer working data",
+  })
+  @ApiBody({ type: ExportAllPersonalItemDataDto })
+  async exportAllPersonalItemDataCsv(
+    @Param("acpId") acpId: string,
+    @Body() dto: ExportAllPersonalItemDataDto,
+    @Request() req: any,
+    @Res() res: Response,
+  ) {
+    if (req?.acpAccessLevel !== "MANAGER" && req?.acpAccessLevel !== "ADMIN") {
+      throw new ForbiddenException(
+        "Only ACP managers can export all participants' item data",
+      );
+    }
+    if (!(await this.isPersonalItemDataEnabled(acpId))) {
+      throw new ForbiddenException(
+        "Personal item data is not enabled for this ACP",
+      );
+    }
+
+    const buffer = await this.viewsService.exportAllPersonalItemDataCsv(
+      acpId,
+      dto.perspective === "editor",
+    );
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="all-participant-item-data-${acpId}.csv"`,
     );
     res.send(buffer);
   }

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -19,6 +19,7 @@ describe("ViewsService", () => {
   let fileRepository: { find: jest.Mock; findOne: jest.Mock };
   let settingsRepository: { findOne: jest.Mock };
   let itemPreferenceRepository: {
+    find: jest.Mock;
     findOne: jest.Mock;
     create: jest.Mock;
     save: jest.Mock;
@@ -36,6 +37,7 @@ describe("ViewsService", () => {
     fileRepository = { find: jest.fn(), findOne: jest.fn() };
     settingsRepository = { findOne: jest.fn() };
     itemPreferenceRepository = {
+      find: jest.fn(),
       findOne: jest.fn(),
       create: jest.fn().mockImplementation((value) => value),
       save: jest.fn().mockImplementation(async (value) => value),
@@ -360,6 +362,86 @@ describe("ViewsService", () => {
       ),
     ).rejects.toThrow(BadRequestException);
     expect(unitParserService.getItemListFromFiles).not.toHaveBeenCalled();
+  });
+
+  it("exports all stored participant rows as CSV with literal note line breaks", async () => {
+    itemPreferenceRepository.find.mockResolvedValue([
+      {
+        credential: { username: "teilnehmer-a" },
+        preferences: {
+          rowData: {
+            "uuid-1::A": {
+              category: "=II",
+              tags: ["Prüfen", "Sicher"],
+              note: "Erste Zeile\nZweite Zeile",
+            },
+          },
+        },
+      },
+      {
+        credential: { username: "ohne-eintrag" },
+        preferences: { rowData: {} },
+      },
+      {
+        user: { username: "teilnehmer-b" },
+        preferences: {
+          rowData: {
+            "uuid-2": { category: "III", tags: [], note: "Fertig" },
+          },
+        },
+      },
+    ]);
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          itemId: "item-1",
+          uuid: "uuid-1",
+          rowKey: "uuid-1::A",
+          subId: "A",
+          unitId: "unit-1",
+          unitLabel: "Aufgabe 1",
+          description: "",
+          variableId: "var-1",
+          metadata: {},
+          empiricalDifficulty: -0.25,
+        },
+        {
+          itemId: "item-2",
+          uuid: "uuid-2",
+          rowKey: "uuid-2",
+          unitId: "unit-1",
+          unitLabel: "Aufgabe 1",
+          description: "",
+          variableId: "var-2",
+          metadata: {},
+          empiricalDifficulty: 0.75,
+        },
+      ],
+    });
+
+    const csv = (
+      await service.exportAllPersonalItemDataCsv("acp-1", true)
+    ).toString("utf8");
+
+    expect(itemPreferenceRepository.find).toHaveBeenCalledWith({
+      where: { acpId: "acp-1", viewId: "item-explorer" },
+      relations: { user: true, credential: true },
+    });
+    expect(itemExplorerStateService.getStateForViewer).toHaveBeenCalledWith(
+      "acp-1",
+      true,
+    );
+    expect(csv.startsWith("\uFEFF")).toBe(true);
+    expect(csv).toContain(
+      '"Teilnehmerkennung";"Unit-ID";"Unit-Label";"Item-ID";"Sub-ID";"Zeilenschlüssel"',
+    );
+    expect(csv).toContain(
+      '"teilnehmer-a";"unit-1";"Aufgabe 1";"item-1";"A";"uuid-1::A";"\'=II";"Prüfen, Sicher";"Erste Zeile\\nZweite Zeile";"-0.25";"0.25"',
+    );
+    expect(csv).toContain(
+      '"teilnehmer-b";"unit-1";"Aufgabe 1";"item-2";"";"uuid-2";"III";"";"Fertig";"0.75";"0.25"',
+    );
+    expect(csv).not.toContain("ohne-eintrag");
   });
 
   it("limits personal data exports to 10,000 requested rows", async () => {

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -556,6 +556,81 @@ export class ViewsService {
     return this.buildPersonalItemDataXlsx(rows);
   }
 
+  async exportAllPersonalItemDataCsv(
+    acpId: string,
+    canEditExplorerState = false,
+  ): Promise<Buffer> {
+    const [preferenceRecords, explorerState] = await Promise.all([
+      this.itemPreferenceRepository.find({
+        where: { acpId, viewId: "item-explorer" },
+        relations: { user: true, credential: true },
+      }),
+      this.itemExplorerStateService.getStateForViewer(
+        acpId,
+        canEditExplorerState,
+      ),
+    ]);
+    const itemList = await this.unitParserService.getItemListFromFiles(acpId, {
+      itemPropertiesOverride: explorerState.activeState.itemProperties,
+    });
+    const itemsByRowKey = new Map(
+      itemList.items.map((item) => [item.rowKey, item] as const),
+    );
+    const itemOrder = new Map(
+      itemList.items.map((item, index) => [item.rowKey, index] as const),
+    );
+    const meanDifficultyByUnit = this.calculateMeanDifficultyByUnit(
+      itemList.items,
+    );
+
+    const rows = preferenceRecords.flatMap((record) => {
+      const participant = this.getPreferenceParticipantIdentifier(record);
+      if (!participant) return [];
+
+      const preferences = this.normalizeItemPreferences(record.preferences);
+      return Object.entries(preferences.rowData).map(
+        ([rowKey, personalRow]) => {
+          const item = itemsByRowKey.get(rowKey);
+          const tags = Array.isArray(personalRow.tags)
+            ? personalRow.tags.map((tag) => String(tag)).join(", ")
+            : "";
+
+          return {
+            participant,
+            unitId: item?.unitId || "",
+            unitLabel: item?.unitLabel || "",
+            itemId: item?.itemId || "",
+            subId: item?.subId || "",
+            rowKey,
+            category:
+              typeof personalRow.category === "string"
+                ? personalRow.category
+                : "",
+            tags,
+            note:
+              typeof personalRow.note === "string"
+                ? personalRow.note.replace(/\n/g, "\\n")
+                : "",
+            empiricalDifficulty: item?.empiricalDifficulty ?? "",
+            meanTaskDifficulty: item
+              ? (meanDifficultyByUnit.get(item.unitId) ?? "")
+              : "",
+            itemOrder: itemOrder.get(rowKey) ?? Number.MAX_SAFE_INTEGER,
+          };
+        },
+      );
+    });
+
+    rows.sort(
+      (left, right) =>
+        left.participant.localeCompare(right.participant, "de") ||
+        left.itemOrder - right.itemOrder ||
+        left.rowKey.localeCompare(right.rowKey, "de"),
+    );
+
+    return this.buildAllPersonalItemDataCsv(rows);
+  }
+
   private async upsertItemPreferences(
     acpId: string,
     viewId: string,
@@ -776,6 +851,80 @@ export class ViewsService {
 
     const buffer = await workbook.xlsx.writeBuffer();
     return Buffer.from(buffer);
+  }
+
+  private buildAllPersonalItemDataCsv(
+    rows: Array<{
+      participant: string;
+      unitId: string;
+      unitLabel: string;
+      itemId: string;
+      subId: string;
+      rowKey: string;
+      category: string;
+      tags: string;
+      note: string;
+      empiricalDifficulty: number | string;
+      meanTaskDifficulty: number | string;
+    }>,
+  ): Buffer {
+    const headers = [
+      "Teilnehmerkennung",
+      "Unit-ID",
+      "Unit-Label",
+      "Item-ID",
+      "Sub-ID",
+      "Zeilenschlüssel",
+      "Kategorie",
+      "Tags",
+      "Notiz",
+      "Empirische Itemschwierigkeit",
+      "Mittlere Aufgabenschwierigkeit",
+    ];
+    const lines = [
+      headers,
+      ...rows.map((row) => [
+        row.participant,
+        row.unitId,
+        row.unitLabel,
+        row.itemId,
+        row.subId,
+        row.rowKey,
+        row.category,
+        row.tags,
+        row.note,
+        row.empiricalDifficulty,
+        row.meanTaskDifficulty,
+      ]),
+    ].map((row) => row.map((value) => this.escapeCsvCell(value)).join(";"));
+
+    return Buffer.from(`\uFEFF${lines.join("\r\n")}\r\n`, "utf8");
+  }
+
+  private escapeCsvCell(value: string | number): string {
+    let normalized = String(value ?? "");
+    if (typeof value === "string" && /^[=+\-@]/.test(normalized)) {
+      normalized = `'${normalized}`;
+    }
+    return `"${normalized.replace(/"/g, '""')}"`;
+  }
+
+  private getPreferenceParticipantIdentifier(
+    record: AcpItemPreference,
+  ): string | null {
+    const identifiers = [
+      record.credential?.username,
+      record.credentialUsername,
+      record.user?.username,
+      record.credentialId,
+      record.userId,
+    ];
+    for (const identifier of identifiers) {
+      if (typeof identifier === "string" && identifier.trim()) {
+        return identifier.trim();
+      }
+    }
+    return null;
   }
 
   private resolvePreferenceIdentity(user: any): PreferenceIdentity | null {

--- a/docs/features/item-explorer.md
+++ b/docs/features/item-explorer.md
@@ -202,6 +202,13 @@ marker colors, note, competence level, empirical item difficulty, and the mean e
 of the unit when at least one value is available. Missing personal or difficulty values remain empty
 cells.
 
+ACP managers and application admins can additionally download one ACP-wide CSV from the Explorer
+toolbar. The endpoint rejects read-only users, credential logins, and public access. It exports every
+stored personal row across participants, using a stable participant identifier and including unit,
+item, Sub-ID, stable row key, category, tags, note, empirical difficulty, and mean unit difficulty.
+Participants without stored rows are skipped without failing the export. Note line breaks are
+written as literal `\\n` sequences so every personal entry remains on one CSV row.
+
 ## Empirical Difficulty Import
 
 Managers can upload empirical difficulty CSV data through item endpoints.

--- a/frontend/src/app/core/services/api.service.spec.ts
+++ b/frontend/src/app/core/services/api.service.spec.ts
@@ -924,6 +924,21 @@ describe('ApiService', () => {
       );
     });
 
+    it('should export all participants personal item data as CSV', () => {
+      const blob = new Blob(['csv']);
+      httpClientMock.post.mockReturnValue(of(blob));
+
+      service.exportAllViewPersonalItemDataCsv('acp1', 'editor').subscribe((result) => {
+        expect(result).toBe(blob);
+      });
+
+      expect(httpClientMock.post).toHaveBeenCalledWith(
+        '/api/view/acp/acp1/items/preferences/export-all.csv',
+        { perspective: 'editor' },
+        { responseType: 'blob' },
+      );
+    });
+
     it('should get view sequences', () => {
       httpClientMock.get.mockReturnValue(of([]));
 

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -459,6 +459,16 @@ export class ApiService {
       { responseType: 'blob' },
     );
   }
+  exportAllViewPersonalItemDataCsv(
+    acpId: string,
+    perspective: ItemExplorerPerspective,
+  ): Observable<Blob> {
+    return this.http.post(
+      `${this.API}/view/acp/${acpId}/items/preferences/export-all.csv`,
+      { perspective },
+      { responseType: 'blob' },
+    );
+  }
   getViewSequences(acpId: string): Observable<any[]> {
     return this.http.get<any[]>(`${this.API}/view/acp/${acpId}/sequences`);
   }

--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -248,6 +248,37 @@ describe('ItemExplorerComponent', () => {
     click.mockRestore();
   });
 
+  it('exports all participants personal data only for ACP managers', async () => {
+    const exportAllViewPersonalItemDataCsv = vi.fn().mockReturnValue(of(new Blob(['csv'])));
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:all-export');
+    const revokeObjectUrl = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+    const component = createComponent({ api: { exportAllViewPersonalItemDataCsv } });
+    component.acpId = 'acp-1';
+    component.enablePersonalItemData = true;
+    component.hasExplorerEditPermission = true;
+    component.viewPerspective = 'editor';
+
+    expect(component.canExportAllPersonalItemData).toBe(true);
+    await component.exportAllPersonalItemDataCsv();
+
+    expect(exportAllViewPersonalItemDataCsv).toHaveBeenCalledWith('acp-1', 'editor');
+    expect(createObjectUrl).toHaveBeenCalled();
+    expect(click).toHaveBeenCalled();
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:all-export');
+    expect(component.allPersonalDataExportError).toBe('');
+    expect(component.allPersonalDataExportInProgress).toBe(false);
+
+    component.hasExplorerEditPermission = false;
+    expect(component.canExportAllPersonalItemData).toBe(false);
+    component.ngOnDestroy();
+    createObjectUrl.mockRestore();
+    revokeObjectUrl.mockRestore();
+    click.mockRestore();
+  });
+
   it('does not expose personal working-data controls to anonymous visitors', () => {
     const component = createComponent({ authService: { isLoggedIn: false } });
     component.enablePersonalItemData = true;

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -168,6 +168,19 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
               {{ personalExportInProgress ? 'Export läuft …' : '📊 Persönliche Daten (XLSX)' }}
             </button>
           }
+          @if (canExportAllPersonalItemData) {
+            <button
+              class="btn btn-outline btn-sm"
+              type="button"
+              (click)="exportAllPersonalItemDataCsv()"
+              [disabled]="allPersonalDataExportInProgress || perspectiveSwitchBusy"
+              title="Persönliche Item-Arbeitsdaten aller Teilnehmenden exportieren"
+            >
+              {{
+                allPersonalDataExportInProgress ? 'Gesamtexport läuft …' : '📄 Gesamtdaten (CSV)'
+              }}
+            </button>
+          }
           @if (canEditExplorer) {
             <input
               type="file"
@@ -284,6 +297,12 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
       @if (personalExportError) {
         <div class="alert alert-error" style="margin-bottom: 12px;" aria-live="polite">
           {{ personalExportError }}
+        </div>
+      }
+
+      @if (allPersonalDataExportError) {
+        <div class="alert alert-error" style="margin-bottom: 12px;" aria-live="polite">
+          {{ allPersonalDataExportError }}
         </div>
       }
 
@@ -2797,6 +2816,8 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   personalDataError = '';
   personalExportInProgress = false;
   personalExportError = '';
+  allPersonalDataExportInProgress = false;
+  allPersonalDataExportError = '';
   showDiscardPersonalItemDataDialog = false;
   private readonly personalPreferenceViewId = 'item-explorer';
   private readonly personalSaveDebounceMs = 350;
@@ -4863,6 +4884,10 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     return this.canEditPersonalItemData && !this.perspectiveSwitchBusy;
   }
 
+  get canExportAllPersonalItemData(): boolean {
+    return this.enablePersonalItemData && this.hasExplorerEditPermission;
+  }
+
   private loadPersonalItemData(
     sessionIdentity = this.personalDataSessionIdentity,
     sessionVersion = this.personalDataSessionVersion,
@@ -5004,6 +5029,37 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       this.personalExportError = 'Persönliche Item-Arbeitsdaten konnten nicht exportiert werden.';
     } finally {
       this.personalExportInProgress = false;
+    }
+  }
+
+  async exportAllPersonalItemDataCsv() {
+    if (!this.canExportAllPersonalItemData || this.allPersonalDataExportInProgress) {
+      return;
+    }
+
+    this.allPersonalDataExportInProgress = true;
+    this.allPersonalDataExportError = '';
+    try {
+      const blob = await firstValueFrom(
+        this.api.exportAllViewPersonalItemDataCsv(
+          this.acpId,
+          this.getPerspectiveForViewerRequests(),
+        ),
+      );
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `all-participant-item-data-${this.acpId}.csv`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Failed to export all personal item working data', error);
+      this.allPersonalDataExportError =
+        'Die persönlichen Item-Arbeitsdaten aller Teilnehmenden konnten nicht exportiert werden.';
+    } finally {
+      this.allPersonalDataExportInProgress = false;
     }
   }
 


### PR DESCRIPTION
## Summary

- add an ACP-wide CSV export for stored personal Item Explorer working data
- restrict the endpoint and UI action to ACP managers and application admins
- include participant, unit, item, Sub-ID, stable row key, category, tags, notes, and difficulty values
- serialize note line breaks as literal `\\n` and protect text cells from spreadsheet formula injection
- add backend/frontend tests and update the Item Explorer documentation

## User impact

ACP managers can download all stored participant working data from the Item Explorer in one CSV. Read-only users, credential participants, and public viewers cannot access the aggregate export. Participants without stored rows do not block the export.

## Validation

- Backend: 510 tests passed
- Frontend: 339 tests passed
- Backend production build passed
- Frontend production build passed
- Targeted backend and frontend lint checks passed
- `git diff --check` passed

Closes #42
