### PR TITLE
Focus item-explorer coding on selected item

### DIFF
--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -1304,6 +1304,233 @@ describe('ItemExplorerComponent', () => {
     expect(ids).toEqual(['TEXT_VAR', 'VAR_02']);
   });
 
+  it('focuses the coding overlay on the variable assigned to the selected item', () => {
+    const component = createComponent();
+    component.selectedItem = {
+      itemId: 'ITEM_1',
+      uuid: 'uuid-1',
+      unitId: 'UNIT_1',
+      unitLabel: 'Unit 1',
+      description: 'First item',
+      variableId: 'IGNORED_FALLBACK',
+      sourceVariable: 'result_alias',
+      metadata: {},
+    } as any;
+    component.currentCodingScheme = {
+      variableCodings: [
+        { id: 'BASE_A', sourceType: 'BASE', deriveSources: [] },
+        {
+          id: 'RESULT',
+          alias: 'RESULT_ALIAS',
+          sourceType: 'SUM_SCORE',
+          deriveSources: ['BASE_A'],
+        },
+      ],
+    };
+    component.currentCodingSchemeAsText = [
+      { id: 'BASE_A', label: 'Teil A', codes: [] },
+      { id: 'RESULT_ALIAS', label: 'Ergebnis', codes: [] },
+    ] as any;
+    component.codingSearchText = 'does-not-match';
+
+    expect(component.codingVariableFocus).toMatchObject({
+      status: 'unique',
+      targetId: 'result_alias',
+      codingId: 'RESULT_ALIAS',
+      isDerived: true,
+      sourceIds: ['BASE_A'],
+    });
+    expect(component.filteredCodingSchemeAsText.map((coding) => coding.id)).toEqual([
+      'RESULT_ALIAS',
+    ]);
+  });
+
+  it('shows the full coding scheme and an explanation when an item has no variable', () => {
+    const component = createComponent();
+    component.selectedItem = {
+      itemId: 'ITEM_2',
+      uuid: 'uuid-2',
+      unitId: 'UNIT_1',
+      unitLabel: 'Unit 1',
+      description: 'Unmapped item',
+      variableId: '',
+      metadata: {},
+    } as any;
+    component.currentCodingSchemeAsText = [
+      { id: 'VAR_A', label: 'A', codes: [] },
+      { id: 'VAR_B', label: 'B', codes: [] },
+    ] as any;
+
+    expect(component.codingVariableFocus.status).toBe('missing-target');
+    expect(component.codingVariableFocusMessage).toContain('keine Variable zugeordnet');
+    expect(component.filteredCodingSchemeAsText.map((coding) => coding.id)).toEqual([
+      'VAR_A',
+      'VAR_B',
+    ]);
+  });
+
+  it('marks a valid base-variable alias shadow as ambiguous when the alias is targeted', () => {
+    const component = createComponent();
+    component.selectedItem = {
+      itemId: 'ITEM_3',
+      uuid: 'uuid-3',
+      unitId: 'UNIT_1',
+      unitLabel: 'Unit 1',
+      description: 'Ambiguous item',
+      variableId: 'BASE_A',
+      metadata: {},
+    } as any;
+    component.currentCodingScheme = {
+      variableCodings: [
+        { id: 'BASE_A', sourceType: 'BASE' },
+        {
+          id: 'TOTAL',
+          alias: 'BASE_A',
+          sourceType: 'SUM_SCORE',
+          deriveSources: ['BASE_A'],
+        },
+      ],
+    };
+    component.currentCodingSchemeAsText = [
+      { id: 'BASE_A', label: 'Basiswert', codes: [] },
+      { id: 'BASE_A', label: 'Gesamtscore', codes: [] },
+    ] as any;
+
+    expect(component.codingVariableFocus.status).toBe('ambiguous');
+    expect(component.codingVariableFocusMessage).toContain('nicht eindeutig');
+    expect(component.filteredCodingSchemeAsText).toHaveLength(2);
+  });
+
+  it('focuses a valid alias-shadowing aggregate when its internal id is targeted', () => {
+    const component = createComponent();
+    component.selectedItem = {
+      itemId: 'ITEM_4',
+      uuid: 'uuid-4',
+      unitId: 'UNIT_1',
+      unitLabel: 'Unit 1',
+      description: 'Aggregate item',
+      variableId: 'TOTAL',
+      metadata: {},
+    } as any;
+    component.currentCodingScheme = {
+      variableCodings: [
+        { id: 'BASE_A', sourceType: 'BASE' },
+        {
+          id: 'TOTAL',
+          alias: 'BASE_A',
+          sourceType: 'SUM_SCORE',
+          deriveSources: ['BASE_A'],
+        },
+      ],
+    };
+    component.currentCodingSchemeAsText = [
+      { id: 'BASE_A', label: 'Basiswert', codes: [] },
+      { id: 'BASE_A', label: 'Gesamtscore', codes: [] },
+    ] as any;
+
+    expect(component.codingVariableFocus).toMatchObject({
+      status: 'unique',
+      targetId: 'TOTAL',
+      codingId: 'BASE_A',
+      isDerived: true,
+      sourceIds: ['BASE_A'],
+    });
+    expect(component.filteredCodingSchemeAsText.map((coding) => coding.label)).toEqual([
+      'Gesamtscore',
+    ]);
+  });
+
+  it('keeps manual variable and code instructions when the coding uses an alias', () => {
+    const component = createComponent();
+    const codings = (component as any).createCodingSchemeAsText([
+      {
+        id: 'INTERNAL_ID',
+        alias: 'VISIBLE_ALIAS',
+        label: 'Visible result',
+        sourceType: 'BASE',
+        manualInstruction: '<p>Text <img src="figure.png"></p>',
+        codes: [
+          {
+            id: 1,
+            score: 1,
+            label: 'Correct',
+            manualInstruction: '<p>Inspect figure</p>',
+            ruleSets: [],
+          },
+        ],
+      },
+    ]);
+
+    expect(codings[0].id).toBe('VISIBLE_ALIAS');
+    expect(codings[0].manualInstructionText).toContain('<img');
+    expect(codings[0].codes[0].manualInstructionText).toContain('Inspect figure');
+  });
+
+  it('sanitizes manual variable and code instructions while preserving graphics', () => {
+    const component = createComponent();
+    const codings = (component as any).createCodingSchemeAsText([
+      {
+        id: 'INTERNAL_ID',
+        alias: 'VISIBLE_ALIAS',
+        sourceType: 'BASE',
+        manualInstruction:
+          '<p>Text <img src="figure.png" onerror="alert(1)"></p><script>alert(2)</script>',
+        codes: [
+          {
+            id: 1,
+            score: 1,
+            label: 'Correct',
+            manualInstruction:
+              '<a href="javascript:alert(3)" onclick="alert(4)">Inspect figure</a>',
+            ruleSets: [],
+          },
+        ],
+      },
+    ]);
+
+    expect(codings[0].manualInstructionText).toContain('<img src="figure.png">');
+    expect(codings[0].manualInstructionText).not.toContain('onerror');
+    expect(codings[0].manualInstructionText).not.toContain('<script');
+    expect(codings[0].codes[0].manualInstructionText).toContain('Inspect figure');
+    expect(codings[0].codes[0].manualInstructionText).not.toContain('javascript:');
+    expect(codings[0].codes[0].manualInstructionText).not.toContain('onclick');
+  });
+
+  it('keeps manual instructions paired by position for a valid alias shadow', () => {
+    const component = createComponent();
+    const codings = (component as any).createCodingSchemeAsText([
+      {
+        id: 'BASE_A',
+        sourceType: 'BASE',
+        manualInstruction: '<p>Base instruction</p>',
+        codes: [],
+      },
+      {
+        id: 'TOTAL',
+        alias: 'BASE_A',
+        sourceType: 'SUM_SCORE',
+        deriveSources: ['BASE_A'],
+        manualInstruction: '<p>Aggregate instruction</p>',
+        codes: [],
+      },
+    ]);
+
+    expect(codings.map((coding: any) => coding.manualInstructionText)).toEqual([
+      '<p>Base instruction</p>',
+      '<p>Aggregate instruction</p>',
+    ]);
+  });
+
+  it('clears a previous coding search when the overlay is opened', () => {
+    const component = createComponent();
+    component.codingSearchText = 'old search';
+
+    component.openCodingOverlay();
+
+    expect(component.codingSearchText).toBe('');
+    expect(component.showOverlay).toBe('coding');
+  });
+
   it('adds the player highlight class when player focus highlighting is enabled', () => {
     const component = createComponent();
     component.playerFocusHighlightEnabled = true;

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { DomSanitizer } from '@angular/platform-browser';
+import DOMPurify from 'dompurify';
 import { ApiService } from '../../core/services/api.service';
 import { VoudService } from '../../core/services/voud.service';
 import {
@@ -89,6 +90,17 @@ interface PreviewTargetResolution {
   isDerived: boolean;
   options: PreviewTargetOption[];
   defaultTargetId: string;
+}
+
+type CodingVariableFocusStatus = 'unique' | 'missing-target' | 'not-found' | 'ambiguous';
+
+interface CodingVariableFocusResolution {
+  status: CodingVariableFocusStatus;
+  targetId: string;
+  codingId: string;
+  matches: CodingAsText[];
+  isDerived: boolean;
+  sourceIds: string[];
 }
 
 type ExplorerUiStatus = 'CLEAN' | 'DIRTY' | 'SAVING' | 'SAVED' | 'ERROR';
@@ -1081,31 +1093,74 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
             </div>
             <div class="overlay-content">
               @if (currentCodingSchemeAsText) {
-                <div class="coding-toolbar">
-                  <div class="search-container">
-                    <input
-                      class="filter-input"
-                      [(ngModel)]="codingSearchText"
-                      placeholder="🔍 Variablen suchen (ID oder Label)..."
-                    />
+                @if (codingVariableFocus.status === 'unique') {
+                  <div class="coding-focus-info" data-testid="coding-variable-focus">
+                    <div>
+                      <strong>Kodierung für Item {{ selectedItem?.itemId }}</strong>
+                      @if (selectedItem?.subId) {
+                        <span>
+                          · {{ itemSubIdLabel }}
+                          {{ selectedItem?.subIdDisplay || selectedItem?.subId }}
+                        </span>
+                      }
+                    </div>
+                    <div>
+                      Zugeordnete Variable:
+                      <code>{{ codingVariableFocus.targetId }}</code>
+                      @if (
+                        codingVariableFocus.codingId &&
+                        codingVariableFocus.codingId.toLowerCase() !==
+                          codingVariableFocus.targetId.toLowerCase()
+                      ) {
+                        · Anzeige im Kodierschema:
+                        <code>{{ codingVariableFocus.codingId }}</code>
+                      }
+                    </div>
+                    @if (codingVariableFocus.isDerived) {
+                      <div class="coding-aggregation-info">
+                        <strong>Abgeleitete/aggregierte Kodierung</strong>
+                        @if (codingVariableFocus.sourceIds.length) {
+                          aus
+                          @for (sourceId of codingVariableFocus.sourceIds; track sourceId) {
+                            <code>{{ sourceId }}</code>
+                          }
+                        }
+                        – angezeigt wird die Ergebnisvariable, die den Itemwert liefert.
+                      </div>
+                    }
                   </div>
-                  <div class="sort-actions">
-                    <button
-                      class="btn btn-outline btn-sm"
-                      (click)="toggleCodingSort('id')"
-                      title="Nach ID sortieren"
-                    >
-                      ID {{ getCodingSortIndicator('id') }}
-                    </button>
-                    <button
-                      class="btn btn-outline btn-sm"
-                      (click)="toggleCodingSort('label')"
-                      title="Nach Label sortieren"
-                    >
-                      Label {{ getCodingSortIndicator('label') }}
-                    </button>
+                } @else {
+                  <div class="coding-focus-warning" role="status">
+                    <strong>Keine eindeutige Kodiervariable für dieses Item</strong>
+                    <span>{{ codingVariableFocusMessage }}</span>
                   </div>
-                </div>
+
+                  <div class="coding-toolbar">
+                    <div class="search-container">
+                      <input
+                        class="filter-input"
+                        [(ngModel)]="codingSearchText"
+                        placeholder="🔍 Variablen suchen (ID oder Label)..."
+                      />
+                    </div>
+                    <div class="sort-actions">
+                      <button
+                        class="btn btn-outline btn-sm"
+                        (click)="toggleCodingSort('id')"
+                        title="Nach ID sortieren"
+                      >
+                        ID {{ getCodingSortIndicator('id') }}
+                      </button>
+                      <button
+                        class="btn btn-outline btn-sm"
+                        (click)="toggleCodingSort('label')"
+                        title="Nach Label sortieren"
+                      >
+                        Label {{ getCodingSortIndicator('label') }}
+                      </button>
+                    </div>
+                  </div>
+                }
 
                 <div class="coding-scheme-view">
                   @for (coding of filteredCodingSchemeAsText; track coding.id) {
@@ -1121,9 +1176,7 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                           <strong>📖 Variable-Instruktion:</strong>
                           <div
                             class="html-content"
-                            [innerHTML]="
-                              sanitizer.bypassSecurityTrustHtml($any(coding).manualInstructionText)
-                            "
+                            [innerHTML]="$any(coding).manualInstructionText"
                           ></div>
                         </div>
                       }
@@ -1145,11 +1198,7 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                                 <strong>Instruktion:</strong>
                                 <div
                                   class="html-content"
-                                  [innerHTML]="
-                                    sanitizer.bypassSecurityTrustHtml(
-                                      $any(code).manualInstructionText
-                                    )
-                                  "
+                                  [innerHTML]="$any(code).manualInstructionText"
                                 ></div>
                               </div>
                             }
@@ -2293,6 +2342,21 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
         flex-direction: column;
         gap: 20px;
       }
+      .coding-focus-info,
+      .coding-focus-warning {
+        margin-bottom: 20px;
+        padding: 12px 16px;
+        border-radius: 8px;
+      }
+      .coding-focus-info {
+        background: rgba(41, 128, 185, 0.06);
+        border: 1px solid rgba(41, 128, 185, 0.25);
+      }
+      .coding-focus-warning {
+        color: #7e5109;
+        background: rgba(243, 156, 18, 0.08);
+        border: 1px solid rgba(243, 156, 18, 0.35);
+      }
       .coding-item {
         background: rgba(0, 0, 0, 0.02);
         border-radius: 12px;
@@ -3002,14 +3066,15 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   get filteredCodingSchemeAsText(): CodingAsText[] {
     if (!this.currentCodingSchemeAsText) return [];
 
-    let list = [...this.currentCodingSchemeAsText];
+    const focus = this.codingVariableFocus;
+    let list = focus.status === 'unique' ? [...focus.matches] : [...this.currentCodingSchemeAsText];
 
     if (!this.showAudioVideoCodingVariables) {
       list = list.filter((c) => !this.isAudioVideoCodingVariable(c));
     }
 
     // Search
-    if (this.codingSearchText) {
+    if (focus.status !== 'unique' && this.codingSearchText) {
       const term = this.codingSearchText.toLowerCase();
       list = list.filter(
         (c) =>
@@ -3025,6 +3090,97 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       const cmp = aVal.localeCompare(bVal, undefined, { numeric: true });
       return this.codingSortDir === 'asc' ? cmp : -cmp;
     });
+  }
+
+  get codingVariableFocus(): CodingVariableFocusResolution {
+    const targetId = this.getPlayerTarget(this.selectedItem);
+    const emptyResolution = (
+      status: Exclude<CodingVariableFocusStatus, 'unique'>,
+      matches: CodingAsText[] = [],
+    ): CodingVariableFocusResolution => ({
+      status,
+      targetId,
+      codingId: '',
+      matches,
+      isDerived: false,
+      sourceIds: [],
+    });
+
+    if (!targetId) {
+      return emptyResolution('missing-target');
+    }
+
+    const normalizedTarget = targetId.toLowerCase();
+    const codings = this.currentCodingSchemeAsText || [];
+    const rawVariables = this.getCurrentCodingVariables();
+    const rawMatchIndices = rawVariables.flatMap((variable, index) =>
+      this.getCodingVariableIdentifiers(variable).some(
+        (identifier) => identifier.toLowerCase() === normalizedTarget,
+      )
+        ? [index]
+        : [],
+    );
+
+    if (rawMatchIndices.length > 1) {
+      return emptyResolution(
+        'ambiguous',
+        rawMatchIndices
+          .map((index) => codings[index])
+          .filter((coding): coding is CodingAsText => Boolean(coding)),
+      );
+    }
+
+    if (rawMatchIndices.length === 1) {
+      const matchIndex = rawMatchIndices[0];
+      const textMatch = codings[matchIndex];
+      if (!textMatch) {
+        return emptyResolution('not-found');
+      }
+
+      const rawVariable = rawVariables[matchIndex];
+      const sourceType = this.getCodingVariableSourceType(rawVariable);
+      return {
+        status: 'unique',
+        targetId,
+        codingId: textMatch.id,
+        matches: [textMatch],
+        isDerived: sourceType !== 'BASE' && sourceType !== 'BASE_NO_VALUE',
+        sourceIds: this.getCodingVariableSources(rawVariable),
+      };
+    }
+
+    const directMatches = codings.filter(
+      (coding) =>
+        String(coding.id || '')
+          .trim()
+          .toLowerCase() === normalizedTarget,
+    );
+    if (directMatches.length !== 1) {
+      return emptyResolution(directMatches.length ? 'ambiguous' : 'not-found', directMatches);
+    }
+
+    return {
+      status: 'unique',
+      targetId,
+      codingId: directMatches[0].id,
+      matches: directMatches,
+      isDerived: false,
+      sourceIds: [],
+    };
+  }
+
+  get codingVariableFocusMessage(): string {
+    const focus = this.codingVariableFocus;
+    if (focus.status === 'missing-target') {
+      return 'Dem ausgewählten Item ist keine Variable zugeordnet. Das vollständige Kodierschema wird angezeigt.';
+    }
+    if (focus.status === 'not-found') {
+      return `Die zugeordnete Variable „${focus.targetId}“ wurde im Kodierschema nicht gefunden. Das vollständige Kodierschema wird angezeigt.`;
+    }
+    if (focus.status === 'ambiguous') {
+      return `Die zugeordnete Variable „${focus.targetId}“ kommt im Kodierschema nicht eindeutig vor. Das vollständige Kodierschema wird angezeigt.`;
+    }
+    return '';
   }
 
   get excludedItemsCount(): number {
@@ -3935,22 +4091,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       const codings = Array.isArray(this.currentCodingScheme)
         ? this.currentCodingScheme
         : this.currentCodingScheme.variableCodings || [];
-      this.currentCodingSchemeAsText = CodingSchemeTextFactory.asText(codings);
-      // Enrich with manual instruction texts from raw JSON
-      this.currentCodingSchemeAsText.forEach((cat) => {
-        const rawVariable = codings.find((v: any) => v.id === cat.id);
-        if (rawVariable) {
-          (cat as any).manualInstructionText = rawVariable.manualInstruction;
-          cat.codes.forEach((c) => {
-            const rawCode = rawVariable.codes?.find(
-              (rc: any) => (rc.id === null ? 'null' : rc.id.toString(10)) === c.id,
-            );
-            if (rawCode) {
-              (c as any).manualInstructionText = rawCode.manualInstruction;
-            }
-          });
-        }
-      });
+      this.currentCodingSchemeAsText = this.createCodingSchemeAsText(codings);
     } else {
       this.currentCodingSchemeAsText = null;
     }
@@ -4621,6 +4762,43 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     return Array.isArray(this.currentCodingScheme?.variableCodings)
       ? this.currentCodingScheme.variableCodings
       : [];
+  }
+
+  private createCodingSchemeAsText(codings: any[]): CodingAsText[] {
+    const codingSchemeAsText = CodingSchemeTextFactory.asText(codings);
+    codingSchemeAsText.forEach((coding, index) => {
+      const rawVariable = codings[index];
+      if (!rawVariable) {
+        return;
+      }
+
+      (coding as any).manualInstructionText = this.sanitizeManualInstruction(
+        rawVariable.manualInstruction,
+      );
+      coding.codes.forEach((code) => {
+        const rawCode = rawVariable.codes?.find(
+          (candidate: any) =>
+            String(candidate?.id === null ? 'null' : candidate?.id) === String(code.id),
+        );
+        if (rawCode) {
+          (code as any).manualInstructionText = this.sanitizeManualInstruction(
+            rawCode.manualInstruction,
+          );
+        }
+      });
+    });
+    return codingSchemeAsText;
+  }
+
+  private sanitizeManualInstruction(value: unknown): string | null {
+    if (typeof value !== 'string' || !value.trim()) {
+      return null;
+    }
+
+    const sanitizedHtml = DOMPurify.sanitize(value, {
+      USE_PROFILES: { html: true },
+    }).trim();
+    return sanitizedHtml || null;
   }
 
   private buildCodingVariableLookup(variables: any[]): Map<string, any> {
@@ -6463,6 +6641,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
 
   openCodingOverlay() {
     this.rememberFocusBeforeOverlay();
+    this.codingSearchText = '';
     this.showOverlay = 'coding';
   }
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -320,6 +320,34 @@ a:hover {
 /* Item Explorer tags and personal row data. Kept global so the already large Explorer
    component stylesheet stays below Angular's per-component budget. */
 app-item-explorer {
+  .overlay-content,
+  .coding-scheme-view,
+  .coding-item,
+  .html-content {
+    min-width: 0;
+  }
+
+  .coding-focus-warning {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .coding-aggregation-info code {
+    display: inline-block;
+    margin-inline: 3px;
+  }
+
+  .html-content {
+    overflow-wrap: anywhere;
+  }
+
+  // Rich-text children inserted through innerHTML are outside Angular's component style scope.
+  .html-content img {
+    max-width: 100%;
+    height: auto;
+  }
+
   .item-count {
     color: var(--color-text-secondary);
     font-size: 0.85rem;


### PR DESCRIPTION
## Summary

- focus the coding overlay on the variable assigned to the selected item
- make ambiguous and missing mappings explicit while retaining the searchable full schema as fallback
- represent aliases and aggregate codings without losing manual variable or code instructions
- sanitize manual instruction HTML and keep embedded images responsive
- improve warning and aggregate-source spacing on narrow viewports

## Why

The item explorer previously displayed the complete coding scheme for a unit. For units with multiple items, especially mathematics content, this made it unclear which coding instruction belonged to the selected item.

Manual instructions are imported HTML. The focused view now preserves supported text and graphics while removing unsafe scripts, event handlers, and dangerous URLs.

## User impact

Opening the coding overlay shows only the coding instruction that supplies the selected item's value. If the mapping cannot be resolved uniquely, the user sees a clear explanation and can still search and sort the complete scheme.

## Validation

- 354 frontend tests
- Angular lint
- production build without warnings
- Playwright UI test covering 6 scenarios and 30 assertions
- desktop and 390 px mobile visual checks
- stored-XSS regression coverage for scripts, event handlers, and `javascript:` URLs

Closes #38
