### PR TITLE
Add item parameters and personal collections

### DIFF
--- a/backend/src/acp/feature-config.utils.spec.ts
+++ b/backend/src/acp/feature-config.utils.spec.ts
@@ -5,6 +5,7 @@ describe("normalizeFeatureConfig", () => {
     expect(
       normalizeFeatureConfig({
         enablePersonalItemData: true,
+        enableItemCollections: true,
         personalItemCategoryLabel: " Stufe ",
         personalItemCategoryValues: ["I", " I ", "II", ""],
         personalItemTagLabel: " Sichtung ",
@@ -16,6 +17,7 @@ describe("normalizeFeatureConfig", () => {
       }),
     ).toMatchObject({
       enablePersonalItemData: true,
+      enableItemCollections: true,
       personalItemCategoryLabel: "Stufe",
       personalItemCategoryValues: ["I", "II"],
       personalItemTagLabel: "Sichtung",

--- a/backend/src/acp/feature-config.utils.ts
+++ b/backend/src/acp/feature-config.utils.ts
@@ -97,6 +97,7 @@ export function normalizeFeatureConfig(featureConfig: unknown): UnknownRecord {
     source.enablePlayerFocusHighlight === true;
 
   normalized.enablePersonalItemData = source.enablePersonalItemData === true;
+  normalized.enableItemCollections = source.enableItemCollections === true;
   normalized.personalItemCategoryLabel =
     typeof source.personalItemCategoryLabel === "string" &&
     source.personalItemCategoryLabel.trim()

--- a/backend/src/files/unit-parser.service.spec.ts
+++ b/backend/src/files/unit-parser.service.spec.ts
@@ -528,7 +528,18 @@ describe("UnitParserService", () => {
       itemPropertiesOverride: {
         i1: { tags: ["legacy"], empiricalDifficulty: 0.25 },
         u1_i1: { tags: ["resolved"] },
-        "uuid-1": { empiricalDifficulty: 0.75 },
+        "uuid-1": {
+          empiricalDifficulty: 0.75,
+          infit: 1.04,
+          discrimination: 0.41,
+          solutionRate: 0.68,
+          itemTimeSeconds: 33,
+          stimulusTimeSeconds: 12,
+          bookletOccurrences: [
+            { booklet: "B2", position: 8 },
+            { booklet: "B1", position: 3 },
+          ],
+        },
       },
     });
 
@@ -537,6 +548,15 @@ describe("UnitParserService", () => {
         uuid: "uuid-1",
         rowKey: "uuid-1",
         empiricalDifficulty: 0.75,
+        infit: 1.04,
+        discrimination: 0.41,
+        solutionRate: 0.68,
+        itemTimeSeconds: 33,
+        stimulusTimeSeconds: 12,
+        bookletOccurrences: [
+          { booklet: "B1", position: 3 },
+          { booklet: "B2", position: 8 },
+        ],
         tags: ["resolved"],
       }),
     ]);

--- a/backend/src/files/unit-parser.service.ts
+++ b/backend/src/files/unit-parser.service.ts
@@ -66,6 +66,12 @@ export interface VomdItemData {
   sourceVariable?: string;
   metadata: Record<string, string>;
   empiricalDifficulty?: number;
+  infit?: number;
+  discrimination?: number;
+  solutionRate?: number;
+  itemTimeSeconds?: number;
+  stimulusTimeSeconds?: number;
+  bookletOccurrences: Array<{ booklet: string; position: number }>;
   tags?: string[];
   rowNumber: number;
 }
@@ -846,6 +852,39 @@ export class UnitParserService {
               !Number.isFinite(Number(empiricalDifficultyRaw))
                 ? undefined
                 : Number(empiricalDifficultyRaw);
+            const optionalNumber = (property: string): number | undefined => {
+              const rawValue = rowProperties[property];
+              if (rawValue === undefined || rawValue === null) return undefined;
+              const value = Number(rawValue);
+              return Number.isFinite(value) ? value : undefined;
+            };
+            const bookletOccurrences = Array.isArray(
+              rowProperties.bookletOccurrences,
+            )
+              ? rowProperties.bookletOccurrences
+                  .map((rawOccurrence) => {
+                    const occurrence =
+                      rawOccurrence && typeof rawOccurrence === "object"
+                        ? (rawOccurrence as Record<string, unknown>)
+                        : {};
+                    return {
+                      booklet: String(occurrence.booklet || "").trim(),
+                      position: Number(occurrence.position),
+                    };
+                  })
+                  .filter(
+                    (occurrence) =>
+                      occurrence.booklet.length > 0 &&
+                      Number.isInteger(occurrence.position) &&
+                      occurrence.position > 0,
+                  )
+                  .sort(
+                    (left, right) =>
+                      left.booklet.localeCompare(right.booklet, "de", {
+                        numeric: true,
+                      }) || left.position - right.position,
+                  )
+              : [];
 
             items.push({
               itemId: item.id,
@@ -863,6 +902,12 @@ export class UnitParserService {
               sourceVariable: sourceVariable || undefined,
               metadata: { ...metadata },
               empiricalDifficulty,
+              infit: optionalNumber("infit"),
+              discrimination: optionalNumber("discrimination"),
+              solutionRate: optionalNumber("solutionRate"),
+              itemTimeSeconds: optionalNumber("itemTimeSeconds"),
+              stimulusTimeSeconds: optionalNumber("stimulusTimeSeconds"),
+              bookletOccurrences,
               tags: Array.isArray(rowProperties.tags)
                 ? rowProperties.tags.map((tag) => String(tag))
                 : [],

--- a/backend/src/items/item-parameter-import.pipeline.spec.ts
+++ b/backend/src/items/item-parameter-import.pipeline.spec.ts
@@ -1,0 +1,219 @@
+import { BadRequestException } from "@nestjs/common";
+import {
+  ItemParameterImportPipeline,
+  ItemParameterImportRequest,
+} from "./item-parameter-import.pipeline";
+
+describe("ItemParameterImportPipeline", () => {
+  const pipeline = new ItemParameterImportPipeline();
+  const items = [
+    {
+      uuid: "uuid-1",
+      itemId: "I-1",
+      unitId: "U-1",
+      unitLabel: "Aufgabe 1",
+    },
+    {
+      uuid: "uuid-2",
+      itemId: "I-2",
+      unitId: "U-1",
+      unitLabel: "Aufgabe 1",
+    },
+  ] as ItemParameterImportRequest["items"];
+
+  it("plans explicit row, item and unit mutations before applying them", () => {
+    const request: ItemParameterImportRequest = {
+      fileBuffer: Buffer.from(
+        "item;sub_id;est;item_time_s;stimulus_time_s\nI1;A;0,25;20;12",
+      ),
+      items,
+      itemProperties: {
+        "uuid-1": { tags: ["keep"], stimulusTimeSeconds: 5 },
+        "uuid-1::A": {
+          itemUuid: "uuid-1",
+          subId: "A",
+          itemTimeSeconds: 3,
+          stimulusTimeSeconds: 5,
+        },
+        "uuid-2": { stimulusTimeSeconds: 5 },
+      },
+    };
+
+    const plan = pipeline.buildPlan(request);
+    expect(plan.mutations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "set",
+          scope: "row",
+          property: "empiricalDifficulty",
+          targetKeys: ["uuid-1::A"],
+        }),
+        expect.objectContaining({
+          action: "set",
+          scope: "item",
+          property: "itemTimeSeconds",
+          targetKeys: ["uuid-1"],
+        }),
+        expect.objectContaining({
+          action: "set",
+          scope: "unit",
+          property: "stimulusTimeSeconds",
+          targetKeys: ["uuid-2"],
+        }),
+        expect.objectContaining({
+          action: "keep",
+          scope: "row",
+          property: "infit",
+        }),
+      ]),
+    );
+    expect(
+      plan.mutations
+        .filter((mutation) => mutation.action === "keep")
+        .every((mutation) => !("targetKeys" in mutation)),
+    ).toBe(true);
+    expect(plan.mutations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          scope: "row",
+          property: "itemTimeSeconds",
+        }),
+      ]),
+    );
+    expect(plan.mutations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          scope: "row",
+          property: "stimulusTimeSeconds",
+        }),
+      ]),
+    );
+
+    expect(pipeline.applyPlan(request.itemProperties, plan)).toEqual({
+      "uuid-1": {
+        tags: ["keep"],
+        itemTimeSeconds: 20,
+        stimulusTimeSeconds: 12,
+      },
+      "uuid-1::A": {
+        itemUuid: "uuid-1",
+        subId: "A",
+        empiricalDifficulty: 0.25,
+      },
+      "uuid-2": { stimulusTimeSeconds: 12 },
+    });
+  });
+
+  it("distinguishes an absent column from an explicitly empty value", () => {
+    const result = pipeline.execute({
+      fileBuffer: Buffer.from("item;est\nI1;"),
+      items,
+      itemProperties: {
+        "uuid-1": { empiricalDifficulty: 0.4, infit: 1.05 },
+      },
+    });
+
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1": { infit: 1.05 },
+    });
+  });
+
+  it("parses BOM, quoted Sub-IDs, decimal commas and grouped booklet rows", () => {
+    const result = pipeline.execute({
+      fileBuffer: Buffer.from(
+        '\uFEFFitem;sub_id;infit;booklet;position\nI1;"A;1";1,05;B2;8\nI1;"A;1";1.05;B1;3',
+      ),
+      items,
+      itemProperties: {},
+    });
+
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1::A%3B1": {
+        itemUuid: "uuid-1",
+        subId: "A;1",
+        infit: 1.05,
+        bookletOccurrences: [
+          { booklet: "B1", position: 3 },
+          { booklet: "B2", position: 8 },
+        ],
+      },
+    });
+  });
+
+  it("rejects structural conflicts without mutating the source properties", () => {
+    const itemProperties = { "uuid-1": { infit: 0.9 } };
+
+    expect(() =>
+      pipeline.execute({
+        fileBuffer: Buffer.from(
+          "item;infit;booklet;position\nI1;1.0;B1;1\nI1;1.1;B2;2",
+        ),
+        items,
+        itemProperties,
+      }),
+    ).toThrow(BadRequestException);
+    expect(itemProperties).toEqual({ "uuid-1": { infit: 0.9 } });
+  });
+
+  it("fans a standard row out to existing partial-credit rows without deleting them", () => {
+    const result = pipeline.execute({
+      fileBuffer: Buffer.from("item;est\nI1;0.5"),
+      items,
+      itemProperties: {
+        "uuid-1": { empiricalDifficulty: 0.1, tags: ["base"] },
+        "uuid-1::A": {
+          itemUuid: "uuid-1",
+          subId: "A",
+          empiricalDifficulty: 0.2,
+          tags: ["partial"],
+        },
+        "uuid-1::B": {
+          itemUuid: "uuid-1",
+          subId: "B",
+          empiricalDifficulty: 0.8,
+        },
+      },
+      requireEmpiricalDifficulty: true,
+    });
+
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1": { tags: ["base"] },
+      "uuid-1::A": {
+        itemUuid: "uuid-1",
+        subId: "A",
+        empiricalDifficulty: 0.5,
+        tags: ["partial"],
+      },
+      "uuid-1::B": {
+        itemUuid: "uuid-1",
+        subId: "B",
+        empiricalDifficulty: 0.5,
+      },
+    });
+  });
+
+  it("keeps the mutation plan linear for many items in one unit", () => {
+    const manyItems = Array.from({ length: 500 }, (_, index) => ({
+      uuid: `uuid-${index}`,
+      itemId: `I-${index}`,
+      unitId: "U-large",
+      unitLabel: "Große Aufgabe",
+    })) as ItemParameterImportRequest["items"];
+    const csvRows = manyItems.map((item) => `${item.itemId};0.5`);
+
+    const plan = pipeline.buildPlan({
+      fileBuffer: Buffer.from(["item;est", ...csvRows].join("\n")),
+      items: manyItems,
+      itemProperties: {},
+    });
+    const keepMutations = plan.mutations.filter(
+      (mutation) => mutation.action === "keep",
+    );
+
+    expect(keepMutations).toHaveLength(6);
+    expect(keepMutations.every((mutation) => !("targetKeys" in mutation))).toBe(
+      true,
+    );
+    expect(plan.mutations).toHaveLength(manyItems.length + 6);
+  });
+});

--- a/backend/src/items/item-parameter-import.pipeline.ts
+++ b/backend/src/items/item-parameter-import.pipeline.ts
@@ -1,0 +1,693 @@
+import { BadRequestException, Injectable } from "@nestjs/common";
+import { VomdItemData } from "../files/unit-parser.service";
+import {
+  buildItemRowKey,
+  normalizeItemSubId,
+  parseItemRowKeyParts,
+} from "./item-row-key.util";
+
+export type ImportAction = "keep" | "set" | "clear";
+export type ImportScope = "row" | "item" | "unit";
+
+type ImportedScalarProperty =
+  | "empiricalDifficulty"
+  | "infit"
+  | "discrimination"
+  | "solutionRate"
+  | "itemTimeSeconds"
+  | "stimulusTimeSeconds";
+
+type ImportedProperty =
+  | ImportedScalarProperty
+  | "bookletOccurrences"
+  | "itemUuid"
+  | "subId";
+
+interface ImportMutationBase {
+  scope: ImportScope;
+  property: ImportedProperty;
+}
+
+export type ImportMutation =
+  | (ImportMutationBase & { action: "keep" })
+  | (ImportMutationBase & { action: "clear"; targetKeys: string[] })
+  | (ImportMutationBase & {
+      action: "set";
+      targetKeys: string[];
+      value: unknown;
+    });
+
+export interface ItemParameterImportPlan {
+  mutations: ImportMutation[];
+  updated: number;
+  failed: Array<{ csvRow: string; reason: string }>;
+  successes: Array<Record<string, unknown>>;
+}
+
+export interface ItemParameterImportRequest {
+  fileBuffer: Buffer;
+  items: VomdItemData[];
+  itemProperties: Record<string, Record<string, unknown>>;
+  requireEmpiricalDifficulty?: boolean;
+}
+
+export interface ItemParameterImportResult {
+  updated: number;
+  failed: Array<{ csvRow: string; reason: string }>;
+  successes: Array<Record<string, unknown>>;
+  nextItemProperties: Record<string, Record<string, unknown>>;
+}
+
+const IMPORTED_SCALAR_COLUMNS: Array<{
+  header: string;
+  property: ImportedScalarProperty;
+  scope: ImportScope;
+  nonNegative?: boolean;
+}> = [
+  { header: "est", property: "empiricalDifficulty", scope: "row" },
+  { header: "infit", property: "infit", scope: "row" },
+  { header: "discrimination", property: "discrimination", scope: "row" },
+  { header: "solution_rate", property: "solutionRate", scope: "row" },
+  {
+    header: "item_time_s",
+    property: "itemTimeSeconds",
+    scope: "item",
+    nonNegative: true,
+  },
+  {
+    header: "stimulus_time_s",
+    property: "stimulusTimeSeconds",
+    scope: "unit",
+    nonNegative: true,
+  },
+];
+
+interface ImportGroup {
+  match: VomdItemData;
+  subId: string;
+  rowIndexes: number[];
+  scalars: Map<ImportedScalarProperty, Set<number>>;
+  occurrences: Map<string, { booklet: string; position: number }>;
+  emptyOccurrenceRows: number[];
+}
+
+@Injectable()
+export class ItemParameterImportPipeline {
+  execute(request: ItemParameterImportRequest): ItemParameterImportResult {
+    const plan = this.buildPlan(request);
+    return {
+      updated: plan.updated,
+      failed: plan.failed,
+      successes: plan.successes,
+      nextItemProperties: this.applyPlan(request.itemProperties, plan),
+    };
+  }
+
+  buildPlan(request: ItemParameterImportRequest): ItemParameterImportPlan {
+    const { fileBuffer, items } = request;
+    const requireEmpiricalDifficulty =
+      request.requireEmpiricalDifficulty === true;
+    const lines = fileBuffer.toString("utf-8").split(/\r?\n/);
+    const headers = this.parseCsvLine(lines[0] || "").map((header, index) =>
+      header
+        .replace(index === 0 ? /^\uFEFF/ : /$^/, "")
+        .trim()
+        .toLowerCase(),
+    );
+    const itemIdx = headers.indexOf("item");
+    const estIdx = headers.indexOf("est");
+    const canonicalSubIdIdx = headers.indexOf("sub_id");
+    const subIdIdx =
+      canonicalSubIdIdx >= 0
+        ? canonicalSubIdIdx
+        : requireEmpiricalDifficulty &&
+            headers.length > 2 &&
+            ![itemIdx, estIdx].includes(1)
+          ? 1
+          : -1;
+    const bookletIdx = headers.indexOf("booklet");
+    const positionIdx = headers.indexOf("position");
+    const hasBookletColumn = bookletIdx >= 0;
+    const hasPositionColumn = positionIdx >= 0;
+
+    if (itemIdx === -1 || (requireEmpiricalDifficulty && estIdx < 0)) {
+      throw new BadRequestException(
+        requireEmpiricalDifficulty
+          ? 'CSV must contain "item" and "est" columns'
+          : 'CSV must contain an "item" column',
+      );
+    }
+    if (hasBookletColumn !== hasPositionColumn) {
+      throw new BadRequestException(
+        'CSV columns "booklet" and "position" must be provided together',
+      );
+    }
+
+    const scalarColumns = IMPORTED_SCALAR_COLUMNS.map((definition) => ({
+      ...definition,
+      index: headers.indexOf(definition.header),
+    })).filter((definition) => definition.index >= 0);
+
+    if (!scalarColumns.length && bookletIdx < 0) {
+      throw new BadRequestException(
+        'CSV must contain at least one supported item parameter column: "est", "infit", "discrimination", "solution_rate", "item_time_s", "stimulus_time_s", or the pair "booklet" and "position"',
+      );
+    }
+
+    const failed: Array<{ csvRow: string; reason: string }> = [];
+    const successes: Array<Record<string, unknown>> = [];
+    const matchedItemModes = new Map<
+      string,
+      { mode: "standard" | "partial"; rowIndex: number }
+    >();
+    const groups = new Map<string, ImportGroup>();
+
+    for (let index = 1; index < lines.length; index++) {
+      const line = lines[index].trim();
+      if (!line) continue;
+
+      const row = this.parseCsvLine(line);
+      const itemValRaw = row[itemIdx]?.trim() || "";
+      const subId = subIdIdx >= 0 ? normalizeItemSubId(row[subIdIdx]) : "";
+      if (!itemValRaw) {
+        failed.push({ csvRow: `Zeile ${index + 1}`, reason: "Item fehlt" });
+        continue;
+      }
+      if (requireEmpiricalDifficulty) {
+        const empiricalValue = Number(
+          (row[estIdx] || "").trim().replace(",", "."),
+        );
+        if (!Number.isFinite(empiricalValue)) continue;
+      }
+
+      const match = this.findItem(items, itemValRaw);
+      if (!match) {
+        failed.push({
+          csvRow: itemValRaw,
+          reason: "Kein passendes Item gefunden",
+        });
+        continue;
+      }
+
+      const rowKey = buildItemRowKey(match.uuid, subId);
+      const mode = subId ? "partial" : "standard";
+      let group = groups.get(rowKey);
+      if (!group) {
+        group = {
+          match,
+          subId,
+          rowIndexes: [],
+          scalars: new Map(),
+          occurrences: new Map(),
+          emptyOccurrenceRows: [],
+        };
+        groups.set(rowKey, group);
+      }
+      if (bookletIdx < 0 && group.rowIndexes.length > 0) {
+        throw new BadRequestException(
+          `Konflikt: Die Zeile für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} kommt mehrfach in der CSV vor.`,
+        );
+      }
+
+      const rowScalars = new Map<ImportedScalarProperty, number>();
+      let invalidReason = "";
+      for (const definition of scalarColumns) {
+        const rawValue = row[definition.index]?.trim() || "";
+        if (!rawValue) continue;
+        const value = Number(rawValue.replace(",", "."));
+        if (!Number.isFinite(value)) {
+          invalidReason = `Ungültiger Zahlenwert in ${definition.header}`;
+          break;
+        }
+        if (definition.nonNegative && value < 0) {
+          invalidReason = `${definition.header} darf nicht negativ sein`;
+          break;
+        }
+        rowScalars.set(definition.property, value);
+      }
+      if (invalidReason) {
+        failed.push({ csvRow: itemValRaw, reason: invalidReason });
+        if (!group.rowIndexes.length) groups.delete(rowKey);
+        continue;
+      }
+
+      const occurrence = this.parseOccurrence(
+        row,
+        bookletIdx,
+        positionIdx,
+        group,
+        match,
+        subId,
+        itemValRaw,
+        failed,
+      );
+      if (occurrence === null) {
+        if (!group.rowIndexes.length) groups.delete(rowKey);
+        continue;
+      }
+
+      const previousMode = matchedItemModes.get(match.uuid);
+      if (previousMode && previousMode.mode !== mode) {
+        throw new BadRequestException(
+          `Konflikt: Das Item "${match.itemId}" wird in derselben CSV sowohl mit als auch ohne Sub-ID verwendet (Zeile ${previousMode.rowIndex + 1} und Zeile ${index + 1}). Bitte verwenden Sie pro Item nur eine Darstellungsform.`,
+        );
+      }
+      matchedItemModes.set(match.uuid, { mode, rowIndex: index });
+      rowScalars.forEach((value, property) => {
+        const values = group.scalars.get(property) || new Set<number>();
+        values.add(value);
+        group.scalars.set(property, values);
+      });
+      if (occurrence && "value" in occurrence) {
+        group.occurrences.set(occurrence.key, occurrence.value);
+      } else if (occurrence && "empty" in occurrence) {
+        group.emptyOccurrenceRows.push(index);
+      }
+      group.rowIndexes.push(index);
+    }
+
+    this.validateGroupConflicts(groups);
+    const itemTimesByUuid = this.collectScopedValues(
+      groups,
+      scalarColumns,
+      "itemTimeSeconds",
+      (group) => group.match.uuid,
+    );
+    const stimulusTimesByUnit = this.collectScopedValues(
+      groups,
+      scalarColumns,
+      "stimulusTimeSeconds",
+      (group) => group.match.unitId,
+    );
+    this.validateScopedConflicts(itemTimesByUuid, "item");
+    this.validateScopedConflicts(stimulusTimesByUnit, "unit");
+
+    const mutations: ImportMutation[] = [];
+    const importedScalarProperties = new Set(
+      scalarColumns.map((definition) => definition.property),
+    );
+    for (const definition of IMPORTED_SCALAR_COLUMNS) {
+      if (importedScalarProperties.has(definition.property)) continue;
+      mutations.push({
+        action: "keep",
+        scope: definition.scope,
+        property: definition.property,
+      });
+    }
+    if (bookletIdx < 0) {
+      mutations.push({
+        action: "keep",
+        scope: "row",
+        property: "bookletOccurrences",
+      });
+    }
+    const importedRowProperties = scalarColumns.filter(
+      (definition) => definition.scope === "row",
+    );
+    const importedRowMutationDefinitions: Array<{
+      property: ImportedProperty;
+      scope: ImportScope;
+    }> = importedRowProperties.map((definition) => ({
+      property: definition.property,
+      scope: definition.scope,
+    }));
+    if (bookletIdx >= 0) {
+      importedRowMutationDefinitions.push({
+        property: "bookletOccurrences",
+        scope: "row",
+      });
+    }
+
+    for (const [rowKey, group] of groups.entries()) {
+      const partialRowKeys = this.getPartialCreditRowKeys(
+        request.itemProperties,
+        group.match.uuid,
+      );
+      const affectedRowKeys =
+        !group.subId && partialRowKeys.length ? partialRowKeys : [rowKey];
+
+      if (group.subId || affectedRowKeys.length > 1) {
+        for (const definition of importedRowMutationDefinitions) {
+          mutations.push({
+            action: "clear",
+            scope: definition.scope,
+            property: definition.property,
+            targetKeys: [group.match.uuid],
+          });
+        }
+      }
+
+      if (group.subId) {
+        mutations.push(
+          {
+            action: "set",
+            scope: "row",
+            property: "itemUuid",
+            targetKeys: [rowKey],
+            value: group.match.uuid,
+          },
+          {
+            action: "set",
+            scope: "row",
+            property: "subId",
+            targetKeys: [rowKey],
+            value: group.subId,
+          },
+        );
+      }
+
+      for (const definition of importedRowProperties) {
+        const values = group.scalars.get(definition.property);
+        if (values?.size) {
+          mutations.push({
+            action: "set",
+            scope: "row",
+            property: definition.property,
+            targetKeys: affectedRowKeys,
+            value: Array.from(values)[0],
+          });
+        } else {
+          mutations.push({
+            action: "clear",
+            scope: "row",
+            property: definition.property,
+            targetKeys: affectedRowKeys,
+          });
+        }
+      }
+
+      const bookletOccurrences =
+        bookletIdx >= 0
+          ? Array.from(group.occurrences.values()).sort(
+              (left, right) =>
+                left.booklet.localeCompare(right.booklet, "de", {
+                  numeric: true,
+                }) || left.position - right.position,
+            )
+          : undefined;
+      if (bookletOccurrences) {
+        mutations.push({
+          action: "set",
+          scope: "row",
+          property: "bookletOccurrences",
+          targetKeys: affectedRowKeys,
+          value: bookletOccurrences,
+        });
+      }
+
+      successes.push({
+        itemId: group.match.itemId,
+        unitId: group.match.unitId,
+        ...(affectedRowKeys.length === 1 ? { rowKey: affectedRowKeys[0] } : {}),
+        affectedRowKeys,
+        subId: group.subId || undefined,
+        ...(!requireEmpiricalDifficulty
+          ? {
+              fields: [
+                ...scalarColumns.map((definition) => definition.header),
+                ...(bookletIdx >= 0 ? ["booklet", "position"] : []),
+              ],
+            }
+          : {}),
+        ...(group.scalars.get("empiricalDifficulty")?.size
+          ? {
+              value: Array.from(
+                group.scalars.get("empiricalDifficulty") as Set<number>,
+              )[0],
+            }
+          : {}),
+        ...(!requireEmpiricalDifficulty && bookletIdx >= 0
+          ? { bookletOccurrences }
+          : {}),
+      });
+    }
+
+    this.addItemScopeMutations(
+      mutations,
+      itemTimesByUuid,
+      request.itemProperties,
+    );
+    this.addUnitScopeMutations(
+      mutations,
+      stimulusTimesByUnit,
+      items,
+      request.itemProperties,
+    );
+
+    return {
+      mutations,
+      updated: groups.size,
+      failed,
+      successes,
+    };
+  }
+
+  applyPlan(
+    source: Record<string, Record<string, unknown>>,
+    plan: ItemParameterImportPlan,
+  ): Record<string, Record<string, unknown>> {
+    const next = this.cloneItemProperties(source);
+    for (const mutation of plan.mutations) {
+      if (mutation.action === "keep") continue;
+      for (const targetKey of mutation.targetKeys) {
+        if (mutation.action === "set") {
+          next[targetKey] = { ...(next[targetKey] || {}) };
+          next[targetKey][mutation.property] = mutation.value;
+        } else if (next[targetKey]) {
+          next[targetKey] = { ...next[targetKey] };
+          delete next[targetKey][mutation.property];
+        }
+      }
+    }
+    return next;
+  }
+
+  private findItem(
+    items: VomdItemData[],
+    rawItemId: string,
+  ): VomdItemData | undefined {
+    const normalizedCsvItem = this.normalizeItemReference(rawItemId);
+    return items.find((item) => {
+      const combinedName1 =
+        this.normalizeItemReference(item.unitId) +
+        this.normalizeItemReference(item.itemId);
+      const combinedName2 =
+        this.normalizeItemReference(item.unitLabel) +
+        this.normalizeItemReference(item.itemId);
+      return (
+        this.normalizeItemReference(item.itemId) === normalizedCsvItem ||
+        combinedName1 === normalizedCsvItem ||
+        combinedName2 === normalizedCsvItem
+      );
+    });
+  }
+
+  private normalizeItemReference(value: string): string {
+    return (value || "").replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+  }
+
+  private parseOccurrence(
+    row: string[],
+    bookletIdx: number,
+    positionIdx: number,
+    group: ImportGroup,
+    match: VomdItemData,
+    subId: string,
+    itemValRaw: string,
+    failed: Array<{ csvRow: string; reason: string }>,
+  ):
+    | { key: string; value: { booklet: string; position: number } }
+    | { empty: true }
+    | undefined
+    | null {
+    if (bookletIdx < 0) return undefined;
+    const booklet = row[bookletIdx]?.trim() || "";
+    const rawPosition = row[positionIdx]?.trim() || "";
+    if (!booklet && !rawPosition) {
+      if (group.emptyOccurrenceRows.length > 0) {
+        throw new BadRequestException(
+          `Konflikt: Die leere Booklet-Zuordnung für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} kommt mehrfach vor.`,
+        );
+      }
+      return { empty: true };
+    }
+    if (!booklet || !rawPosition) {
+      failed.push({
+        csvRow: itemValRaw,
+        reason: "Booklet und Position müssen gemeinsam gesetzt sein",
+      });
+      return null;
+    }
+    const position = Number(rawPosition);
+    if (!Number.isInteger(position) || position <= 0) {
+      failed.push({
+        csvRow: itemValRaw,
+        reason: "Position muss eine positive Ganzzahl sein",
+      });
+      return null;
+    }
+    const key = `${booklet}\u0000${position}`;
+    if (group.occurrences.has(key)) {
+      throw new BadRequestException(
+        `Konflikt: Booklet "${booklet}" und Position ${position} kommen für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} mehrfach vor.`,
+      );
+    }
+    return { key, value: { booklet, position } };
+  }
+
+  private validateGroupConflicts(groups: Map<string, ImportGroup>): void {
+    for (const group of groups.values()) {
+      for (const [property, values] of group.scalars.entries()) {
+        if (values.size > 1) {
+          throw new BadRequestException(
+            `Konflikt: Für Item "${group.match.itemId}"${group.subId ? ` und Sub-ID "${group.subId}"` : ""} wurden unterschiedliche Werte für ${property} geliefert.`,
+          );
+        }
+      }
+    }
+  }
+
+  private collectScopedValues(
+    groups: Map<string, ImportGroup>,
+    scalarColumns: Array<{ property: ImportedScalarProperty }>,
+    property: "itemTimeSeconds" | "stimulusTimeSeconds",
+    getScopeKey: (group: ImportGroup) => string,
+  ): Map<string, Set<number>> {
+    if (!scalarColumns.some((definition) => definition.property === property)) {
+      return new Map();
+    }
+    const valuesByScope = new Map<string, Set<number>>();
+    for (const group of groups.values()) {
+      const scopeKey = getScopeKey(group);
+      const values = valuesByScope.get(scopeKey) || new Set<number>();
+      const groupValues = group.scalars.get(property);
+      if (groupValues?.size) values.add(Array.from(groupValues)[0]);
+      valuesByScope.set(scopeKey, values);
+    }
+    return valuesByScope;
+  }
+
+  private validateScopedConflicts(
+    valuesByScope: Map<string, Set<number>>,
+    scope: "item" | "unit",
+  ): void {
+    for (const [scopeKey, values] of valuesByScope.entries()) {
+      if (values.size <= 1) continue;
+      throw new BadRequestException(
+        scope === "unit"
+          ? `Konflikt: Für Unit "${scopeKey}" wurden unterschiedliche Stimuluszeiten geliefert.`
+          : `Konflikt: Für Item "${scopeKey}" wurden unterschiedliche Itemzeiten geliefert.`,
+      );
+    }
+  }
+
+  private addItemScopeMutations(
+    mutations: ImportMutation[],
+    valuesByItem: Map<string, Set<number>>,
+    source: Record<string, Record<string, unknown>>,
+  ): void {
+    for (const [itemUuid, values] of valuesByItem.entries()) {
+      if (values.size) {
+        mutations.push({
+          action: "set",
+          scope: "item",
+          property: "itemTimeSeconds",
+          targetKeys: [itemUuid],
+          value: Array.from(values)[0],
+        });
+      } else {
+        mutations.push({
+          action: "clear",
+          scope: "item",
+          property: "itemTimeSeconds",
+          targetKeys: [itemUuid],
+        });
+      }
+      mutations.push({
+        action: "clear",
+        scope: "item",
+        property: "itemTimeSeconds",
+        targetKeys: this.getPartialCreditRowKeys(source, itemUuid),
+      });
+    }
+  }
+
+  private addUnitScopeMutations(
+    mutations: ImportMutation[],
+    valuesByUnit: Map<string, Set<number>>,
+    items: VomdItemData[],
+    source: Record<string, Record<string, unknown>>,
+  ): void {
+    const itemUuidsByUnit = new Map<string, Set<string>>();
+    for (const item of items) {
+      const itemUuids = itemUuidsByUnit.get(item.unitId) || new Set<string>();
+      itemUuids.add(item.uuid);
+      itemUuidsByUnit.set(item.unitId, itemUuids);
+    }
+    for (const [unitId, values] of valuesByUnit.entries()) {
+      for (const itemUuid of itemUuidsByUnit.get(unitId) || []) {
+        if (values.size) {
+          mutations.push({
+            action: "set",
+            scope: "unit",
+            property: "stimulusTimeSeconds",
+            targetKeys: [itemUuid],
+            value: Array.from(values)[0],
+          });
+        } else {
+          mutations.push({
+            action: "clear",
+            scope: "unit",
+            property: "stimulusTimeSeconds",
+            targetKeys: [itemUuid],
+          });
+        }
+        mutations.push({
+          action: "clear",
+          scope: "unit",
+          property: "stimulusTimeSeconds",
+          targetKeys: this.getPartialCreditRowKeys(source, itemUuid),
+        });
+      }
+    }
+  }
+
+  private getPartialCreditRowKeys(
+    itemProperties: Record<string, Record<string, unknown>>,
+    itemUuid: string,
+  ): string[] {
+    return Object.keys(itemProperties).filter(
+      (rowKey) => parseItemRowKeyParts(rowKey)?.itemUuid === itemUuid,
+    );
+  }
+
+  private parseCsvLine(line: string): string[] {
+    const cells: string[] = [];
+    let current = "";
+    let quoted = false;
+    for (let index = 0; index < line.length; index++) {
+      const character = line[index];
+      if (character === '"') {
+        if (quoted && line[index + 1] === '"') {
+          current += '"';
+          index += 1;
+        } else {
+          quoted = !quoted;
+        }
+      } else if (character === ";" && !quoted) {
+        cells.push(current);
+        current = "";
+      } else {
+        current += character;
+      }
+    }
+    cells.push(current);
+    return cells;
+  }
+
+  private cloneItemProperties(
+    source: Record<string, Record<string, unknown>>,
+  ): Record<string, Record<string, unknown>> {
+    return JSON.parse(JSON.stringify(source || {}));
+  }
+}

--- a/backend/src/items/items.controller.spec.ts
+++ b/backend/src/items/items.controller.spec.ts
@@ -10,6 +10,7 @@ describe("ItemsController", () => {
   beforeEach(() => {
     itemsService = {
       getFilteredItems: jest.fn().mockResolvedValue([{ itemId: "item-1" }]),
+      canUseItemList: jest.fn().mockResolvedValue(true),
       canUseItemTags: jest.fn().mockResolvedValue(true),
       getItemTags: jest.fn().mockResolvedValue({ item1: ["A"] }),
       getItem: jest.fn().mockResolvedValue({ itemId: "item-1" }),
@@ -93,6 +94,30 @@ describe("ItemsController", () => {
       "label",
       "asc",
     );
+  });
+
+  it("rejects item reads for non-managers when the item list is disabled", async () => {
+    itemsService.canUseItemList.mockResolvedValue(false);
+    const req = { user: { isAppAdmin: false }, acpAccessLevel: "READ_ONLY" };
+
+    await expect(
+      controller.getItems("acp-1", undefined, undefined, undefined, req),
+    ).rejects.toThrow(ForbiddenException);
+    await expect(controller.getItem("acp-1", "item-1", req)).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(itemsService.getFilteredItems).not.toHaveBeenCalled();
+    expect(itemsService.getItem).not.toHaveBeenCalled();
+  });
+
+  it("allows managers to read items when the item list is disabled", async () => {
+    itemsService.canUseItemList.mockResolvedValue(false);
+    const req = { user: { isAppAdmin: false }, acpAccessLevel: "MANAGER" };
+
+    await expect(
+      controller.getItems("acp-1", undefined, undefined, undefined, req),
+    ).resolves.toEqual([{ itemId: "item-1" }]);
+    expect(itemsService.canUseItemList).not.toHaveBeenCalled();
   });
 
   it("returns item tags for manager users", async () => {
@@ -251,6 +276,38 @@ describe("ItemsController", () => {
       expect.objectContaining({
         updated: 1,
         explorerState: { status: "DIRTY", version: 5 },
+      }),
+    );
+    expect(
+      itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("preserves the difficulty-only visibility behavior for wide imports", async () => {
+    itemsService.uploadItemParameters.mockResolvedValueOnce({
+      updated: 1,
+      failed: [],
+      successes: [{ fields: ["est", "infit"], value: -0.4 }],
+      nextItemProperties: {
+        "item-1": { empiricalDifficulty: -0.4, infit: 1.05 },
+      },
+    });
+    const file = { buffer: Buffer.from("csv-data") } as Express.Multer.File;
+
+    const result = await controller.uploadItemParameters(
+      "acp-1",
+      file,
+      "true",
+      "4",
+      { user: { sub: "u-1" } },
+    );
+
+    expect(
+      itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty,
+    ).toHaveBeenCalledWith("acp-1");
+    expect(result).toEqual(
+      expect.objectContaining({
+        showOnlyItemsWithEmpiricalDifficulty: true,
       }),
     );
   });

--- a/backend/src/items/items.controller.spec.ts
+++ b/backend/src/items/items.controller.spec.ts
@@ -21,6 +21,14 @@ describe("ItemsController", () => {
           "item-1": { id: "item-1", empiricalDifficulty: 0.7 },
         },
       }),
+      uploadItemParameters: jest.fn().mockResolvedValue({
+        updated: 1,
+        failed: [],
+        successes: ["item-1"],
+        nextItemProperties: {
+          "item-1": { infit: 1.05, itemTimeSeconds: 30 },
+        },
+      }),
       clearEmpiricalDifficulties: jest.fn().mockResolvedValue({
         nextItemProperties: {
           "item-1": { id: "item-1" },
@@ -205,6 +213,46 @@ describe("ItemsController", () => {
     );
     expect(itemExplorerStateService.patchDraft).not.toHaveBeenCalled();
     expect(itemExplorerStateService.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it("uploads wide item parameters into the explorer draft", async () => {
+    const file = { buffer: Buffer.from("csv-data") } as Express.Multer.File;
+    const req = { user: { sub: "u-1" } };
+
+    const result = await controller.uploadItemParameters(
+      "acp-1",
+      file,
+      "true",
+      "4",
+      req,
+    );
+
+    expect(itemsService.uploadItemParameters).toHaveBeenCalledWith(
+      "acp-1",
+      file.buffer,
+      {
+        persist: false,
+        itemPropertiesOverride: { "item-1": { id: "item-1" } },
+      },
+    );
+    expect(itemExplorerStateService.patchDraft).toHaveBeenCalledWith(
+      "acp-1",
+      {
+        itemProperties: {
+          "item-1": { infit: 1.05, itemTimeSeconds: 30 },
+        },
+      },
+      expect.objectContaining({
+        changeType: "CSV_UPLOAD_ITEM_PARAMETERS",
+        baseVersion: 4,
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        updated: 1,
+        explorerState: { status: "DIRTY", version: 5 },
+      }),
+    );
   });
 
   it("uploads empirical difficulties in draft mode and patches explorer state", async () => {

--- a/backend/src/items/items.controller.ts
+++ b/backend/src/items/items.controller.ts
@@ -66,7 +66,9 @@ export class ItemsController {
     @Query("filter") filter?: string,
     @Query("sortBy") sortBy?: string,
     @Query("sortDir") sortDir?: "asc" | "desc",
+    @Request() req?: any,
   ) {
+    await this.assertCanReadItemList(acpId, req);
     return this.itemsService.getFilteredItems(acpId, filter, sortBy, sortDir);
   }
 
@@ -113,7 +115,9 @@ export class ItemsController {
   async getItem(
     @Param("acpId") acpId: string,
     @Param("itemId") itemId: string,
+    @Request() req?: any,
   ) {
+    await this.assertCanReadItemList(acpId, req);
     return this.itemsService.getItem(acpId, itemId);
   }
 
@@ -165,6 +169,9 @@ export class ItemsController {
           : currentState.publishedState.itemProperties,
       },
     );
+    const importedEmpiricalDifficulty = this.hasImportedEmpiricalDifficulty(
+      uploadResult.successes,
+    );
     const actor = this.itemExplorerStateService.resolveActor(req?.user, acpId);
 
     if (!draftMode) {
@@ -182,7 +189,15 @@ export class ItemsController {
           },
         );
       }
-      return uploadResult;
+      const showOnlyItemsWithEmpiricalDifficulty = importedEmpiricalDifficulty
+        ? await this.itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty(
+            acpId,
+          )
+        : undefined;
+      return {
+        ...uploadResult,
+        showOnlyItemsWithEmpiricalDifficulty,
+      };
     }
 
     if (uploadResult.updated === 0) {
@@ -210,11 +225,17 @@ export class ItemsController {
           : parsedBaseVersion,
       },
     );
+    const showOnlyItemsWithEmpiricalDifficulty = importedEmpiricalDifficulty
+      ? await this.itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty(
+          acpId,
+        )
+      : undefined;
 
     return {
       updated: uploadResult.updated,
       failed: uploadResult.failed,
       successes: uploadResult.successes,
+      showOnlyItemsWithEmpiricalDifficulty,
       explorerState,
     };
   }
@@ -541,5 +562,32 @@ export class ItemsController {
         "Direct item-property changes are not allowed while an Item Explorer draft is pending. Use draft mode or publish/discard the draft first.",
       );
     }
+  }
+
+  private async assertCanReadItemList(acpId: string, req?: any): Promise<void> {
+    const isManager =
+      req?.user?.isAppAdmin ||
+      req?.acpAccessLevel === "MANAGER" ||
+      req?.acpAccessLevel === "ADMIN";
+    if (!isManager && !(await this.itemsService.canUseItemList(acpId))) {
+      throw new ForbiddenException("Item list is not enabled for this ACP");
+    }
+  }
+
+  private hasImportedEmpiricalDifficulty(successes: unknown): boolean {
+    return (
+      Array.isArray(successes) &&
+      successes.some((success) => {
+        if (!success || typeof success !== "object") return false;
+        const fields = (success as { fields?: unknown }).fields;
+        const value = (success as { value?: unknown }).value;
+        return (
+          Array.isArray(fields) &&
+          fields.includes("est") &&
+          typeof value === "number" &&
+          Number.isFinite(value)
+        );
+      })
+    );
   }
 }

--- a/backend/src/items/items.controller.ts
+++ b/backend/src/items/items.controller.ts
@@ -34,6 +34,18 @@ import { Roles } from "../auth/roles.decorator";
 import { IsObject } from "class-validator";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
 
+type ItemParameterImportKind = "item-parameters" | "empirical-difficulty";
+type ItemParameterImportTarget = "draft" | "published";
+
+interface ItemParameterImportCommand {
+  acpId: string;
+  fileBuffer: Buffer;
+  kind: ItemParameterImportKind;
+  target: ItemParameterImportTarget;
+  baseVersion?: number;
+  user?: unknown;
+}
+
 class SaveItemTagsDto {
   @ApiProperty({
     description: "Map of item UUID to tag list",
@@ -148,96 +160,14 @@ export class ItemsController {
     if (!file?.buffer) {
       throw new BadRequestException("A CSV file is required");
     }
-    const draftMode = draft === "true";
-    const parsedBaseVersion = parseInt(baseVersion || "", 10);
-    const currentState = await this.itemExplorerStateService.getStateForViewer(
+    return this.runItemParameterImport({
       acpId,
-      true,
-    );
-
-    if (!draftMode) {
-      this.assertCleanExplorerStateForDirectWrite(currentState.status);
-    }
-
-    const uploadResult = await this.itemsService.uploadItemParameters(
-      acpId,
-      file.buffer,
-      {
-        persist: false,
-        itemPropertiesOverride: draftMode
-          ? currentState.draftState.itemProperties
-          : currentState.publishedState.itemProperties,
-      },
-    );
-    const importedEmpiricalDifficulty = this.hasImportedEmpiricalDifficulty(
-      uploadResult.successes,
-    );
-    const actor = this.itemExplorerStateService.resolveActor(req?.user, acpId);
-
-    if (!draftMode) {
-      if (uploadResult.updated > 0) {
-        await this.itemExplorerStateService.publishItemPropertiesImmediately(
-          acpId,
-          uploadResult.nextItemProperties as Record<
-            string,
-            Record<string, unknown>
-          >,
-          {
-            actor,
-            changeType: "CSV_UPLOAD_ITEM_PARAMETERS",
-            baseVersion: currentState.version,
-          },
-        );
-      }
-      const showOnlyItemsWithEmpiricalDifficulty = importedEmpiricalDifficulty
-        ? await this.itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty(
-            acpId,
-          )
-        : undefined;
-      return {
-        ...uploadResult,
-        showOnlyItemsWithEmpiricalDifficulty,
-      };
-    }
-
-    if (uploadResult.updated === 0) {
-      return {
-        updated: 0,
-        failed: uploadResult.failed,
-        successes: uploadResult.successes,
-        explorerState: currentState,
-      };
-    }
-
-    const explorerState = await this.itemExplorerStateService.patchDraft(
-      acpId,
-      {
-        itemProperties: uploadResult.nextItemProperties as Record<
-          string,
-          Record<string, unknown>
-        >,
-      },
-      {
-        actor,
-        changeType: "CSV_UPLOAD_ITEM_PARAMETERS",
-        baseVersion: Number.isNaN(parsedBaseVersion)
-          ? undefined
-          : parsedBaseVersion,
-      },
-    );
-    const showOnlyItemsWithEmpiricalDifficulty = importedEmpiricalDifficulty
-      ? await this.itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty(
-          acpId,
-        )
-      : undefined;
-
-    return {
-      updated: uploadResult.updated,
-      failed: uploadResult.failed,
-      successes: uploadResult.successes,
-      showOnlyItemsWithEmpiricalDifficulty,
-      explorerState,
-    };
+      fileBuffer: file.buffer,
+      kind: "item-parameters",
+      target: draft === "true" ? "draft" : "published",
+      baseVersion: this.parseBaseVersion(baseVersion),
+      user: req?.user,
+    });
   }
 
   @Post("upload-empirical-difficulty")
@@ -267,96 +197,14 @@ export class ItemsController {
     @Query("baseVersion") baseVersion?: string,
     @Request() req?: any,
   ) {
-    const draftMode = draft === "true";
-    const parsedBaseVersion = parseInt(baseVersion || "", 10);
-
-    if (!draftMode) {
-      const currentState =
-        await this.itemExplorerStateService.getStateForViewer(acpId, true);
-      this.assertCleanExplorerStateForDirectWrite(currentState.status);
-      const uploadResult = await this.itemsService.uploadEmpiricalDifficulties(
-        acpId,
-        file.buffer,
-        {
-          persist: false,
-          itemPropertiesOverride: currentState.publishedState.itemProperties,
-        },
-      );
-      if (uploadResult.updated > 0) {
-        const actor = this.itemExplorerStateService.resolveActor(
-          req?.user,
-          acpId,
-        );
-        await this.itemExplorerStateService.publishItemPropertiesImmediately(
-          acpId,
-          uploadResult.nextItemProperties as Record<
-            string,
-            Record<string, unknown>
-          >,
-          {
-            actor,
-            changeType: "CSV_UPLOAD_EMPIRICAL_DIFFICULTY",
-            baseVersion: currentState.version,
-          },
-        );
-      }
-      const showOnlyItemsWithEmpiricalDifficulty =
-        uploadResult.updated > 0
-          ? await this.itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty(
-              acpId,
-            )
-          : undefined;
-
-      return {
-        ...uploadResult,
-        showOnlyItemsWithEmpiricalDifficulty,
-      };
-    }
-
-    const currentState = await this.itemExplorerStateService.getStateForViewer(
+    return this.runItemParameterImport({
       acpId,
-      true,
-    );
-    const uploadResult = await this.itemsService.uploadEmpiricalDifficulties(
-      acpId,
-      file.buffer,
-      {
-        persist: false,
-        itemPropertiesOverride: currentState.draftState.itemProperties,
-      },
-    );
-
-    const actor = this.itemExplorerStateService.resolveActor(req?.user, acpId);
-    const explorerState = await this.itemExplorerStateService.patchDraft(
-      acpId,
-      {
-        itemProperties: uploadResult.nextItemProperties as Record<
-          string,
-          Record<string, unknown>
-        >,
-      },
-      {
-        actor,
-        changeType: "CSV_UPLOAD_EMPIRICAL_DIFFICULTY",
-        baseVersion: Number.isNaN(parsedBaseVersion)
-          ? undefined
-          : parsedBaseVersion,
-      },
-    );
-    const showOnlyItemsWithEmpiricalDifficulty =
-      uploadResult.updated > 0
-        ? await this.itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty(
-            acpId,
-          )
-        : undefined;
-
-    return {
-      updated: uploadResult.updated,
-      failed: uploadResult.failed,
-      successes: uploadResult.successes,
-      showOnlyItemsWithEmpiricalDifficulty,
-      explorerState,
-    };
+      fileBuffer: file.buffer,
+      kind: "empirical-difficulty",
+      target: draft === "true" ? "draft" : "published",
+      baseVersion: this.parseBaseVersion(baseVersion),
+      user: req?.user,
+    });
   }
 
   @Delete("empirical-difficulty")
@@ -554,6 +402,105 @@ export class ItemsController {
       true,
       rowKey,
     );
+  }
+
+  private async runItemParameterImport(command: ItemParameterImportCommand) {
+    const currentState = await this.itemExplorerStateService.getStateForViewer(
+      command.acpId,
+      true,
+    );
+    if (command.target === "published") {
+      this.assertCleanExplorerStateForDirectWrite(currentState.status);
+    }
+
+    const itemProperties =
+      command.target === "draft"
+        ? currentState.draftState.itemProperties
+        : currentState.publishedState.itemProperties;
+    const uploadResult =
+      command.kind === "empirical-difficulty"
+        ? await this.itemsService.uploadEmpiricalDifficulties(
+            command.acpId,
+            command.fileBuffer,
+            { persist: false, itemPropertiesOverride: itemProperties },
+          )
+        : await this.itemsService.uploadItemParameters(
+            command.acpId,
+            command.fileBuffer,
+            { persist: false, itemPropertiesOverride: itemProperties },
+          );
+    const importedEmpiricalDifficulty =
+      command.kind === "empirical-difficulty"
+        ? uploadResult.updated > 0
+        : this.hasImportedEmpiricalDifficulty(uploadResult.successes);
+    const actor = this.itemExplorerStateService.resolveActor(
+      command.user,
+      command.acpId,
+    );
+    const changeType =
+      command.kind === "empirical-difficulty"
+        ? "CSV_UPLOAD_EMPIRICAL_DIFFICULTY"
+        : "CSV_UPLOAD_ITEM_PARAMETERS";
+
+    if (command.target === "published") {
+      if (uploadResult.updated > 0) {
+        await this.itemExplorerStateService.publishItemPropertiesImmediately(
+          command.acpId,
+          uploadResult.nextItemProperties,
+          {
+            actor,
+            changeType,
+            baseVersion: currentState.version,
+          },
+        );
+      }
+      const showOnlyItemsWithEmpiricalDifficulty = importedEmpiricalDifficulty
+        ? await this.itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty(
+            command.acpId,
+          )
+        : undefined;
+      return {
+        ...uploadResult,
+        showOnlyItemsWithEmpiricalDifficulty,
+      };
+    }
+
+    if (command.kind === "item-parameters" && uploadResult.updated === 0) {
+      return {
+        updated: 0,
+        failed: uploadResult.failed,
+        successes: uploadResult.successes,
+        explorerState: currentState,
+      };
+    }
+
+    const explorerState = await this.itemExplorerStateService.patchDraft(
+      command.acpId,
+      { itemProperties: uploadResult.nextItemProperties },
+      {
+        actor,
+        changeType,
+        baseVersion: command.baseVersion,
+      },
+    );
+    const showOnlyItemsWithEmpiricalDifficulty = importedEmpiricalDifficulty
+      ? await this.itemsService.ensureShowOnlyItemsWithEmpiricalDifficulty(
+          command.acpId,
+        )
+      : undefined;
+
+    return {
+      updated: uploadResult.updated,
+      failed: uploadResult.failed,
+      successes: uploadResult.successes,
+      showOnlyItemsWithEmpiricalDifficulty,
+      explorerState,
+    };
+  }
+
+  private parseBaseVersion(baseVersion?: string): number | undefined {
+    const parsedBaseVersion = parseInt(baseVersion || "", 10);
+    return Number.isNaN(parsedBaseVersion) ? undefined : parsedBaseVersion;
   }
 
   private assertCleanExplorerStateForDirectWrite(status: string): void {

--- a/backend/src/items/items.controller.ts
+++ b/backend/src/items/items.controller.ts
@@ -117,6 +117,108 @@ export class ItemsController {
     return this.itemsService.getItem(acpId, itemId);
   }
 
+  @Post("upload-item-parameters")
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles("ACP_MANAGER")
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: "Upload a wide CSV with empirical and additional item parameters",
+  })
+  @ApiConsumes("multipart/form-data")
+  @ApiBody({
+    schema: {
+      type: "object",
+      properties: {
+        file: { type: "string", format: "binary" },
+      },
+    },
+  })
+  @UseInterceptors(FileInterceptor("file"))
+  async uploadItemParameters(
+    @Param("acpId") acpId: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Query("draft") draft?: string,
+    @Query("baseVersion") baseVersion?: string,
+    @Request() req?: any,
+  ) {
+    if (!file?.buffer) {
+      throw new BadRequestException("A CSV file is required");
+    }
+    const draftMode = draft === "true";
+    const parsedBaseVersion = parseInt(baseVersion || "", 10);
+    const currentState = await this.itemExplorerStateService.getStateForViewer(
+      acpId,
+      true,
+    );
+
+    if (!draftMode) {
+      this.assertCleanExplorerStateForDirectWrite(currentState.status);
+    }
+
+    const uploadResult = await this.itemsService.uploadItemParameters(
+      acpId,
+      file.buffer,
+      {
+        persist: false,
+        itemPropertiesOverride: draftMode
+          ? currentState.draftState.itemProperties
+          : currentState.publishedState.itemProperties,
+      },
+    );
+    const actor = this.itemExplorerStateService.resolveActor(req?.user, acpId);
+
+    if (!draftMode) {
+      if (uploadResult.updated > 0) {
+        await this.itemExplorerStateService.publishItemPropertiesImmediately(
+          acpId,
+          uploadResult.nextItemProperties as Record<
+            string,
+            Record<string, unknown>
+          >,
+          {
+            actor,
+            changeType: "CSV_UPLOAD_ITEM_PARAMETERS",
+            baseVersion: currentState.version,
+          },
+        );
+      }
+      return uploadResult;
+    }
+
+    if (uploadResult.updated === 0) {
+      return {
+        updated: 0,
+        failed: uploadResult.failed,
+        successes: uploadResult.successes,
+        explorerState: currentState,
+      };
+    }
+
+    const explorerState = await this.itemExplorerStateService.patchDraft(
+      acpId,
+      {
+        itemProperties: uploadResult.nextItemProperties as Record<
+          string,
+          Record<string, unknown>
+        >,
+      },
+      {
+        actor,
+        changeType: "CSV_UPLOAD_ITEM_PARAMETERS",
+        baseVersion: Number.isNaN(parsedBaseVersion)
+          ? undefined
+          : parsedBaseVersion,
+      },
+    );
+
+    return {
+      updated: uploadResult.updated,
+      failed: uploadResult.failed,
+      successes: uploadResult.successes,
+      explorerState,
+    };
+  }
+
   @Post("upload-empirical-difficulty")
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles("ACP_MANAGER")

--- a/backend/src/items/items.module.ts
+++ b/backend/src/items/items.module.ts
@@ -7,6 +7,7 @@ import { Acp, AcpAccessConfig, ItemResponseState } from "../database/entities";
 import { FilesModule } from "../files/files.module";
 import { AuthModule } from "../auth/auth.module";
 import { ItemExplorerModule } from "../item-explorer/item-explorer.module";
+import { ItemParameterImportPipeline } from "./item-parameter-import.pipeline";
 
 @Module({
   imports: [
@@ -16,7 +17,11 @@ import { ItemExplorerModule } from "../item-explorer/item-explorer.module";
     ItemExplorerModule,
   ],
   controllers: [ItemsController],
-  providers: [ItemsService, ItemResponseStateService],
+  providers: [
+    ItemsService,
+    ItemResponseStateService,
+    ItemParameterImportPipeline,
+  ],
   exports: [ItemsService],
 })
 export class ItemsModule {}

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -106,6 +106,91 @@ describe("ItemsService", () => {
     ]);
   });
 
+  it("resolves explicit VOMD UUID properties and partial-credit rows in the item list", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      acpIndex: {
+        assessmentParts: [
+          {
+            units: [
+              {
+                id: "unit-1",
+                name: "Unit One",
+                items: [{ id: "item-1", name: "Item One" }],
+              },
+            ],
+          },
+        ],
+      },
+      itemProperties: {
+        "explicit-uuid::A": { infit: 1.1 },
+        "explicit-uuid::B": { infit: 1.2 },
+      },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          itemId: "item-1",
+          uuid: "explicit-uuid",
+          rowKey: "explicit-uuid::A",
+          rowNumber: 1,
+          subId: "A",
+          unitId: "unit-1",
+          unitLabel: "Unit One",
+          description: "",
+          variableId: "v1",
+          metadata: {},
+          empiricalDifficulty: 0.1,
+          infit: 1.1,
+          itemTimeSeconds: 20,
+          stimulusTimeSeconds: 10,
+          bookletOccurrences: [{ booklet: "B1", position: 3 }],
+          tags: [],
+        },
+        {
+          itemId: "item-1",
+          uuid: "explicit-uuid",
+          rowKey: "explicit-uuid::B",
+          rowNumber: 2,
+          subId: "B",
+          unitId: "unit-1",
+          unitLabel: "Unit One",
+          description: "",
+          variableId: "v1",
+          metadata: {},
+          empiricalDifficulty: 0.2,
+          infit: 1.2,
+          itemTimeSeconds: 20,
+          stimulusTimeSeconds: 10,
+          bookletOccurrences: [{ booklet: "B2", position: 4 }],
+          tags: [],
+        },
+      ],
+    });
+
+    const items = await service.getItems("acp-1");
+
+    expect(items).toHaveLength(2);
+    expect(items).toEqual([
+      expect.objectContaining({
+        itemId: "unit-1_item-1",
+        uuid: "explicit-uuid",
+        rowKey: "explicit-uuid::A",
+        subId: "A",
+        infit: 1.1,
+        bookletOccurrences: [{ booklet: "B1", position: 3 }],
+      }),
+      expect.objectContaining({
+        itemId: "unit-1_item-1",
+        uuid: "explicit-uuid",
+        rowKey: "explicit-uuid::B",
+        subId: "B",
+        infit: 1.2,
+        bookletOccurrences: [{ booklet: "B2", position: 4 }],
+      }),
+    ]);
+  });
+
   it("returns item details by id and null for unknown items", async () => {
     jest
       .spyOn(service, "getItems")
@@ -169,7 +254,33 @@ describe("ItemsService", () => {
       Buffer.from("item;est"),
     );
 
-    expect(result).toEqual({ updated: 0, failed: [] });
+    expect(result).toEqual({
+      updated: 0,
+      failed: [],
+      successes: [],
+      nextItemProperties: {},
+    });
+  });
+
+  it("accepts an item-only CSV as an unchanged import", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: { "uuid-1": { infit: 1.05 } },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({ items: [] });
+
+    const result = await service.uploadItemParameters(
+      "acp-1",
+      Buffer.from("item\nI1"),
+    );
+
+    expect(result).toEqual({
+      updated: 0,
+      failed: [],
+      successes: [],
+      nextItemProperties: { "uuid-1": { infit: 1.05 } },
+    });
+    expect(acpRepository.save).not.toHaveBeenCalled();
   });
 
   it("validates required CSV headers", async () => {
@@ -270,6 +381,242 @@ describe("ItemsService", () => {
     await expect(
       service.uploadEmpiricalDifficulties("acp-1", Buffer.from(csv)),
     ).rejects.toThrow(BadRequestException);
+  });
+
+  it("imports wide item parameters and groups multiple booklet occurrences", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: { "uuid-1": { tags: ["keep"] } },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          uuid: "uuid-1",
+          itemId: "I-1",
+          unitId: "U-1",
+          unitLabel: "Aufgabe 1",
+        },
+      ],
+    });
+
+    const csv = [
+      "item;sub_id;est;infit;discrimination;solution_rate;item_time_s;stimulus_time_s;booklet;position",
+      "I1;;0,25;1,05;0,42;0,73;35;12;B2;8",
+      "I1;;0.25;1.05;0.42;0.73;35;12;B1;3",
+    ].join("\n");
+    const result = await service.uploadItemParameters(
+      "acp-1",
+      Buffer.from(csv),
+    );
+
+    expect(result.updated).toBe(1);
+    expect(result.failed).toEqual([]);
+    expect(result.successes).toEqual([
+      expect.objectContaining({
+        fields: [
+          "est",
+          "infit",
+          "discrimination",
+          "solution_rate",
+          "item_time_s",
+          "stimulus_time_s",
+          "booklet",
+          "position",
+        ],
+        bookletOccurrences: [
+          { booklet: "B1", position: 3 },
+          { booklet: "B2", position: 8 },
+        ],
+      }),
+    ]);
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1": {
+        tags: ["keep"],
+        empiricalDifficulty: 0.25,
+        infit: 1.05,
+        discrimination: 0.42,
+        solutionRate: 0.73,
+        itemTimeSeconds: 35,
+        stimulusTimeSeconds: 12,
+        bookletOccurrences: [
+          { booklet: "B1", position: 3 },
+          { booklet: "B2", position: 8 },
+        ],
+      },
+    });
+  });
+
+  it("reports clearing booklet occurrences as an explicit field update", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {
+        "uuid-1": {
+          bookletOccurrences: [{ booklet: "B1", position: 3 }],
+        },
+      },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          uuid: "uuid-1",
+          itemId: "I-1",
+          unitId: "U-1",
+          unitLabel: "Aufgabe 1",
+        },
+      ],
+    });
+
+    const result = await service.uploadItemParameters(
+      "acp-1",
+      Buffer.from("item;booklet;position\nI1;;"),
+    );
+
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1": { bookletOccurrences: [] },
+    });
+    expect(result.successes).toEqual([
+      expect.objectContaining({
+        fields: ["booklet", "position"],
+        bookletOccurrences: [],
+      }),
+    ]);
+  });
+
+  it("rejects conflicting scalar values and duplicate booklet occurrences", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {},
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          uuid: "uuid-1",
+          itemId: "I-1",
+          unitId: "U-1",
+          unitLabel: "U1",
+        },
+      ],
+    });
+
+    await expect(
+      service.uploadItemParameters(
+        "acp-1",
+        Buffer.from("item;infit;booklet;position\nI1;1.0;B1;1\nI1;1.1;B2;2"),
+      ),
+    ).rejects.toThrow(/unterschiedliche Werte/);
+
+    await expect(
+      service.uploadItemParameters(
+        "acp-1",
+        Buffer.from("item;infit;booklet;position\nI1;1.0;B1;1\nI1;1.0;B1;1"),
+      ),
+    ).rejects.toThrow(/mehrfach vor/);
+  });
+
+  it("rejects inconsistent stimulus times within one unit", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {},
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        { uuid: "uuid-1", itemId: "I-1", unitId: "U-1", unitLabel: "U1" },
+        { uuid: "uuid-2", itemId: "I-2", unitId: "U-1", unitLabel: "U1" },
+      ],
+    });
+
+    await expect(
+      service.uploadItemParameters(
+        "acp-1",
+        Buffer.from("item;stimulus_time_s\nI1;10\nI2;12"),
+      ),
+    ).rejects.toThrow(/unterschiedliche Stimuluszeiten/);
+  });
+
+  it("accepts one stimulus time with blank repetitions in the same unit", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {},
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        { uuid: "uuid-1", itemId: "I-1", unitId: "U-1", unitLabel: "U1" },
+        { uuid: "uuid-2", itemId: "I-2", unitId: "U-1", unitLabel: "U1" },
+      ],
+    });
+
+    const result = await service.uploadItemParameters(
+      "acp-1",
+      Buffer.from("item;stimulus_time_s\nI1;10\nI2;"),
+    );
+
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1": { stimulusTimeSeconds: 10 },
+      "uuid-2": { stimulusTimeSeconds: 10 },
+    });
+  });
+
+  it("accepts one item time with blank partial-credit repetitions", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {},
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        { uuid: "uuid-1", itemId: "I-1", unitId: "U-1", unitLabel: "U1" },
+      ],
+    });
+
+    const result = await service.uploadItemParameters(
+      "acp-1",
+      Buffer.from("item;sub_id;item_time_s\nI1;A;20\nI1;B;"),
+    );
+
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1": { itemTimeSeconds: 20 },
+      "uuid-1::A": { itemUuid: "uuid-1", subId: "A" },
+      "uuid-1::B": { itemUuid: "uuid-1", subId: "B" },
+    });
+  });
+
+  it("canonicalizes item time by UUID and stimulus time across the complete unit", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {
+        "uuid-1": { stimulusTimeSeconds: 5 },
+        "uuid-1::A": {
+          itemUuid: "uuid-1",
+          subId: "A",
+          itemTimeSeconds: 3,
+          stimulusTimeSeconds: 5,
+        },
+        "uuid-1::B": {
+          itemUuid: "uuid-1",
+          subId: "B",
+          itemTimeSeconds: 4,
+          stimulusTimeSeconds: 5,
+        },
+        "uuid-2": { stimulusTimeSeconds: 6 },
+      },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        { uuid: "uuid-1", itemId: "I-1", unitId: "U-1", unitLabel: "U1" },
+        { uuid: "uuid-2", itemId: "I-2", unitId: "U-1", unitLabel: "U1" },
+      ],
+    });
+
+    const result = await service.uploadItemParameters(
+      "acp-1",
+      Buffer.from("item;sub_id;item_time_s;stimulus_time_s\nI1;A;20;12"),
+    );
+
+    expect(result.nextItemProperties).toEqual({
+      "uuid-1": { itemTimeSeconds: 20, stimulusTimeSeconds: 12 },
+      "uuid-1::A": { itemUuid: "uuid-1", subId: "A" },
+      "uuid-1::B": { itemUuid: "uuid-1", subId: "B" },
+      "uuid-2": { stimulusTimeSeconds: 12 },
+    });
   });
 
   it("imports multiple partial-credit rows for the same item by second-column Sub-ID", async () => {
@@ -450,6 +797,43 @@ describe("ItemsService", () => {
     ).rejects.toThrow(/sowohl mit als auch ohne Sub-ID/);
 
     expect(acpRepository.save).not.toHaveBeenCalled();
+  });
+
+  it("does not let an invalid row poison standard/partial mode detection", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      itemProperties: {},
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          uuid: "uuid-1",
+          itemId: "I-1",
+          unitId: "U-1",
+          unitLabel: "U1",
+        },
+      ],
+    });
+
+    const result = await service.uploadItemParameters(
+      "acp-1",
+      Buffer.from("item;sub_id;infit\nI1;A;invalid\nI1;;1.0"),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        updated: 1,
+        failed: [
+          { csvRow: "I1", reason: "Ungültiger Zahlenwert in infit" },
+        ],
+        nextItemProperties: { "uuid-1": { infit: 1 } },
+      }),
+    );
+    expect(acpRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemProperties: { "uuid-1": { infit: 1 } },
+      }),
+    );
   });
 
   it("supports dry-run upload mode without persistence", async () => {

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -815,9 +815,7 @@ describe("ItemsService", () => {
     expect(result).toEqual(
       expect.objectContaining({
         updated: 1,
-        failed: [
-          { csvRow: "I1", reason: "Ungültiger Zahlenwert in infit" },
-        ],
+        failed: [{ csvRow: "I1", reason: "Ungültiger Zahlenwert in infit" }],
         nextItemProperties: { "uuid-1": { infit: 1 } },
       }),
     );

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { ItemsService } from "./items.service";
 import { AccessModel } from "../database/entities";
+import { ItemParameterImportPipeline } from "./item-parameter-import.pipeline";
 
 describe("ItemsService", () => {
   let service: ItemsService;
@@ -32,6 +33,7 @@ describe("ItemsService", () => {
       acpRepository as any,
       accessConfigRepository as any,
       unitParserService as any,
+      new ItemParameterImportPipeline(),
     );
   });
 

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -262,24 +262,16 @@ describe("ItemsService", () => {
     });
   });
 
-  it("accepts an item-only CSV as an unchanged import", async () => {
+  it("rejects a CSV without a supported item parameter column", async () => {
     acpRepository.findOne.mockResolvedValue({
       id: "acp-1",
       itemProperties: { "uuid-1": { infit: 1.05 } },
     });
     unitParserService.getItemListFromFiles.mockResolvedValue({ items: [] });
 
-    const result = await service.uploadItemParameters(
-      "acp-1",
-      Buffer.from("item\nI1"),
-    );
-
-    expect(result).toEqual({
-      updated: 0,
-      failed: [],
-      successes: [],
-      nextItemProperties: { "uuid-1": { infit: 1.05 } },
-    });
+    await expect(
+      service.uploadItemParameters("acp-1", Buffer.from("item")),
+    ).rejects.toThrow(/at least one supported item parameter column/);
     expect(acpRepository.save).not.toHaveBeenCalled();
   });
 
@@ -1012,5 +1004,20 @@ describe("ItemsService", () => {
 
     accessConfigRepository.findOne.mockResolvedValueOnce(null);
     await expect(service.canUseItemTags("acp-1")).resolves.toBe(false);
+  });
+
+  it("checks the item-list feature switch with the public default", async () => {
+    accessConfigRepository.findOne.mockResolvedValueOnce({
+      featureConfig: { enableItemList: false },
+    });
+    await expect(service.canUseItemList("acp-1")).resolves.toBe(false);
+
+    accessConfigRepository.findOne.mockResolvedValueOnce({
+      featureConfig: { enableItemList: true },
+    });
+    await expect(service.canUseItemList("acp-1")).resolves.toBe(true);
+
+    accessConfigRepository.findOne.mockResolvedValueOnce(null);
+    await expect(service.canUseItemList("acp-1")).resolves.toBe(true);
   });
 });

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -6,7 +6,7 @@ import {
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Acp, AcpAccessConfig, AccessModel } from "../database/entities";
-import { UnitParserService } from "../files/unit-parser.service";
+import { UnitParserService, VomdItemData } from "../files/unit-parser.service";
 import { getIndexUnits } from "../acp/acp-index.utils";
 import { normalizeFeatureConfig } from "../acp/feature-config.utils";
 import {
@@ -20,14 +20,50 @@ const SHOW_ONLY_ITEMS_WITH_EMPIRICAL_DIFFICULTY_KEY =
 
 export interface ItemData {
   itemId: string;
+  uuid?: string;
+  rowKey?: string;
+  rowNumber?: number;
+  subId?: string;
+  subIdDisplay?: string;
   unitId: string;
   unitName: string;
   name: string;
   sourceVariable?: string;
   metadata?: Record<string, any>;
   empiricalDifficulty?: number;
+  infit?: number;
+  discrimination?: number;
+  solutionRate?: number;
+  itemTimeSeconds?: number;
+  stimulusTimeSeconds?: number;
+  bookletOccurrences?: Array<{ booklet: string; position: number }>;
   tags?: string[];
 }
+
+type ImportedScalarProperty =
+  | "empiricalDifficulty"
+  | "infit"
+  | "discrimination"
+  | "solutionRate"
+  | "itemTimeSeconds"
+  | "stimulusTimeSeconds";
+
+const IMPORTED_SCALAR_COLUMNS: Array<{
+  header: string;
+  property: ImportedScalarProperty;
+  nonNegative?: boolean;
+}> = [
+  { header: "est", property: "empiricalDifficulty" },
+  { header: "infit", property: "infit" },
+  { header: "discrimination", property: "discrimination" },
+  { header: "solution_rate", property: "solutionRate" },
+  { header: "item_time_s", property: "itemTimeSeconds", nonNegative: true },
+  {
+    header: "stimulus_time_s",
+    property: "stimulusTimeSeconds",
+    nonNegative: true,
+  },
+];
 
 @Injectable()
 export class ItemsService {
@@ -49,6 +85,15 @@ export class ItemsService {
     const index = acp.acpIndex as any;
     const units = getIndexUnits(index);
     const items: ItemData[] = [];
+    const parsedItemList =
+      await this.unitParserService.getItemListFromFiles(acpId);
+    const fileRowsByItem = new Map<string, VomdItemData[]>();
+    for (const fileRow of parsedItemList?.items || []) {
+      const key = `${fileRow.unitId}\u0000${fileRow.itemId}`;
+      const rows = fileRowsByItem.get(key) || [];
+      rows.push(fileRow);
+      fileRowsByItem.set(key, rows);
+    }
 
     for (const unit of units) {
       for (const item of unit.items || []) {
@@ -56,6 +101,40 @@ export class ItemsService {
           item.useUnitAliasAsPrefix !== false
             ? `${unit.id}_${item.id}`
             : item.id;
+        const fileRows =
+          fileRowsByItem.get(`${unit.id}\u0000${item.id}`) ||
+          fileRowsByItem.get(`${unit.id}\u0000${itemId}`) ||
+          [];
+
+        if (fileRows.length) {
+          for (const fileRow of fileRows) {
+            items.push({
+              itemId,
+              uuid: fileRow.uuid,
+              rowKey: fileRow.rowKey,
+              rowNumber: fileRow.rowNumber,
+              subId: fileRow.subId,
+              subIdDisplay: fileRow.subIdDisplay,
+              unitId: unit.id,
+              unitName: unit.name,
+              name: item.name || fileRow.description || item.id,
+              sourceVariable: fileRow.sourceVariable || item.sourceVariable,
+              metadata: {
+                ...(item.metadata || {}),
+                ...(fileRow.metadata || {}),
+              },
+              empiricalDifficulty: fileRow.empiricalDifficulty,
+              infit: fileRow.infit,
+              discrimination: fileRow.discrimination,
+              solutionRate: fileRow.solutionRate,
+              itemTimeSeconds: fileRow.itemTimeSeconds,
+              stimulusTimeSeconds: fileRow.stimulusTimeSeconds,
+              bookletOccurrences: fileRow.bookletOccurrences,
+              tags: fileRow.tags || [],
+            });
+          }
+          continue;
+        }
 
         const props = acp.itemProperties?.[itemId] || {};
 
@@ -67,6 +146,32 @@ export class ItemsService {
           sourceVariable: item.sourceVariable,
           metadata: item.metadata,
           empiricalDifficulty: props.empiricalDifficulty,
+          ...(this.toFiniteNumber(props.infit) !== undefined
+            ? { infit: this.toFiniteNumber(props.infit) }
+            : {}),
+          ...(this.toFiniteNumber(props.discrimination) !== undefined
+            ? { discrimination: this.toFiniteNumber(props.discrimination) }
+            : {}),
+          ...(this.toFiniteNumber(props.solutionRate) !== undefined
+            ? { solutionRate: this.toFiniteNumber(props.solutionRate) }
+            : {}),
+          ...(this.toFiniteNumber(props.itemTimeSeconds) !== undefined
+            ? { itemTimeSeconds: this.toFiniteNumber(props.itemTimeSeconds) }
+            : {}),
+          ...(this.toFiniteNumber(props.stimulusTimeSeconds) !== undefined
+            ? {
+                stimulusTimeSeconds: this.toFiniteNumber(
+                  props.stimulusTimeSeconds,
+                ),
+              }
+            : {}),
+          ...(this.normalizeBookletOccurrences(props.bookletOccurrences).length
+            ? {
+                bookletOccurrences: this.normalizeBookletOccurrences(
+                  props.bookletOccurrences,
+                ),
+              }
+            : {}),
           tags: Array.isArray(props.tags) ? props.tags : [],
         });
       }
@@ -127,6 +232,26 @@ export class ItemsService {
       itemPropertiesOverride?: Record<string, Record<string, unknown>>;
     } = {},
   ) {
+    return this.uploadItemParameters(acpId, fileBuffer, {
+      ...options,
+      requireEmpiricalDifficulty: true,
+    });
+  }
+
+  /**
+   * Upload empirical values and additional item parameters from a wide CSV.
+   * Rows that share an item/Sub-ID are grouped so booklet occurrences remain
+   * a 1:n property of one stable Explorer row.
+   */
+  async uploadItemParameters(
+    acpId: string,
+    fileBuffer: Buffer,
+    options: {
+      persist?: boolean;
+      itemPropertiesOverride?: Record<string, Record<string, unknown>>;
+      requireEmpiricalDifficulty?: boolean;
+    } = {},
+  ) {
     const acp = await this.acpRepository.findOne({ where: { id: acpId } });
     if (!acp) throw new NotFoundException("ACP not found");
 
@@ -135,35 +260,87 @@ export class ItemsService {
 
     const content = fileBuffer.toString("utf-8");
     const lines = content.split(/\r?\n/);
-    if (lines.length < 2) return { updated: 0, failed: [] };
+    if (lines.length < 2) {
+      return {
+        updated: 0,
+        failed: [],
+        successes: [],
+        nextItemProperties: this.cloneItemProperties(
+          options.itemPropertiesOverride || acp.itemProperties || {},
+        ),
+      };
+    }
 
-    const headers = this.parseCsvLine(lines[0]).map((header) =>
-      header.trim().toLowerCase(),
+    const headers = this.parseCsvLine(lines[0]).map((header, index) =>
+      header
+        .replace(index === 0 ? /^\uFEFF/ : /$^/, "")
+        .trim()
+        .toLowerCase(),
     );
     const itemIdx = headers.indexOf("item");
     const estIdx = headers.indexOf("est");
+    const canonicalSubIdIdx = headers.indexOf("sub_id");
     const subIdIdx =
-      headers.length > 2 && ![itemIdx, estIdx].includes(1) ? 1 : -1;
+      canonicalSubIdIdx >= 0
+        ? canonicalSubIdIdx
+        : options.requireEmpiricalDifficulty &&
+            headers.length > 2 &&
+            ![itemIdx, estIdx].includes(1)
+          ? 1
+          : -1;
+    const bookletIdx = headers.indexOf("booklet");
+    const positionIdx = headers.indexOf("position");
+    const hasBookletColumn = bookletIdx >= 0;
+    const hasPositionColumn = positionIdx >= 0;
 
-    if (itemIdx === -1 || estIdx === -1) {
+    if (itemIdx === -1 || (options.requireEmpiricalDifficulty && estIdx < 0)) {
       throw new BadRequestException(
-        'CSV must contain "item" and "est" columns',
+        options.requireEmpiricalDifficulty
+          ? 'CSV must contain "item" and "est" columns'
+          : 'CSV must contain an "item" column',
+      );
+    }
+    if (hasBookletColumn !== hasPositionColumn) {
+      throw new BadRequestException(
+        'CSV columns "booklet" and "position" must be provided together',
       );
     }
 
-    const failed = [];
-    const successes = [];
-    const matchedRowKeys = new Map<string, number>(); // stable row key -> row index
+    const scalarColumns = IMPORTED_SCALAR_COLUMNS.map((definition) => ({
+      ...definition,
+      index: headers.indexOf(definition.header),
+    })).filter((definition) => definition.index >= 0);
+
+    const props = this.cloneItemProperties(
+      options.itemPropertiesOverride || acp.itemProperties || {},
+    );
+    if (!scalarColumns.length && bookletIdx < 0) {
+      return {
+        updated: 0,
+        failed: [],
+        successes: [],
+        nextItemProperties: props,
+      };
+    }
+
+    const failed: Array<{ csvRow: string; reason: string }> = [];
+    const successes: Array<Record<string, unknown>> = [];
     const matchedItemModes = new Map<
       string,
       { mode: "standard" | "partial"; rowIndex: number }
     >();
-    let updatedCount = 0;
+    const groups = new Map<
+      string,
+      {
+        match: (typeof items)[number];
+        subId: string;
+        rowIndexes: number[];
+        scalars: Map<ImportedScalarProperty, Set<number>>;
+        occurrences: Map<string, { booklet: string; position: number }>;
+        emptyOccurrenceRows: number[];
+      }
+    >();
 
-    // Copy existing prop configurations
-    const props = this.cloneItemProperties(
-      options.itemPropertiesOverride || acp.itemProperties || {},
-    );
     let isUpdated = false;
 
     // Normalization helper handles variable separators
@@ -176,12 +353,17 @@ export class ItemsService {
 
       const row = this.parseCsvLine(line);
       const itemValRaw = row[itemIdx]?.trim() || "";
-      const estValRaw = row[estIdx]?.trim() || "";
       const subId = subIdIdx >= 0 ? normalizeItemSubId(row[subIdIdx]) : "";
-
-      const estValNum = parseFloat(estValRaw.replace(",", "."));
-
-      if (!itemValRaw || isNaN(estValNum)) continue;
+      if (!itemValRaw) {
+        failed.push({ csvRow: `Zeile ${i + 1}`, reason: "Item fehlt" });
+        continue;
+      }
+      if (options.requireEmpiricalDifficulty) {
+        const empiricalValue = Number(
+          (row[estIdx] || "").trim().replace(",", "."),
+        );
+        if (!Number.isFinite(empiricalValue)) continue;
+      }
 
       const normalizedCsvItem = normalize(itemValRaw);
 
@@ -201,6 +383,90 @@ export class ItemsService {
       if (match) {
         const rowKey = buildItemRowKey(match.uuid, subId);
         const mode = subId ? "partial" : "standard";
+
+        let group = groups.get(rowKey);
+        if (!group) {
+          group = {
+            match,
+            subId,
+            rowIndexes: [],
+            scalars: new Map(),
+            occurrences: new Map(),
+            emptyOccurrenceRows: [],
+          };
+          groups.set(rowKey, group);
+        }
+        if (bookletIdx < 0 && group.rowIndexes.length > 0) {
+          throw new BadRequestException(
+            `Konflikt: Die Zeile für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} kommt mehrfach in der CSV vor.`,
+          );
+        }
+
+        let invalidReason = "";
+        const rowScalars = new Map<ImportedScalarProperty, number>();
+        for (const definition of scalarColumns) {
+          const rawValue = row[definition.index]?.trim() || "";
+          if (!rawValue) continue;
+          const value = Number(rawValue.replace(",", "."));
+          if (!Number.isFinite(value)) {
+            invalidReason = `Ungültiger Zahlenwert in ${definition.header}`;
+            break;
+          }
+          if (definition.nonNegative && value < 0) {
+            invalidReason = `${definition.header} darf nicht negativ sein`;
+            break;
+          }
+          rowScalars.set(definition.property, value);
+        }
+        if (invalidReason) {
+          failed.push({ csvRow: itemValRaw, reason: invalidReason });
+          if (!group.rowIndexes.length) groups.delete(rowKey);
+          continue;
+        }
+
+        let occurrence:
+          | { key: string; value: { booklet: string; position: number } }
+          | undefined;
+        let emptyOccurrence = false;
+        if (bookletIdx >= 0) {
+          const booklet = row[bookletIdx]?.trim() || "";
+          const rawPosition = row[positionIdx]?.trim() || "";
+          if (!booklet && !rawPosition) {
+            if (group.emptyOccurrenceRows.length > 0) {
+              throw new BadRequestException(
+                `Konflikt: Die leere Booklet-Zuordnung für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} kommt mehrfach vor.`,
+              );
+            }
+            emptyOccurrence = true;
+          } else if (!booklet || !rawPosition) {
+            failed.push({
+              csvRow: itemValRaw,
+              reason: "Booklet und Position müssen gemeinsam gesetzt sein",
+            });
+            if (!group.rowIndexes.length) groups.delete(rowKey);
+            continue;
+          } else {
+            const position = Number(rawPosition);
+            if (!Number.isInteger(position) || position <= 0) {
+              failed.push({
+                csvRow: itemValRaw,
+                reason: "Position muss eine positive Ganzzahl sein",
+              });
+              if (!group.rowIndexes.length) groups.delete(rowKey);
+              continue;
+            }
+            const occurrenceKey = `${booklet}\u0000${position}`;
+            if (group.occurrences.has(occurrenceKey)) {
+              throw new BadRequestException(
+                `Konflikt: Booklet "${booklet}" und Position ${position} kommen für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} mehrfach vor.`,
+              );
+            }
+            occurrence = {
+              key: occurrenceKey,
+              value: { booklet, position },
+            };
+          }
+        }
         const previousMode = matchedItemModes.get(match.uuid);
         if (previousMode && previousMode.mode !== mode) {
           throw new BadRequestException(
@@ -208,57 +474,180 @@ export class ItemsService {
           );
         }
         matchedItemModes.set(match.uuid, { mode, rowIndex: i });
-
-        if (matchedRowKeys.has(rowKey)) {
-          throw new BadRequestException(
-            `Konflikt: Die Zeile für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} kommt mehrfach in der CSV vor (Zeile ${matchedRowKeys.get(rowKey)! + 1} und Zeile ${i + 1}). Bitte bereinigen Sie die Datei.`,
-          );
-        }
-        matchedRowKeys.set(rowKey, i);
-
-        const partialRowKeys = this.getPartialCreditRowKeys(props, match.uuid);
-        let affectedRowKeys = [rowKey];
-        if (mode === "standard" && partialRowKeys.length) {
-          affectedRowKeys = partialRowKeys;
-          if (props[match.uuid]?.empiricalDifficulty !== undefined) {
-            delete props[match.uuid].empiricalDifficulty;
-          }
-          for (const partialRowKey of partialRowKeys) {
-            props[partialRowKey] = {
-              ...props[partialRowKey],
-              empiricalDifficulty: estValNum,
-            };
-          }
-        } else {
-          if (
-            mode === "partial" &&
-            props[match.uuid]?.empiricalDifficulty !== undefined
-          ) {
-            delete props[match.uuid].empiricalDifficulty;
-          }
-          props[rowKey] = {
-            ...props[rowKey],
-            ...(subId ? { itemUuid: match.uuid, subId } : {}),
-            empiricalDifficulty: estValNum,
-          };
-        }
-        successes.push({
-          itemId: match.itemId,
-          unitId: match.unitId,
-          ...(affectedRowKeys.length === 1
-            ? { rowKey: affectedRowKeys[0] }
-            : {}),
-          affectedRowKeys,
-          subId: subId || undefined,
-          value: estValNum,
+        rowScalars.forEach((value, property) => {
+          const values = group.scalars.get(property) || new Set<number>();
+          values.add(value);
+          group.scalars.set(property, values);
         });
-        updatedCount++;
-        isUpdated = true;
+        if (occurrence) {
+          group.occurrences.set(occurrence.key, occurrence.value);
+        }
+        if (emptyOccurrence) group.emptyOccurrenceRows.push(i);
+        group.rowIndexes.push(i);
       } else {
         failed.push({
           csvRow: itemValRaw,
           reason: "Kein passendes Item gefunden",
         });
+      }
+    }
+
+    for (const group of groups.values()) {
+      for (const [property, values] of group.scalars.entries()) {
+        if (values.size > 1) {
+          throw new BadRequestException(
+            `Konflikt: Für Item "${group.match.itemId}"${group.subId ? ` und Sub-ID "${group.subId}"` : ""} wurden unterschiedliche Werte für ${property} geliefert.`,
+          );
+        }
+      }
+    }
+
+    const hasStimulusColumn = scalarColumns.some(
+      (definition) => definition.property === "stimulusTimeSeconds",
+    );
+    const hasItemTimeColumn = scalarColumns.some(
+      (definition) => definition.property === "itemTimeSeconds",
+    );
+    const stimulusTimesByUnit = new Map<string, Set<number>>();
+    const itemTimesByUuid = new Map<string, Set<number>>();
+    for (const group of groups.values()) {
+      const values = group.scalars.get("stimulusTimeSeconds");
+      if (hasStimulusColumn) {
+        const unitValues =
+          stimulusTimesByUnit.get(group.match.unitId) || new Set<number>();
+        if (values?.size) unitValues.add(Array.from(values)[0]);
+        stimulusTimesByUnit.set(group.match.unitId, unitValues);
+      }
+
+      const itemTimeValues = group.scalars.get("itemTimeSeconds");
+      if (hasItemTimeColumn) {
+        const valuesForItem =
+          itemTimesByUuid.get(group.match.uuid) || new Set<number>();
+        if (itemTimeValues?.size) {
+          valuesForItem.add(Array.from(itemTimeValues)[0]);
+        }
+        itemTimesByUuid.set(group.match.uuid, valuesForItem);
+      }
+    }
+    for (const [unitId, values] of stimulusTimesByUnit.entries()) {
+      if (values.size > 1) {
+        throw new BadRequestException(
+          `Konflikt: Für Unit "${unitId}" wurden unterschiedliche Stimuluszeiten geliefert.`,
+        );
+      }
+    }
+    for (const [itemUuid, values] of itemTimesByUuid.entries()) {
+      if (values.size > 1) {
+        throw new BadRequestException(
+          `Konflikt: Für Item "${itemUuid}" wurden unterschiedliche Itemzeiten geliefert.`,
+        );
+      }
+    }
+
+    for (const [rowKey, group] of groups.entries()) {
+      const partialRowKeys = this.getPartialCreditRowKeys(
+        props,
+        group.match.uuid,
+      );
+      const affectedRowKeys =
+        !group.subId && partialRowKeys.length ? partialRowKeys : [rowKey];
+      const importedProperties = scalarColumns.map(
+        (definition) => definition.property,
+      );
+      const bookletOccurrences =
+        bookletIdx >= 0
+          ? Array.from(group.occurrences.values()).sort(
+              (left, right) =>
+                left.booklet.localeCompare(right.booklet, "de", {
+                  numeric: true,
+                }) || left.position - right.position,
+            )
+          : undefined;
+
+      if (group.subId || affectedRowKeys.length > 1) {
+        const base = props[group.match.uuid];
+        if (base) {
+          for (const property of importedProperties) delete base[property];
+          if (bookletIdx >= 0) delete base.bookletOccurrences;
+        }
+      }
+
+      for (const affectedRowKey of affectedRowKeys) {
+        const nextProperties: Record<string, unknown> = {
+          ...(props[affectedRowKey] || {}),
+          ...(group.subId
+            ? { itemUuid: group.match.uuid, subId: group.subId }
+            : {}),
+        };
+        for (const definition of scalarColumns) {
+          const values = group.scalars.get(definition.property);
+          if (values?.size) {
+            nextProperties[definition.property] = Array.from(values)[0];
+          } else {
+            delete nextProperties[definition.property];
+          }
+        }
+        if (bookletOccurrences) {
+          nextProperties.bookletOccurrences = bookletOccurrences;
+        }
+        props[affectedRowKey] = nextProperties;
+      }
+
+      successes.push({
+        itemId: group.match.itemId,
+        unitId: group.match.unitId,
+        ...(affectedRowKeys.length === 1 ? { rowKey: affectedRowKeys[0] } : {}),
+        affectedRowKeys,
+        subId: group.subId || undefined,
+        ...(!options.requireEmpiricalDifficulty
+          ? {
+              fields: [
+                ...scalarColumns.map((definition) => definition.header),
+                ...(bookletIdx >= 0 ? ["booklet", "position"] : []),
+              ],
+            }
+          : {}),
+        ...(group.scalars.get("empiricalDifficulty")?.size
+          ? {
+              value: Array.from(
+                group.scalars.get("empiricalDifficulty") as Set<number>,
+              )[0],
+            }
+          : {}),
+        ...(!options.requireEmpiricalDifficulty && bookletIdx >= 0
+          ? { bookletOccurrences }
+          : {}),
+      });
+      isUpdated = true;
+    }
+
+    if (hasItemTimeColumn) {
+      for (const [itemUuid, values] of itemTimesByUuid.entries()) {
+        this.setCanonicalItemProperty(
+          props,
+          itemUuid,
+          "itemTimeSeconds",
+          this.parseImportedTimeValue(values),
+        );
+      }
+    }
+    if (hasStimulusColumn) {
+      const itemUuidsByUnit = new Map<string, Set<string>>();
+      for (const item of items) {
+        const itemUuids = itemUuidsByUnit.get(item.unitId) || new Set<string>();
+        itemUuids.add(item.uuid);
+        itemUuidsByUnit.set(item.unitId, itemUuids);
+      }
+      for (const [unitId, values] of stimulusTimesByUnit.entries()) {
+        const stimulusTime = this.parseImportedTimeValue(values);
+        for (const itemUuid of itemUuidsByUnit.get(unitId) || []) {
+          this.setCanonicalItemProperty(
+            props,
+            itemUuid,
+            "stimulusTimeSeconds",
+            stimulusTime,
+          );
+        }
       }
     }
 
@@ -268,11 +657,77 @@ export class ItemsService {
     }
 
     return {
-      updated: updatedCount,
+      updated: groups.size,
       failed,
       successes,
       nextItemProperties: props,
     };
+  }
+
+  private toFiniteNumber(value: unknown): number | undefined {
+    const numberValue = Number(value);
+    return value === undefined ||
+      value === null ||
+      !Number.isFinite(numberValue)
+      ? undefined
+      : numberValue;
+  }
+
+  private normalizeBookletOccurrences(
+    value: unknown,
+  ): Array<{ booklet: string; position: number }> {
+    if (!Array.isArray(value)) return [];
+    return value
+      .map((entry) => {
+        const booklet =
+          entry && typeof entry === "object" && "booklet" in entry
+            ? String((entry as { booklet?: unknown }).booklet || "").trim()
+            : "";
+        const position =
+          entry && typeof entry === "object" && "position" in entry
+            ? Number((entry as { position?: unknown }).position)
+            : Number.NaN;
+        return { booklet, position };
+      })
+      .filter(
+        (entry) =>
+          entry.booklet.length > 0 &&
+          Number.isInteger(entry.position) &&
+          entry.position > 0,
+      )
+      .sort(
+        (left, right) =>
+          left.booklet.localeCompare(right.booklet, "de", { numeric: true }) ||
+          left.position - right.position,
+      );
+  }
+
+  private parseImportedTimeValue(values: Set<number>): number | undefined {
+    return Array.from(values)[0];
+  }
+
+  private setCanonicalItemProperty(
+    itemProperties: Record<string, Record<string, unknown>>,
+    itemUuid: string,
+    property: "itemTimeSeconds" | "stimulusTimeSeconds",
+    value: number | undefined,
+  ): void {
+    const baseProperties = { ...(itemProperties[itemUuid] || {}) };
+    if (value === undefined) delete baseProperties[property];
+    else baseProperties[property] = value;
+    if (Object.keys(baseProperties).length || itemProperties[itemUuid]) {
+      itemProperties[itemUuid] = baseProperties;
+    }
+    for (const rowKey of this.getPartialCreditRowKeys(
+      itemProperties,
+      itemUuid,
+    )) {
+      if (itemProperties[rowKey]?.[property] !== undefined) {
+        const rowProperties = { ...itemProperties[rowKey] };
+        delete rowProperties[property];
+        itemProperties[rowKey] = rowProperties;
+      }
+    }
   }
 
   private getPartialCreditRowKeys(

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -260,16 +260,6 @@ export class ItemsService {
 
     const content = fileBuffer.toString("utf-8");
     const lines = content.split(/\r?\n/);
-    if (lines.length < 2) {
-      return {
-        updated: 0,
-        failed: [],
-        successes: [],
-        nextItemProperties: this.cloneItemProperties(
-          options.itemPropertiesOverride || acp.itemProperties || {},
-        ),
-      };
-    }
 
     const headers = this.parseCsvLine(lines[0]).map((header, index) =>
       header
@@ -315,12 +305,9 @@ export class ItemsService {
       options.itemPropertiesOverride || acp.itemProperties || {},
     );
     if (!scalarColumns.length && bookletIdx < 0) {
-      return {
-        updated: 0,
-        failed: [],
-        successes: [],
-        nextItemProperties: props,
-      };
+      throw new BadRequestException(
+        'CSV must contain at least one supported item parameter column: "est", "infit", "discrimination", "solution_rate", "item_time_s", "stimulus_time_s", or the pair "booklet" and "position"',
+      );
     }
 
     const failed: Array<{ csvRow: string; reason: string }> = [];
@@ -812,6 +799,17 @@ export class ItemsService {
       unknown
     >;
     return Boolean(featureConfig.enableItemListTags);
+  }
+
+  async canUseItemList(acpId: string): Promise<boolean> {
+    const config = await this.accessConfigRepository.findOne({
+      where: { acpId },
+    });
+    const featureConfig = (config?.featureConfig || {}) as Record<
+      string,
+      unknown
+    >;
+    return featureConfig.enableItemList !== false;
   }
 
   async ensureShowOnlyItemsWithEmpiricalDifficulty(

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -1,19 +1,12 @@
-import {
-  Injectable,
-  NotFoundException,
-  BadRequestException,
-} from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Acp, AcpAccessConfig, AccessModel } from "../database/entities";
 import { UnitParserService, VomdItemData } from "../files/unit-parser.service";
 import { getIndexUnits } from "../acp/acp-index.utils";
 import { normalizeFeatureConfig } from "../acp/feature-config.utils";
-import {
-  buildItemRowKey,
-  normalizeItemSubId,
-  parseItemRowKeyParts,
-} from "./item-row-key.util";
+import { parseItemRowKeyParts } from "./item-row-key.util";
+import { ItemParameterImportPipeline } from "./item-parameter-import.pipeline";
 
 const SHOW_ONLY_ITEMS_WITH_EMPIRICAL_DIFFICULTY_KEY =
   "showOnlyItemsWithEmpiricalDifficulty";
@@ -40,31 +33,6 @@ export interface ItemData {
   tags?: string[];
 }
 
-type ImportedScalarProperty =
-  | "empiricalDifficulty"
-  | "infit"
-  | "discrimination"
-  | "solutionRate"
-  | "itemTimeSeconds"
-  | "stimulusTimeSeconds";
-
-const IMPORTED_SCALAR_COLUMNS: Array<{
-  header: string;
-  property: ImportedScalarProperty;
-  nonNegative?: boolean;
-}> = [
-  { header: "est", property: "empiricalDifficulty" },
-  { header: "infit", property: "infit" },
-  { header: "discrimination", property: "discrimination" },
-  { header: "solution_rate", property: "solutionRate" },
-  { header: "item_time_s", property: "itemTimeSeconds", nonNegative: true },
-  {
-    header: "stimulus_time_s",
-    property: "stimulusTimeSeconds",
-    nonNegative: true,
-  },
-];
-
 @Injectable()
 export class ItemsService {
   constructor(
@@ -73,6 +41,7 @@ export class ItemsService {
     @InjectRepository(AcpAccessConfig)
     private readonly accessConfigRepository: Repository<AcpAccessConfig>,
     private readonly unitParserService: UnitParserService,
+    private readonly itemParameterImportPipeline: ItemParameterImportPipeline,
   ) {}
 
   /**
@@ -255,400 +224,21 @@ export class ItemsService {
     const acp = await this.acpRepository.findOne({ where: { id: acpId } });
     if (!acp) throw new NotFoundException("ACP not found");
 
-    const result = await this.unitParserService.getItemListFromFiles(acpId);
-    const items = result.items || [];
+    const itemList = await this.unitParserService.getItemListFromFiles(acpId);
+    const result = this.itemParameterImportPipeline.execute({
+      fileBuffer,
+      items: itemList.items || [],
+      itemProperties:
+        options.itemPropertiesOverride || acp.itemProperties || {},
+      requireEmpiricalDifficulty: options.requireEmpiricalDifficulty,
+    });
 
-    const content = fileBuffer.toString("utf-8");
-    const lines = content.split(/\r?\n/);
-
-    const headers = this.parseCsvLine(lines[0]).map((header, index) =>
-      header
-        .replace(index === 0 ? /^\uFEFF/ : /$^/, "")
-        .trim()
-        .toLowerCase(),
-    );
-    const itemIdx = headers.indexOf("item");
-    const estIdx = headers.indexOf("est");
-    const canonicalSubIdIdx = headers.indexOf("sub_id");
-    const subIdIdx =
-      canonicalSubIdIdx >= 0
-        ? canonicalSubIdIdx
-        : options.requireEmpiricalDifficulty &&
-            headers.length > 2 &&
-            ![itemIdx, estIdx].includes(1)
-          ? 1
-          : -1;
-    const bookletIdx = headers.indexOf("booklet");
-    const positionIdx = headers.indexOf("position");
-    const hasBookletColumn = bookletIdx >= 0;
-    const hasPositionColumn = positionIdx >= 0;
-
-    if (itemIdx === -1 || (options.requireEmpiricalDifficulty && estIdx < 0)) {
-      throw new BadRequestException(
-        options.requireEmpiricalDifficulty
-          ? 'CSV must contain "item" and "est" columns'
-          : 'CSV must contain an "item" column',
-      );
-    }
-    if (hasBookletColumn !== hasPositionColumn) {
-      throw new BadRequestException(
-        'CSV columns "booklet" and "position" must be provided together',
-      );
-    }
-
-    const scalarColumns = IMPORTED_SCALAR_COLUMNS.map((definition) => ({
-      ...definition,
-      index: headers.indexOf(definition.header),
-    })).filter((definition) => definition.index >= 0);
-
-    const props = this.cloneItemProperties(
-      options.itemPropertiesOverride || acp.itemProperties || {},
-    );
-    if (!scalarColumns.length && bookletIdx < 0) {
-      throw new BadRequestException(
-        'CSV must contain at least one supported item parameter column: "est", "infit", "discrimination", "solution_rate", "item_time_s", "stimulus_time_s", or the pair "booklet" and "position"',
-      );
-    }
-
-    const failed: Array<{ csvRow: string; reason: string }> = [];
-    const successes: Array<Record<string, unknown>> = [];
-    const matchedItemModes = new Map<
-      string,
-      { mode: "standard" | "partial"; rowIndex: number }
-    >();
-    const groups = new Map<
-      string,
-      {
-        match: (typeof items)[number];
-        subId: string;
-        rowIndexes: number[];
-        scalars: Map<ImportedScalarProperty, Set<number>>;
-        occurrences: Map<string, { booklet: string; position: number }>;
-        emptyOccurrenceRows: number[];
-      }
-    >();
-
-    let isUpdated = false;
-
-    // Normalization helper handles variable separators
-    const normalize = (str: string) =>
-      (str || "").replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
-
-    for (let i = 1; i < lines.length; i++) {
-      const line = lines[i].trim();
-      if (!line) continue;
-
-      const row = this.parseCsvLine(line);
-      const itemValRaw = row[itemIdx]?.trim() || "";
-      const subId = subIdIdx >= 0 ? normalizeItemSubId(row[subIdIdx]) : "";
-      if (!itemValRaw) {
-        failed.push({ csvRow: `Zeile ${i + 1}`, reason: "Item fehlt" });
-        continue;
-      }
-      if (options.requireEmpiricalDifficulty) {
-        const empiricalValue = Number(
-          (row[estIdx] || "").trim().replace(",", "."),
-        );
-        if (!Number.isFinite(empiricalValue)) continue;
-      }
-
-      const normalizedCsvItem = normalize(itemValRaw);
-
-      const match = items.find((existingItem) => {
-        const combinedName1 =
-          normalize(existingItem.unitId) + normalize(existingItem.itemId);
-        const combinedName2 =
-          normalize(existingItem.unitLabel) + normalize(existingItem.itemId);
-        const normalizedId = normalize(existingItem.itemId);
-        return (
-          normalizedId === normalizedCsvItem ||
-          combinedName1 === normalizedCsvItem ||
-          combinedName2 === normalizedCsvItem
-        );
-      });
-
-      if (match) {
-        const rowKey = buildItemRowKey(match.uuid, subId);
-        const mode = subId ? "partial" : "standard";
-
-        let group = groups.get(rowKey);
-        if (!group) {
-          group = {
-            match,
-            subId,
-            rowIndexes: [],
-            scalars: new Map(),
-            occurrences: new Map(),
-            emptyOccurrenceRows: [],
-          };
-          groups.set(rowKey, group);
-        }
-        if (bookletIdx < 0 && group.rowIndexes.length > 0) {
-          throw new BadRequestException(
-            `Konflikt: Die Zeile für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} kommt mehrfach in der CSV vor.`,
-          );
-        }
-
-        let invalidReason = "";
-        const rowScalars = new Map<ImportedScalarProperty, number>();
-        for (const definition of scalarColumns) {
-          const rawValue = row[definition.index]?.trim() || "";
-          if (!rawValue) continue;
-          const value = Number(rawValue.replace(",", "."));
-          if (!Number.isFinite(value)) {
-            invalidReason = `Ungültiger Zahlenwert in ${definition.header}`;
-            break;
-          }
-          if (definition.nonNegative && value < 0) {
-            invalidReason = `${definition.header} darf nicht negativ sein`;
-            break;
-          }
-          rowScalars.set(definition.property, value);
-        }
-        if (invalidReason) {
-          failed.push({ csvRow: itemValRaw, reason: invalidReason });
-          if (!group.rowIndexes.length) groups.delete(rowKey);
-          continue;
-        }
-
-        let occurrence:
-          | { key: string; value: { booklet: string; position: number } }
-          | undefined;
-        let emptyOccurrence = false;
-        if (bookletIdx >= 0) {
-          const booklet = row[bookletIdx]?.trim() || "";
-          const rawPosition = row[positionIdx]?.trim() || "";
-          if (!booklet && !rawPosition) {
-            if (group.emptyOccurrenceRows.length > 0) {
-              throw new BadRequestException(
-                `Konflikt: Die leere Booklet-Zuordnung für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} kommt mehrfach vor.`,
-              );
-            }
-            emptyOccurrence = true;
-          } else if (!booklet || !rawPosition) {
-            failed.push({
-              csvRow: itemValRaw,
-              reason: "Booklet und Position müssen gemeinsam gesetzt sein",
-            });
-            if (!group.rowIndexes.length) groups.delete(rowKey);
-            continue;
-          } else {
-            const position = Number(rawPosition);
-            if (!Number.isInteger(position) || position <= 0) {
-              failed.push({
-                csvRow: itemValRaw,
-                reason: "Position muss eine positive Ganzzahl sein",
-              });
-              if (!group.rowIndexes.length) groups.delete(rowKey);
-              continue;
-            }
-            const occurrenceKey = `${booklet}\u0000${position}`;
-            if (group.occurrences.has(occurrenceKey)) {
-              throw new BadRequestException(
-                `Konflikt: Booklet "${booklet}" und Position ${position} kommen für Item "${match.itemId}"${subId ? ` und Sub-ID "${subId}"` : ""} mehrfach vor.`,
-              );
-            }
-            occurrence = {
-              key: occurrenceKey,
-              value: { booklet, position },
-            };
-          }
-        }
-        const previousMode = matchedItemModes.get(match.uuid);
-        if (previousMode && previousMode.mode !== mode) {
-          throw new BadRequestException(
-            `Konflikt: Das Item "${match.itemId}" wird in derselben CSV sowohl mit als auch ohne Sub-ID verwendet (Zeile ${previousMode.rowIndex + 1} und Zeile ${i + 1}). Bitte verwenden Sie pro Item nur eine Darstellungsform.`,
-          );
-        }
-        matchedItemModes.set(match.uuid, { mode, rowIndex: i });
-        rowScalars.forEach((value, property) => {
-          const values = group.scalars.get(property) || new Set<number>();
-          values.add(value);
-          group.scalars.set(property, values);
-        });
-        if (occurrence) {
-          group.occurrences.set(occurrence.key, occurrence.value);
-        }
-        if (emptyOccurrence) group.emptyOccurrenceRows.push(i);
-        group.rowIndexes.push(i);
-      } else {
-        failed.push({
-          csvRow: itemValRaw,
-          reason: "Kein passendes Item gefunden",
-        });
-      }
-    }
-
-    for (const group of groups.values()) {
-      for (const [property, values] of group.scalars.entries()) {
-        if (values.size > 1) {
-          throw new BadRequestException(
-            `Konflikt: Für Item "${group.match.itemId}"${group.subId ? ` und Sub-ID "${group.subId}"` : ""} wurden unterschiedliche Werte für ${property} geliefert.`,
-          );
-        }
-      }
-    }
-
-    const hasStimulusColumn = scalarColumns.some(
-      (definition) => definition.property === "stimulusTimeSeconds",
-    );
-    const hasItemTimeColumn = scalarColumns.some(
-      (definition) => definition.property === "itemTimeSeconds",
-    );
-    const stimulusTimesByUnit = new Map<string, Set<number>>();
-    const itemTimesByUuid = new Map<string, Set<number>>();
-    for (const group of groups.values()) {
-      const values = group.scalars.get("stimulusTimeSeconds");
-      if (hasStimulusColumn) {
-        const unitValues =
-          stimulusTimesByUnit.get(group.match.unitId) || new Set<number>();
-        if (values?.size) unitValues.add(Array.from(values)[0]);
-        stimulusTimesByUnit.set(group.match.unitId, unitValues);
-      }
-
-      const itemTimeValues = group.scalars.get("itemTimeSeconds");
-      if (hasItemTimeColumn) {
-        const valuesForItem =
-          itemTimesByUuid.get(group.match.uuid) || new Set<number>();
-        if (itemTimeValues?.size) {
-          valuesForItem.add(Array.from(itemTimeValues)[0]);
-        }
-        itemTimesByUuid.set(group.match.uuid, valuesForItem);
-      }
-    }
-    for (const [unitId, values] of stimulusTimesByUnit.entries()) {
-      if (values.size > 1) {
-        throw new BadRequestException(
-          `Konflikt: Für Unit "${unitId}" wurden unterschiedliche Stimuluszeiten geliefert.`,
-        );
-      }
-    }
-    for (const [itemUuid, values] of itemTimesByUuid.entries()) {
-      if (values.size > 1) {
-        throw new BadRequestException(
-          `Konflikt: Für Item "${itemUuid}" wurden unterschiedliche Itemzeiten geliefert.`,
-        );
-      }
-    }
-
-    for (const [rowKey, group] of groups.entries()) {
-      const partialRowKeys = this.getPartialCreditRowKeys(
-        props,
-        group.match.uuid,
-      );
-      const affectedRowKeys =
-        !group.subId && partialRowKeys.length ? partialRowKeys : [rowKey];
-      const importedProperties = scalarColumns.map(
-        (definition) => definition.property,
-      );
-      const bookletOccurrences =
-        bookletIdx >= 0
-          ? Array.from(group.occurrences.values()).sort(
-              (left, right) =>
-                left.booklet.localeCompare(right.booklet, "de", {
-                  numeric: true,
-                }) || left.position - right.position,
-            )
-          : undefined;
-
-      if (group.subId || affectedRowKeys.length > 1) {
-        const base = props[group.match.uuid];
-        if (base) {
-          for (const property of importedProperties) delete base[property];
-          if (bookletIdx >= 0) delete base.bookletOccurrences;
-        }
-      }
-
-      for (const affectedRowKey of affectedRowKeys) {
-        const nextProperties: Record<string, unknown> = {
-          ...(props[affectedRowKey] || {}),
-          ...(group.subId
-            ? { itemUuid: group.match.uuid, subId: group.subId }
-            : {}),
-        };
-        for (const definition of scalarColumns) {
-          const values = group.scalars.get(definition.property);
-          if (values?.size) {
-            nextProperties[definition.property] = Array.from(values)[0];
-          } else {
-            delete nextProperties[definition.property];
-          }
-        }
-        if (bookletOccurrences) {
-          nextProperties.bookletOccurrences = bookletOccurrences;
-        }
-        props[affectedRowKey] = nextProperties;
-      }
-
-      successes.push({
-        itemId: group.match.itemId,
-        unitId: group.match.unitId,
-        ...(affectedRowKeys.length === 1 ? { rowKey: affectedRowKeys[0] } : {}),
-        affectedRowKeys,
-        subId: group.subId || undefined,
-        ...(!options.requireEmpiricalDifficulty
-          ? {
-              fields: [
-                ...scalarColumns.map((definition) => definition.header),
-                ...(bookletIdx >= 0 ? ["booklet", "position"] : []),
-              ],
-            }
-          : {}),
-        ...(group.scalars.get("empiricalDifficulty")?.size
-          ? {
-              value: Array.from(
-                group.scalars.get("empiricalDifficulty") as Set<number>,
-              )[0],
-            }
-          : {}),
-        ...(!options.requireEmpiricalDifficulty && bookletIdx >= 0
-          ? { bookletOccurrences }
-          : {}),
-      });
-      isUpdated = true;
-    }
-
-    if (hasItemTimeColumn) {
-      for (const [itemUuid, values] of itemTimesByUuid.entries()) {
-        this.setCanonicalItemProperty(
-          props,
-          itemUuid,
-          "itemTimeSeconds",
-          this.parseImportedTimeValue(values),
-        );
-      }
-    }
-    if (hasStimulusColumn) {
-      const itemUuidsByUnit = new Map<string, Set<string>>();
-      for (const item of items) {
-        const itemUuids = itemUuidsByUnit.get(item.unitId) || new Set<string>();
-        itemUuids.add(item.uuid);
-        itemUuidsByUnit.set(item.unitId, itemUuids);
-      }
-      for (const [unitId, values] of stimulusTimesByUnit.entries()) {
-        const stimulusTime = this.parseImportedTimeValue(values);
-        for (const itemUuid of itemUuidsByUnit.get(unitId) || []) {
-          this.setCanonicalItemProperty(
-            props,
-            itemUuid,
-            "stimulusTimeSeconds",
-            stimulusTime,
-          );
-        }
-      }
-    }
-
-    if (isUpdated && options.persist !== false) {
-      acp.itemProperties = props;
+    if (result.updated > 0 && options.persist !== false) {
+      acp.itemProperties = result.nextItemProperties;
       await this.acpRepository.save(acp);
     }
 
-    return {
-      updated: groups.size,
-      failed,
-      successes,
-      nextItemProperties: props,
-    };
+    return result;
   }
 
   private toFiniteNumber(value: unknown): number | undefined {
@@ -687,68 +277,6 @@ export class ItemsService {
           left.booklet.localeCompare(right.booklet, "de", { numeric: true }) ||
           left.position - right.position,
       );
-  }
-
-  private parseImportedTimeValue(values: Set<number>): number | undefined {
-    return Array.from(values)[0];
-  }
-
-  private setCanonicalItemProperty(
-    itemProperties: Record<string, Record<string, unknown>>,
-    itemUuid: string,
-    property: "itemTimeSeconds" | "stimulusTimeSeconds",
-    value: number | undefined,
-  ): void {
-    const baseProperties = { ...(itemProperties[itemUuid] || {}) };
-    if (value === undefined) delete baseProperties[property];
-    else baseProperties[property] = value;
-    if (Object.keys(baseProperties).length || itemProperties[itemUuid]) {
-      itemProperties[itemUuid] = baseProperties;
-    }
-    for (const rowKey of this.getPartialCreditRowKeys(
-      itemProperties,
-      itemUuid,
-    )) {
-      if (itemProperties[rowKey]?.[property] !== undefined) {
-        const rowProperties = { ...itemProperties[rowKey] };
-        delete rowProperties[property];
-        itemProperties[rowKey] = rowProperties;
-      }
-    }
-  }
-
-  private getPartialCreditRowKeys(
-    itemProperties: Record<string, Record<string, unknown>>,
-    itemUuid: string,
-  ): string[] {
-    return Object.keys(itemProperties).filter(
-      (rowKey) => parseItemRowKeyParts(rowKey)?.itemUuid === itemUuid,
-    );
-  }
-
-  private parseCsvLine(line: string): string[] {
-    const cells: string[] = [];
-    let current = "";
-    let quoted = false;
-
-    for (let index = 0; index < line.length; index++) {
-      const character = line[index];
-      if (character === '"') {
-        if (quoted && line[index + 1] === '"') {
-          current += '"';
-          index += 1;
-        } else {
-          quoted = !quoted;
-        }
-      } else if (character === ";" && !quoted) {
-        cells.push(current);
-        current = "";
-      } else {
-        current += character;
-      }
-    }
-    cells.push(current);
-    return cells;
   }
 
   /**

--- a/backend/src/views/item-export-projection.spec.ts
+++ b/backend/src/views/item-export-projection.spec.ts
@@ -1,0 +1,103 @@
+import {
+  getItemExportCell,
+  ITEM_EXPORT_IDENTITY_COLUMNS,
+  ITEM_EXPORT_IDENTITY_WITH_UUID_COLUMNS,
+  ITEM_EXPORT_PARAMETER_COLUMNS,
+  projectItemExportRow,
+} from "./item-export-projection";
+
+describe("item export projection", () => {
+  it("defines Sub-ID and every shared parameter once for all serializers", () => {
+    expect(ITEM_EXPORT_IDENTITY_COLUMNS.map((column) => column.header)).toEqual(
+      ["Unit-ID", "Unit-Label", "Item-ID", "Sub-ID", "Zeilenschlüssel"],
+    );
+    expect(
+      ITEM_EXPORT_IDENTITY_WITH_UUID_COLUMNS.map((column) => column.header),
+    ).toEqual([
+      "Unit-ID",
+      "Unit-Label",
+      "Item-ID",
+      "Item-UUID",
+      "Sub-ID",
+      "Zeilenschlüssel",
+    ]);
+    expect(
+      ITEM_EXPORT_PARAMETER_COLUMNS.map((column) => column.header),
+    ).toEqual([
+      "Empirische Itemschwierigkeit",
+      "Infit",
+      "Trennschärfe",
+      "Lösungshäufigkeit",
+      "Itemzeit (s)",
+      "Stimuluszeit (s)",
+      "Booklet",
+      "Position im Booklet",
+    ]);
+  });
+
+  it("projects item, personal and derived values into one typed row", () => {
+    const projection = projectItemExportRow({
+      rowKey: "uuid-1::A",
+      item: {
+        uuid: "uuid-1",
+        rowKey: "uuid-1::A",
+        subId: "A",
+        itemId: "item-1",
+        unitId: "unit-1",
+        unitLabel: "Aufgabe 1",
+        empiricalDifficulty: -0.25,
+        infit: 1.05,
+        discrimination: 0.4,
+        solutionRate: 0.75,
+        itemTimeSeconds: 20,
+        stimulusTimeSeconds: 12,
+        bookletOccurrences: [
+          { booklet: "B1", position: 3 },
+          { booklet: "B2", position: 8 },
+        ],
+      } as any,
+      personalRow: {
+        category: "II",
+        tags: ["Prüfen"],
+        note: "Notiz",
+      },
+      meanDifficultyByUnit: new Map([["unit-1", 0.5]]),
+    });
+
+    expect(projection).toEqual(
+      expect.objectContaining({
+        itemUuid: "uuid-1",
+        subId: "A",
+        rowKey: "uuid-1::A",
+        category: "II",
+        tags: ["Prüfen"],
+        booklets: "B1 | B2",
+        bookletPositions: "3 | 8",
+        meanTaskDifficulty: 0.5,
+      }),
+    );
+    expect(
+      ITEM_EXPORT_IDENTITY_COLUMNS.map((column) =>
+        getItemExportCell(projection, column),
+      ),
+    ).toEqual(["unit-1", "Aufgabe 1", "item-1", "A", "uuid-1::A"]);
+  });
+
+  it("keeps orphaned personal rows exportable by their stable row key", () => {
+    expect(
+      projectItemExportRow({
+        rowKey: "removed-row",
+        personalRow: { category: "III", note: "keep" },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        unitId: "",
+        itemId: "",
+        subId: null,
+        rowKey: "removed-row",
+        category: "III",
+        note: "keep",
+      }),
+    );
+  });
+});

--- a/backend/src/views/item-export-projection.ts
+++ b/backend/src/views/item-export-projection.ts
@@ -1,0 +1,149 @@
+import { VomdItemData } from "../files/unit-parser.service";
+
+export interface ItemExportProjection {
+  unitId: string;
+  unitLabel: string;
+  itemId: string;
+  itemUuid: string | null;
+  subId: string | null;
+  rowKey: string;
+  category: string | null;
+  tags: string[];
+  note: string | null;
+  empiricalDifficulty: number | null;
+  infit: number | null;
+  discrimination: number | null;
+  solutionRate: number | null;
+  itemTimeSeconds: number | null;
+  stimulusTimeSeconds: number | null;
+  booklets: string | null;
+  bookletPositions: string | null;
+  meanTaskDifficulty: number | null;
+}
+
+export type ItemExportScalarKey = Exclude<keyof ItemExportProjection, "tags">;
+
+export interface ItemExportColumnDefinition {
+  header: string;
+  key: ItemExportScalarKey;
+  width: number;
+  numeric?: boolean;
+}
+
+export const ITEM_EXPORT_IDENTITY_COLUMNS: readonly ItemExportColumnDefinition[] =
+  [
+    { header: "Unit-ID", key: "unitId", width: 22 },
+    { header: "Unit-Label", key: "unitLabel", width: 30 },
+    { header: "Item-ID", key: "itemId", width: 22 },
+    { header: "Sub-ID", key: "subId", width: 18 },
+    { header: "Zeilenschlüssel", key: "rowKey", width: 45 },
+  ];
+
+export const ITEM_UUID_EXPORT_COLUMN: ItemExportColumnDefinition = {
+  header: "Item-UUID",
+  key: "itemUuid",
+  width: 38,
+};
+
+export const ITEM_EXPORT_IDENTITY_WITH_UUID_COLUMNS: readonly ItemExportColumnDefinition[] =
+  [
+    ...ITEM_EXPORT_IDENTITY_COLUMNS.slice(0, 3),
+    ITEM_UUID_EXPORT_COLUMN,
+    ...ITEM_EXPORT_IDENTITY_COLUMNS.slice(3),
+  ];
+
+export const ITEM_EXPORT_PARAMETER_COLUMNS: readonly ItemExportColumnDefinition[] =
+  [
+    {
+      header: "Empirische Itemschwierigkeit",
+      key: "empiricalDifficulty",
+      width: 30,
+      numeric: true,
+    },
+    { header: "Infit", key: "infit", width: 16, numeric: true },
+    {
+      header: "Trennschärfe",
+      key: "discrimination",
+      width: 18,
+      numeric: true,
+    },
+    {
+      header: "Lösungshäufigkeit",
+      key: "solutionRate",
+      width: 22,
+      numeric: true,
+    },
+    {
+      header: "Itemzeit (s)",
+      key: "itemTimeSeconds",
+      width: 18,
+      numeric: true,
+    },
+    {
+      header: "Stimuluszeit (s)",
+      key: "stimulusTimeSeconds",
+      width: 20,
+      numeric: true,
+    },
+    { header: "Booklet", key: "booklets", width: 30 },
+    {
+      header: "Position im Booklet",
+      key: "bookletPositions",
+      width: 25,
+    },
+  ];
+
+export const MEAN_DIFFICULTY_EXPORT_COLUMN: ItemExportColumnDefinition = {
+  header: "Mittlere Aufgabenschwierigkeit",
+  key: "meanTaskDifficulty",
+  width: 32,
+  numeric: true,
+};
+
+export function projectItemExportRow(input: {
+  rowKey: string;
+  item?: VomdItemData;
+  personalRow?: Record<string, unknown>;
+  meanDifficultyByUnit?: ReadonlyMap<string, number>;
+}): ItemExportProjection {
+  const { item } = input;
+  const personalRow = input.personalRow || {};
+  const occurrences = item?.bookletOccurrences || [];
+  return {
+    unitId: item?.unitId || "",
+    unitLabel: item?.unitLabel || "",
+    itemId: item?.itemId || "",
+    itemUuid: item?.uuid || null,
+    subId: item?.subId || null,
+    rowKey: input.rowKey,
+    category:
+      typeof personalRow.category === "string" ? personalRow.category : null,
+    tags: Array.isArray(personalRow.tags)
+      ? personalRow.tags.map((tag) => String(tag))
+      : [],
+    note: typeof personalRow.note === "string" ? personalRow.note : null,
+    empiricalDifficulty: item?.empiricalDifficulty ?? null,
+    infit: item?.infit ?? null,
+    discrimination: item?.discrimination ?? null,
+    solutionRate: item?.solutionRate ?? null,
+    itemTimeSeconds: item?.itemTimeSeconds ?? null,
+    stimulusTimeSeconds: item?.stimulusTimeSeconds ?? null,
+    booklets: occurrences.length
+      ? occurrences.map((occurrence) => occurrence.booklet).join(" | ")
+      : null,
+    bookletPositions: occurrences.length
+      ? occurrences.map((occurrence) => String(occurrence.position)).join(" | ")
+      : null,
+    meanTaskDifficulty: item
+      ? (input.meanDifficultyByUnit?.get(item.unitId) ?? null)
+      : null,
+  };
+}
+
+export function getItemExportCell(
+  row: ItemExportProjection,
+  column: ItemExportColumnDefinition,
+): string | number {
+  const value = row[column.key];
+  return typeof value === "string" || typeof value === "number" ? value : "";
+}

--- a/backend/src/views/views.controller.spec.ts
+++ b/backend/src/views/views.controller.spec.ts
@@ -22,6 +22,7 @@ describe("ViewsController", () => {
           enableSequenceNavigation: true,
           persistUserPreferences: true,
           enablePersonalItemData: true,
+          enableItemCollections: true,
         },
       }),
       getAcpIndex: jest.fn().mockResolvedValue({ packageId: "pkg-1" }),
@@ -42,6 +43,29 @@ describe("ViewsController", () => {
       exportAllPersonalItemDataCsv: jest
         .fn()
         .mockResolvedValue(Buffer.from("all-personal-csv")),
+      getItemCollections: jest.fn().mockResolvedValue({
+        activeCollectionId: "collection-1",
+        collections: [],
+      }),
+      createItemCollection: jest.fn().mockResolvedValue({
+        activeCollectionId: "collection-1",
+        collections: [],
+      }),
+      updateItemCollection: jest.fn().mockResolvedValue({
+        activeCollectionId: "collection-1",
+        collections: [],
+      }),
+      activateItemCollection: jest.fn().mockResolvedValue({
+        activeCollectionId: "collection-1",
+        collections: [],
+      }),
+      deleteItemCollection: jest.fn().mockResolvedValue({
+        activeCollectionId: null,
+        collections: [],
+      }),
+      exportItemCollectionCsv: jest
+        .fn()
+        .mockResolvedValue(Buffer.from("collection-csv")),
       getTaskSequence: jest
         .fn()
         .mockResolvedValue({ id: "seq-1", units: [{ id: "unit-1" }] }),
@@ -473,6 +497,61 @@ describe("ViewsController", () => {
       'attachment; filename="all-participant-item-data-acp-1.csv"',
     );
     expect(res.send).toHaveBeenCalledWith(Buffer.from("all-personal-csv"));
+  });
+
+  it("routes personal collection reads, updates and exports to the caller identity", async () => {
+    const request = {
+      user: { sub: "user-1" },
+      acpAccessLevel: "MANAGER",
+    };
+    await controller.getItemCollections("acp-1", "editor", request);
+    await controller.updateItemCollection(
+      "acp-1",
+      "collection-1",
+      { baseVersion: 2, rowKeys: ["uuid::1"], perspective: "editor" },
+      request,
+    );
+    const res = { setHeader: jest.fn(), send: jest.fn() } as any;
+    await controller.exportItemCollectionCsv(
+      "acp-1",
+      "collection-1",
+      "editor",
+      request,
+      res,
+    );
+
+    expect(viewsService.getItemCollections).toHaveBeenCalledWith(
+      "acp-1",
+      request.user,
+      true,
+    );
+    expect(viewsService.updateItemCollection).toHaveBeenCalledWith(
+      "acp-1",
+      request.user,
+      "collection-1",
+      expect.objectContaining({ baseVersion: 2, rowKeys: ["uuid::1"] }),
+      true,
+    );
+    expect(viewsService.exportItemCollectionCsv).toHaveBeenCalledWith(
+      "acp-1",
+      request.user,
+      "collection-1",
+      true,
+    );
+    expect(res.send).toHaveBeenCalledWith(Buffer.from("collection-csv"));
+  });
+
+  it("blocks collection endpoints when the feature is disabled", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: { enableItemCollections: false },
+    });
+
+    await expect(
+      controller.getItemCollections("acp-1", "read-only", {
+        user: { sub: "user-1" },
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(viewsService.getItemCollections).not.toHaveBeenCalled();
   });
 
   it.each(["READ_ONLY", "CREDENTIAL", "PUBLIC", undefined])(

--- a/backend/src/views/views.controller.spec.ts
+++ b/backend/src/views/views.controller.spec.ts
@@ -554,6 +554,44 @@ describe("ViewsController", () => {
     expect(viewsService.getItemCollections).not.toHaveBeenCalled();
   });
 
+  it("blocks collection endpoints when the public item list is disabled", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: {
+        enableItemList: false,
+        enableItemCollections: true,
+      },
+    });
+
+    await expect(
+      controller.getItemCollections("acp-1", "read-only", {
+        user: { sub: "user-1" },
+        acpAccessLevel: "READ_ONLY",
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(viewsService.getItemCollections).not.toHaveBeenCalled();
+  });
+
+  it("allows managers to use collections when the public item list is disabled", async () => {
+    viewsService.getAcpStartPage.mockResolvedValue({
+      featureConfig: {
+        enableItemList: false,
+        enableItemCollections: true,
+      },
+    });
+    const request = {
+      user: { sub: "manager-1" },
+      acpAccessLevel: "MANAGER",
+    };
+
+    await controller.getItemCollections("acp-1", "editor", request);
+
+    expect(viewsService.getItemCollections).toHaveBeenCalledWith(
+      "acp-1",
+      request.user,
+      true,
+    );
+  });
+
   it.each(["READ_ONLY", "CREDENTIAL", "PUBLIC", undefined])(
     "blocks all-participant exports for access level %s",
     async (acpAccessLevel) => {

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -450,7 +450,7 @@ export class ViewsController {
     @Query("perspective") perspective: "editor" | "read-only" | undefined,
     @Request() req: any,
   ) {
-    await this.assertItemCollectionsEnabled(acpId);
+    await this.assertItemCollectionsEnabled(acpId, req);
     return this.viewsService.getItemCollections(
       acpId,
       req?.user,
@@ -466,7 +466,7 @@ export class ViewsController {
     @Body() dto: CreateItemCollectionDto,
     @Request() req: any,
   ) {
-    await this.assertItemCollectionsEnabled(acpId);
+    await this.assertItemCollectionsEnabled(acpId, req);
     return this.viewsService.createItemCollection(
       acpId,
       req?.user,
@@ -484,7 +484,7 @@ export class ViewsController {
     @Body() dto: UpdateItemCollectionDto,
     @Request() req: any,
   ) {
-    await this.assertItemCollectionsEnabled(acpId);
+    await this.assertItemCollectionsEnabled(acpId, req);
     return this.viewsService.updateItemCollection(
       acpId,
       req?.user,
@@ -502,7 +502,7 @@ export class ViewsController {
     @Body() dto: ActivateItemCollectionDto,
     @Request() req: any,
   ) {
-    await this.assertItemCollectionsEnabled(acpId);
+    await this.assertItemCollectionsEnabled(acpId, req);
     return this.viewsService.activateItemCollection(
       acpId,
       req?.user,
@@ -520,7 +520,7 @@ export class ViewsController {
     @Query("perspective") perspective: "editor" | "read-only" | undefined,
     @Request() req: any,
   ) {
-    await this.assertItemCollectionsEnabled(acpId);
+    await this.assertItemCollectionsEnabled(acpId, req);
     return this.viewsService.deleteItemCollection(
       acpId,
       req?.user,
@@ -539,7 +539,7 @@ export class ViewsController {
     @Request() req: any,
     @Res() res: Response,
   ) {
-    await this.assertItemCollectionsEnabled(acpId);
+    await this.assertItemCollectionsEnabled(acpId, req);
     const buffer = await this.viewsService.exportItemCollectionCsv(
       acpId,
       req?.user,
@@ -636,12 +636,22 @@ export class ViewsController {
     return featureConfig.enablePersonalItemData === true;
   }
 
-  private async assertItemCollectionsEnabled(acpId: string): Promise<void> {
+  private async assertItemCollectionsEnabled(
+    acpId: string,
+    req?: any,
+  ): Promise<void> {
     const data = await this.viewsService.getAcpStartPage(acpId);
     const featureConfig = (data?.featureConfig || {}) as Record<
       string,
       unknown
     >;
+    const isManager =
+      req?.user?.isAppAdmin ||
+      req?.acpAccessLevel === "MANAGER" ||
+      req?.acpAccessLevel === "ADMIN";
+    if (!isManager && featureConfig.enableItemList === false) {
+      throw new ForbiddenException("Item list is not enabled for this ACP");
+    }
     if (featureConfig.enableItemCollections !== true) {
       throw new ForbiddenException(
         "Item collections are not enabled for this ACP",

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   ForbiddenException,
   Get,
   Param,
@@ -24,9 +25,11 @@ import {
   ArrayMaxSize,
   IsArray,
   IsIn,
+  IsInt,
   IsObject,
   IsOptional,
   IsString,
+  Min,
 } from "class-validator";
 import { Response } from "express";
 import { ViewsService } from "./views.service";
@@ -129,6 +132,54 @@ class ExportAllPersonalItemDataDto {
     enum: ["editor", "read-only"],
     default: "read-only",
   })
+  @IsOptional()
+  @IsIn(["editor", "read-only"])
+  perspective?: "editor" | "read-only";
+}
+
+class CreateItemCollectionDto {
+  @ApiPropertyOptional({ example: "Meine Kollektion" })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ enum: ["editor", "read-only"] })
+  @IsOptional()
+  @IsIn(["editor", "read-only"])
+  perspective?: "editor" | "read-only";
+}
+
+class UpdateItemCollectionDto {
+  @ApiProperty()
+  @IsInt()
+  @Min(1)
+  baseVersion!: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ type: [String], maxItems: 10_000 })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(10_000)
+  @IsString({ each: true })
+  rowKeys?: string[];
+
+  @ApiPropertyOptional({ enum: ["editor", "read-only"] })
+  @IsOptional()
+  @IsIn(["editor", "read-only"])
+  perspective?: "editor" | "read-only";
+}
+
+class ActivateItemCollectionDto {
+  @ApiPropertyOptional({ nullable: true })
+  @IsOptional()
+  @IsString()
+  collectionId?: string | null;
+
+  @ApiPropertyOptional({ enum: ["editor", "read-only"] })
   @IsOptional()
   @IsIn(["editor", "read-only"])
   perspective?: "editor" | "read-only";
@@ -391,6 +442,118 @@ export class ViewsController {
     res.send(buffer);
   }
 
+  @Get("acp/:acpId/items/collections")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "List the caller's personal item collections" })
+  async getItemCollections(
+    @Param("acpId") acpId: string,
+    @Query("perspective") perspective: "editor" | "read-only" | undefined,
+    @Request() req: any,
+  ) {
+    await this.assertItemCollectionsEnabled(acpId);
+    return this.viewsService.getItemCollections(
+      acpId,
+      req?.user,
+      this.isEditorPerspective(req, perspective),
+    );
+  }
+
+  @Post("acp/:acpId/items/collections")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "Create a personal item collection" })
+  async createItemCollection(
+    @Param("acpId") acpId: string,
+    @Body() dto: CreateItemCollectionDto,
+    @Request() req: any,
+  ) {
+    await this.assertItemCollectionsEnabled(acpId);
+    return this.viewsService.createItemCollection(
+      acpId,
+      req?.user,
+      dto.name,
+      this.isEditorPerspective(req, dto.perspective),
+    );
+  }
+
+  @Patch("acp/:acpId/items/collections/:collectionId")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "Update a personal item collection" })
+  async updateItemCollection(
+    @Param("acpId") acpId: string,
+    @Param("collectionId") collectionId: string,
+    @Body() dto: UpdateItemCollectionDto,
+    @Request() req: any,
+  ) {
+    await this.assertItemCollectionsEnabled(acpId);
+    return this.viewsService.updateItemCollection(
+      acpId,
+      req?.user,
+      collectionId,
+      dto,
+      this.isEditorPerspective(req, dto.perspective),
+    );
+  }
+
+  @Put("acp/:acpId/items/collections/active")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "Persist the active personal item collection" })
+  async activateItemCollection(
+    @Param("acpId") acpId: string,
+    @Body() dto: ActivateItemCollectionDto,
+    @Request() req: any,
+  ) {
+    await this.assertItemCollectionsEnabled(acpId);
+    return this.viewsService.activateItemCollection(
+      acpId,
+      req?.user,
+      dto.collectionId || null,
+      this.isEditorPerspective(req, dto.perspective),
+    );
+  }
+
+  @Delete("acp/:acpId/items/collections/:collectionId")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "Delete a personal item collection" })
+  async deleteItemCollection(
+    @Param("acpId") acpId: string,
+    @Param("collectionId") collectionId: string,
+    @Query("perspective") perspective: "editor" | "read-only" | undefined,
+    @Request() req: any,
+  ) {
+    await this.assertItemCollectionsEnabled(acpId);
+    return this.viewsService.deleteItemCollection(
+      acpId,
+      req?.user,
+      collectionId,
+      this.isEditorPerspective(req, perspective),
+    );
+  }
+
+  @Post("acp/:acpId/items/collections/:collectionId/export.csv")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "Export one personal item collection as CSV" })
+  async exportItemCollectionCsv(
+    @Param("acpId") acpId: string,
+    @Param("collectionId") collectionId: string,
+    @Query("perspective") perspective: "editor" | "read-only" | undefined,
+    @Request() req: any,
+    @Res() res: Response,
+  ) {
+    await this.assertItemCollectionsEnabled(acpId);
+    const buffer = await this.viewsService.exportItemCollectionCsv(
+      acpId,
+      req?.user,
+      collectionId,
+      this.isEditorPerspective(req, perspective),
+    );
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="item-collection-${collectionId}.csv"`,
+    );
+    res.send(buffer);
+  }
+
   @Get("acp/:acpId/sequences")
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "List task sequences for an ACP" })
@@ -471,6 +634,29 @@ export class ViewsController {
       unknown
     >;
     return featureConfig.enablePersonalItemData === true;
+  }
+
+  private async assertItemCollectionsEnabled(acpId: string): Promise<void> {
+    const data = await this.viewsService.getAcpStartPage(acpId);
+    const featureConfig = (data?.featureConfig || {}) as Record<
+      string,
+      unknown
+    >;
+    if (featureConfig.enableItemCollections !== true) {
+      throw new ForbiddenException(
+        "Item collections are not enabled for this ACP",
+      );
+    }
+  }
+
+  private isEditorPerspective(
+    req: any,
+    perspective?: "editor" | "read-only",
+  ): boolean {
+    return (
+      (req?.acpAccessLevel === "MANAGER" || req?.acpAccessLevel === "ADMIN") &&
+      perspective === "editor"
+    );
   }
 
   private normalizePreferenceViewId(viewId?: string): string {

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -625,6 +625,69 @@ describe("ViewsService", () => {
     ).rejects.toThrow(UnauthorizedException);
   });
 
+  it("exports collection rows through the shared Sub-ID and parameter columns", async () => {
+    itemPreferenceRepository.findOne.mockResolvedValue({
+      preferences: {
+        collections: [
+          {
+            id: "collection-1",
+            name: "Auswahl A",
+            rowKeys: ["uuid-1::A", "removed-row"],
+            version: 1,
+            createdAt: "2026-07-01T10:00:00.000Z",
+            updatedAt: "2026-07-01T10:00:00.000Z",
+          },
+        ],
+        rowData: {
+          "uuid-1::A": {
+            category: "II",
+            tags: ["Prüfen"],
+            note: "Erste Zeile\nZweite Zeile",
+          },
+        },
+      },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          itemId: "item-1",
+          uuid: "uuid-1",
+          rowKey: "uuid-1::A",
+          subId: "A",
+          unitId: "unit-1",
+          unitLabel: "Aufgabe 1",
+          empiricalDifficulty: -0.25,
+          infit: 1.05,
+          discrimination: 0.4,
+          solutionRate: 0.75,
+          itemTimeSeconds: 20,
+          stimulusTimeSeconds: 12,
+          bookletOccurrences: [{ booklet: "B1", position: 3 }],
+        },
+      ],
+    });
+
+    const csv = (
+      await service.exportItemCollectionCsv(
+        "acp-1",
+        { sub: "user-1", type: "user" },
+        "collection-1",
+        true,
+      )
+    ).toString("utf8");
+
+    expect(csv).toContain(
+      '"Unit-ID";"Unit-Label";"Item-ID";"Item-UUID";"Sub-ID";"Zeilenschlüssel"',
+    );
+    expect(csv).toContain(
+      '"Empirische Itemschwierigkeit";"Infit";"Trennschärfe";"Lösungshäufigkeit";"Itemzeit (s)";"Stimuluszeit (s)";"Booklet";"Position im Booklet"',
+    );
+    expect(csv).toContain(
+      '"Auswahl A";"1";"unit-1";"Aufgabe 1";"item-1";"uuid-1";"A";"uuid-1::A";"-0.25";"1.05";"0.4";"0.75";"20";"12";"B1";"3";"II";"Prüfen";"Erste Zeile\\nZweite Zeile"',
+    );
+    expect(csv).not.toContain("removed-row");
+  });
+
   it("exports all stored participant rows as CSV with literal note line breaks", async () => {
     itemPreferenceRepository.find.mockResolvedValue([
       {

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
-import { BadRequestException, UnauthorizedException } from "@nestjs/common";
+import {
+  BadRequestException,
+  ConflictException,
+  UnauthorizedException,
+} from "@nestjs/common";
 import { ViewsService } from "./views.service";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
 import { UnitParserService } from "../files/unit-parser.service";
@@ -24,7 +28,9 @@ describe("ViewsService", () => {
     create: jest.Mock;
     save: jest.Mock;
     query: jest.Mock;
+    manager: { transaction: jest.Mock };
   };
+  let transactionManager: { getRepository: jest.Mock; query: jest.Mock };
   let itemExplorerStateService: { getStateForViewer: jest.Mock };
   let unitParserService: {
     getItemRowKeysFromFiles: jest.Mock;
@@ -36,13 +42,29 @@ describe("ViewsService", () => {
     accessConfigRepository = { findOne: jest.fn(), find: jest.fn() };
     fileRepository = { find: jest.fn(), findOne: jest.fn() };
     settingsRepository = { findOne: jest.fn() };
+    transactionManager = {
+      getRepository: jest.fn(),
+      query: jest.fn(),
+    };
     itemPreferenceRepository = {
       find: jest.fn(),
       findOne: jest.fn(),
       create: jest.fn().mockImplementation((value) => value),
       save: jest.fn().mockImplementation(async (value) => value),
       query: jest.fn(),
+      manager: {
+        transaction: jest
+          .fn()
+          .mockImplementation(
+            async (
+              callback: (
+                manager: typeof transactionManager,
+              ) => Promise<unknown>,
+            ) => callback(transactionManager),
+          ),
+      },
     };
+    transactionManager.getRepository.mockReturnValue(itemPreferenceRepository);
     itemExplorerStateService = {
       getStateForViewer: jest.fn().mockResolvedValue({
         activeState: { itemProperties: {} },
@@ -286,6 +308,7 @@ describe("ViewsService", () => {
           itemId: "item-1",
           uuid: "uuid-1",
           rowKey: "uuid-1::1",
+          subId: "1",
           unitId: "unit-1",
           unitLabel: "Aufgabe 1",
           description: "",
@@ -297,6 +320,7 @@ describe("ViewsService", () => {
           itemId: "item-2",
           uuid: "uuid-2",
           rowKey: "uuid-2::1",
+          subId: "1",
           unitId: "unit-1",
           unitLabel: "Aufgabe 1",
           description: "",
@@ -347,21 +371,34 @@ describe("ViewsService", () => {
       "Unit-Label",
       "Item-ID",
       "Item-UUID",
+      "Sub-ID",
+      "Zeilenschlüssel",
       "Markierung/Farbe",
       "Notiz",
       "Kompetenzstufe",
       "Empirische Itemschwierigkeit",
+      "Infit",
+      "Trennschärfe",
+      "Lösungshäufigkeit",
+      "Itemzeit (s)",
+      "Stimuluszeit (s)",
+      "Booklet",
+      "Position im Booklet",
       "Mittlere Aufgabenschwierigkeit",
     ]);
     expect(sheet!.getCell("A2").value).toBe(1);
     expect(sheet!.getCell("E2").value).toBe("uuid-2");
-    expect(sheet!.getCell("F2").value).toBeNull();
-    expect(sheet!.getCell("J2").value).toBe(0.5);
+    expect(sheet!.getCell("F2").value).toBe("1");
+    expect(sheet!.getCell("G2").value).toBe("uuid-2::1");
+    expect(sheet!.getCell("H2").value).toBeNull();
+    expect(sheet!.getCell("S2").value).toBe(0.5);
     expect(sheet!.getCell("A3").value).toBe(2);
     expect(sheet!.getCell("E3").value).toBe("uuid-1");
-    expect(sheet!.getCell("F3").value).toBe("Prüfen (#ff0000)");
-    expect(sheet!.getCell("G3").value).toBe("Eigene Notiz");
-    expect(sheet!.getCell("H3").value).toBe("II");
+    expect(sheet!.getCell("F3").value).toBe("1");
+    expect(sheet!.getCell("G3").value).toBe("uuid-1::1");
+    expect(sheet!.getCell("H3").value).toBe("Prüfen (#ff0000)");
+    expect(sheet!.getCell("I3").value).toBe("Eigene Notiz");
+    expect(sheet!.getCell("J3").value).toBe("II");
   });
 
   it("requires an explicit filtered and sorted row order for exports", async () => {
@@ -373,6 +410,219 @@ describe("ViewsService", () => {
       ),
     ).rejects.toThrow(BadRequestException);
     expect(unitParserService.getItemListFromFiles).not.toHaveBeenCalled();
+  });
+
+  it("resolves personal collection summaries without double-counting partial-credit rows", async () => {
+    itemPreferenceRepository.findOne.mockResolvedValue({
+      preferences: {
+        activeCollectionId: "collection-1",
+        collections: [
+          {
+            id: "collection-1",
+            name: "Auswahl A",
+            rowKeys: ["uuid-1::1", "uuid-1::2", "uuid-2", "removed"],
+            version: 3,
+            createdAt: "2026-07-01T10:00:00.000Z",
+            updatedAt: "2026-07-02T10:00:00.000Z",
+          },
+        ],
+      },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        {
+          rowKey: "uuid-1::1",
+          uuid: "uuid-1",
+          unitId: "unit-1",
+          itemTimeSeconds: 10,
+          stimulusTimeSeconds: 5,
+        },
+        {
+          rowKey: "uuid-1::2",
+          uuid: "uuid-1",
+          unitId: "unit-1",
+          itemTimeSeconds: 10,
+          stimulusTimeSeconds: 5,
+        },
+        {
+          rowKey: "uuid-2",
+          uuid: "uuid-2",
+          unitId: "unit-1",
+          stimulusTimeSeconds: 5,
+        },
+      ],
+    });
+
+    const result = await service.getItemCollections(
+      "acp-1",
+      { sub: "user-1", type: "user" },
+      true,
+    );
+
+    expect(result.activeCollectionId).toBe("collection-1");
+    expect(result.collections[0].unavailableRowKeys).toEqual(["removed"]);
+    expect(result.collections[0].summary).toEqual({
+      rowCount: 4,
+      itemCount: 2,
+      unitCount: 1,
+      itemTimeSeconds: 10,
+      stimulusTimeSeconds: 5,
+      testTimeSeconds: 15,
+      missingItemTimeCount: 1,
+      missingStimulusTimeUnitCount: 0,
+      complete: false,
+    });
+  });
+
+  it("version-checks and persists personal collection updates", async () => {
+    const record = {
+      preferences: {
+        rowData: { "uuid-1::1": { note: "keep" } },
+        activeCollectionId: "collection-1",
+        collections: [
+          {
+            id: "collection-1",
+            name: "Alt",
+            rowKeys: ["uuid-1::1"],
+            version: 2,
+            createdAt: "2026-07-01T10:00:00.000Z",
+            updatedAt: "2026-07-01T10:00:00.000Z",
+          },
+        ],
+      },
+    };
+    itemPreferenceRepository.findOne.mockResolvedValue(record);
+
+    await expect(
+      service.updateItemCollection(
+        "acp-1",
+        { sub: "user-1", type: "user" },
+        "collection-1",
+        { baseVersion: 1, name: "Neu" },
+      ),
+    ).rejects.toThrow(ConflictException);
+
+    await service.updateItemCollection(
+      "acp-1",
+      { sub: "user-1", type: "user" },
+      "collection-1",
+      { baseVersion: 2, name: "Neu", rowKeys: ["uuid-1::1", "uuid-2::1"] },
+    );
+
+    expect(itemPreferenceRepository.save).toHaveBeenCalledWith(record);
+    expect(record.preferences.collections[0] as any).toEqual(
+      expect.objectContaining({
+        name: "Neu",
+        rowKeys: ["uuid-1::1", "uuid-2::1"],
+        version: 3,
+      }),
+    );
+    expect(record.preferences.rowData).toEqual({
+      "uuid-1::1": { note: "keep" },
+    });
+    expect(itemPreferenceRepository.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({ lock: { mode: "pessimistic_write" } }),
+    );
+  });
+
+  it("serializes concurrent collection updates before checking the version", async () => {
+    const record = {
+      preferences: {
+        rowData: { "uuid-1::1": { note: "keep" } },
+        activeCollectionId: "collection-1",
+        collections: [
+          {
+            id: "collection-1",
+            name: "Alt",
+            rowKeys: ["uuid-1::1"],
+            version: 2,
+            createdAt: "2026-07-01T10:00:00.000Z",
+            updatedAt: "2026-07-01T10:00:00.000Z",
+          },
+        ],
+      },
+    };
+    itemPreferenceRepository.findOne.mockResolvedValue(record);
+    let transactionTail = Promise.resolve();
+    itemPreferenceRepository.manager.transaction.mockImplementation(
+      (callback: (manager: typeof transactionManager) => Promise<unknown>) => {
+        const result = transactionTail.then(() => callback(transactionManager));
+        transactionTail = result.then(
+          () => undefined,
+          () => undefined,
+        );
+        return result;
+      },
+    );
+
+    const results = await Promise.allSettled([
+      service.updateItemCollection(
+        "acp-1",
+        { sub: "user-1", type: "user" },
+        "collection-1",
+        { baseVersion: 2, name: "Erste Änderung" },
+      ),
+      service.updateItemCollection(
+        "acp-1",
+        { sub: "user-1", type: "user" },
+        "collection-1",
+        { baseVersion: 2, name: "Zweite Änderung" },
+      ),
+    ]);
+
+    expect(results[0].status).toBe("fulfilled");
+    expect(results[1]).toEqual(
+      expect.objectContaining({
+        status: "rejected",
+        reason: expect.any(ConflictException),
+      }),
+    );
+    expect(record.preferences.collections[0]).toEqual(
+      expect.objectContaining({ name: "Erste Änderung", version: 3 }),
+    );
+    expect(record.preferences.rowData).toEqual({
+      "uuid-1::1": { note: "keep" },
+    });
+  });
+
+  it("limits the number of personal item collections", async () => {
+    const timestamp = "2026-07-01T10:00:00.000Z";
+    const record = {
+      preferences: {
+        activeCollectionId: "collection-1",
+        collections: Array.from({ length: 100 }, (_, index) => ({
+          id: `collection-${index + 1}`,
+          name: `Kollektion ${index + 1}`,
+          rowKeys: [],
+          version: 1,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        })),
+      },
+    };
+    itemPreferenceRepository.findOne.mockResolvedValue(record);
+
+    await expect(
+      service.createItemCollection(
+        "acp-1",
+        { sub: "user-1", type: "user" },
+        "Eine zu viel",
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(itemPreferenceRepository.save).not.toHaveBeenCalled();
+  });
+
+  it("requires a stable identity for item collections", async () => {
+    await expect(service.getItemCollections("acp-1", null)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    await expect(
+      service.getItemCollections("acp-1", {
+        type: "credential",
+        username: "legacy-only",
+      }),
+    ).rejects.toThrow(UnauthorizedException);
   });
 
   it("exports all stored participant rows as CSV with literal note line breaks", async () => {
@@ -447,10 +697,10 @@ describe("ViewsService", () => {
       '"Teilnehmerkennung";"Unit-ID";"Unit-Label";"Item-ID";"Sub-ID";"Zeilenschlüssel"',
     );
     expect(csv).toContain(
-      '"teilnehmer-a";"unit-1";"Aufgabe 1";"item-1";"A";"uuid-1::A";"\'=II";"Prüfen, Sicher";"Erste Zeile\\nZweite Zeile";"-0.25";"0.25"',
+      '"teilnehmer-a";"unit-1";"Aufgabe 1";"item-1";"A";"uuid-1::A";"\'=II";"Prüfen, Sicher";"Erste Zeile\\nZweite Zeile";"-0.25";"";"";"";"";"";"";"";"0.25"',
     );
     expect(csv).toContain(
-      '"teilnehmer-b";"unit-1";"Aufgabe 1";"item-2";"";"uuid-2";"III";"";"Fertig";"0.75";"0.25"',
+      '"teilnehmer-b";"unit-1";"Aufgabe 1";"item-2";"";"uuid-2";"III";"";"Fertig";"0.75";"";"";"";"";"";"";"";"0.25"',
     );
     expect(csv).not.toContain("ohne-eintrag");
   });

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -28,6 +28,15 @@ import {
   buildPatchPersonalItemPreferenceRowQuery,
   PreferenceIdentityColumn,
 } from "./personal-item-preferences.query";
+import {
+  getItemExportCell,
+  ITEM_EXPORT_IDENTITY_COLUMNS,
+  ITEM_EXPORT_IDENTITY_WITH_UUID_COLUMNS,
+  ITEM_EXPORT_PARAMETER_COLUMNS,
+  ItemExportProjection,
+  MEAN_DIFFICULTY_EXPORT_COLUMN,
+  projectItemExportRow,
+} from "./item-export-projection";
 import { v4 as uuidv4 } from "uuid";
 
 const MAX_PERSONAL_ITEM_ROWS = 10_000;
@@ -759,20 +768,8 @@ export class ViewsService {
     const headers = [
       "Kollektion",
       "Reihenfolge",
-      "Unit-ID",
-      "Unit-Label",
-      "Item-ID",
-      "Item-UUID",
-      "Sub-ID",
-      "Zeilenschlüssel",
-      "Empirische Itemschwierigkeit",
-      "Infit",
-      "Trennschärfe",
-      "Lösungshäufigkeit",
-      "Itemzeit (s)",
-      "Stimuluszeit (s)",
-      "Booklet",
-      "Position im Booklet",
+      ...ITEM_EXPORT_IDENTITY_WITH_UUID_COLUMNS.map((column) => column.header),
+      ...ITEM_EXPORT_PARAMETER_COLUMNS.map((column) => column.header),
       "Kategorie",
       "Tags",
       "Notiz",
@@ -781,30 +778,24 @@ export class ViewsService {
       const item = itemsByRowKey.get(rowKey);
       if (!item) return [];
       const personal = personalRows[rowKey] || {};
-      const occurrenceColumns = this.formatBookletOccurrenceColumns(item);
+      const projection = projectItemExportRow({
+        rowKey,
+        item,
+        personalRow: personal,
+      });
       return [
         [
           collection.name,
           index + 1,
-          item.unitId,
-          item.unitLabel,
-          item.itemId,
-          item.uuid,
-          item.subId || "",
-          item.rowKey,
-          item.empiricalDifficulty ?? "",
-          item.infit ?? "",
-          item.discrimination ?? "",
-          item.solutionRate ?? "",
-          item.itemTimeSeconds ?? "",
-          item.stimulusTimeSeconds ?? "",
-          occurrenceColumns.booklets,
-          occurrenceColumns.positions,
-          typeof personal.category === "string" ? personal.category : "",
-          Array.isArray(personal.tags) ? personal.tags.join(", ") : "",
-          typeof personal.note === "string"
-            ? personal.note.replace(/\n/g, "\\n")
-            : "",
+          ...ITEM_EXPORT_IDENTITY_WITH_UUID_COLUMNS.map((column) =>
+            getItemExportCell(projection, column),
+          ),
+          ...ITEM_EXPORT_PARAMETER_COLUMNS.map((column) =>
+            getItemExportCell(projection, column),
+          ),
+          projection.category || "",
+          projection.tags.join(", "),
+          projection.note?.replace(/\n/g, "\\n") || "",
         ],
       ];
     });
@@ -848,38 +839,18 @@ export class ViewsService {
     );
 
     const rows = items.map((item, index) => {
-      const personalRow = preferences.rowData[item.rowKey] || {};
-      const tags = Array.isArray(personalRow.tags)
-        ? personalRow.tags.map((tag) => String(tag))
-        : [];
-      const occurrenceColumns = this.formatBookletOccurrenceColumns(item);
+      const projection = projectItemExportRow({
+        rowKey: item.rowKey,
+        item,
+        personalRow: preferences.rowData[item.rowKey],
+        meanDifficultyByUnit,
+      });
 
       return {
+        ...projection,
         sequenceNumber: index + 1,
-        unitId: item.unitId,
-        unitLabel: item.unitLabel,
-        itemId: item.itemId,
-        itemUuid: item.uuid,
-        subId: item.subId || null,
-        rowKey: item.rowKey,
-        markers: this.formatPersonalMarkers(tags, personalTagColors),
-        note: typeof personalRow.note === "string" ? personalRow.note : null,
-        competenceLevel:
-          typeof personalRow.category === "string"
-            ? personalRow.category
-            : null,
-        empiricalDifficulty:
-          item.empiricalDifficulty === undefined
-            ? null
-            : item.empiricalDifficulty,
-        infit: item.infit ?? null,
-        discrimination: item.discrimination ?? null,
-        solutionRate: item.solutionRate ?? null,
-        itemTimeSeconds: item.itemTimeSeconds ?? null,
-        stimulusTimeSeconds: item.stimulusTimeSeconds ?? null,
-        booklets: occurrenceColumns.booklets || null,
-        bookletPositions: occurrenceColumns.positions || null,
-        meanTaskDifficulty: meanDifficultyByUnit.get(item.unitId) ?? null,
+        markers: this.formatPersonalMarkers(projection.tags, personalTagColors),
+        competenceLevel: projection.category,
       };
     });
 
@@ -923,40 +894,16 @@ export class ViewsService {
       return Object.entries(preferences.rowData).map(
         ([rowKey, personalRow]) => {
           const item = itemsByRowKey.get(rowKey);
-          const tags = Array.isArray(personalRow.tags)
-            ? personalRow.tags.map((tag) => String(tag)).join(", ")
-            : "";
-          const occurrenceColumns = item
-            ? this.formatBookletOccurrenceColumns(item)
-            : { booklets: "", positions: "" };
+          const projection = projectItemExportRow({
+            rowKey,
+            item,
+            personalRow,
+            meanDifficultyByUnit,
+          });
 
           return {
+            ...projection,
             participant,
-            unitId: item?.unitId || "",
-            unitLabel: item?.unitLabel || "",
-            itemId: item?.itemId || "",
-            subId: item?.subId || "",
-            rowKey,
-            category:
-              typeof personalRow.category === "string"
-                ? personalRow.category
-                : "",
-            tags,
-            note:
-              typeof personalRow.note === "string"
-                ? personalRow.note.replace(/\n/g, "\\n")
-                : "",
-            empiricalDifficulty: item?.empiricalDifficulty ?? "",
-            infit: item?.infit ?? "",
-            discrimination: item?.discrimination ?? "",
-            solutionRate: item?.solutionRate ?? "",
-            itemTimeSeconds: item?.itemTimeSeconds ?? "",
-            stimulusTimeSeconds: item?.stimulusTimeSeconds ?? "",
-            booklets: occurrenceColumns.booklets,
-            bookletPositions: occurrenceColumns.positions,
-            meanTaskDifficulty: item
-              ? (meanDifficultyByUnit.get(item.unitId) ?? "")
-              : "",
             itemOrder: itemOrder.get(rowKey) ?? Number.MAX_SAFE_INTEGER,
           };
         },
@@ -1270,19 +1217,6 @@ export class ViewsService {
     };
   }
 
-  private formatBookletOccurrenceColumns(item: VomdItemData): {
-    booklets: string;
-    positions: string;
-  } {
-    const occurrences = item.bookletOccurrences || [];
-    return {
-      booklets: occurrences.map((occurrence) => occurrence.booklet).join(" | "),
-      positions: occurrences
-        .map((occurrence) => String(occurrence.position))
-        .join(" | "),
-    };
-  }
-
   private async upsertItemPreferences(
     acpId: string,
     viewId: string,
@@ -1455,7 +1389,13 @@ export class ViewsService {
   }
 
   private async buildPersonalItemDataXlsx(
-    rows: Array<Record<string, string | number | null>>,
+    rows: Array<
+      ItemExportProjection & {
+        sequenceNumber: number;
+        markers: string | null;
+        competenceLevel: string | null;
+      }
+    >,
   ): Promise<Buffer> {
     const ExcelJS = await import("exceljs");
     const workbook = new ExcelJS.Workbook();
@@ -1465,36 +1405,12 @@ export class ViewsService {
     const sheet = workbook.addWorksheet("Persönliche Itemdaten");
     sheet.columns = [
       { header: "Laufende Nummer", key: "sequenceNumber", width: 18 },
-      { header: "Unit-ID", key: "unitId", width: 22 },
-      { header: "Unit-Label", key: "unitLabel", width: 30 },
-      { header: "Item-ID", key: "itemId", width: 22 },
-      { header: "Item-UUID", key: "itemUuid", width: 38 },
-      { header: "Sub-ID", key: "subId", width: 18 },
-      { header: "Zeilenschlüssel", key: "rowKey", width: 45 },
+      ...ITEM_EXPORT_IDENTITY_WITH_UUID_COLUMNS,
       { header: "Markierung/Farbe", key: "markers", width: 32 },
       { header: "Notiz", key: "note", width: 50 },
       { header: "Kompetenzstufe", key: "competenceLevel", width: 22 },
-      {
-        header: "Empirische Itemschwierigkeit",
-        key: "empiricalDifficulty",
-        width: 30,
-      },
-      { header: "Infit", key: "infit", width: 16 },
-      { header: "Trennschärfe", key: "discrimination", width: 18 },
-      { header: "Lösungshäufigkeit", key: "solutionRate", width: 22 },
-      { header: "Itemzeit (s)", key: "itemTimeSeconds", width: 18 },
-      { header: "Stimuluszeit (s)", key: "stimulusTimeSeconds", width: 20 },
-      { header: "Booklet", key: "booklets", width: 30 },
-      {
-        header: "Position im Booklet",
-        key: "bookletPositions",
-        width: 25,
-      },
-      {
-        header: "Mittlere Aufgabenschwierigkeit",
-        key: "meanTaskDifficulty",
-        width: 32,
-      },
+      ...ITEM_EXPORT_PARAMETER_COLUMNS,
+      MEAN_DIFFICULTY_EXPORT_COLUMN,
     ];
     sheet.views = [{ state: "frozen", ySplit: 1 }];
     sheet.autoFilter = { from: "A1", to: "S1" };
@@ -1513,16 +1429,13 @@ export class ViewsService {
       vertical: "top",
       wrapText: true,
     };
-    sheet.getColumn("empiricalDifficulty").numFmt = "0.############";
-    sheet.getColumn("meanTaskDifficulty").numFmt = "0.############";
-    for (const key of [
-      "infit",
-      "discrimination",
-      "solutionRate",
-      "itemTimeSeconds",
-      "stimulusTimeSeconds",
+    for (const column of [
+      ...ITEM_EXPORT_PARAMETER_COLUMNS,
+      MEAN_DIFFICULTY_EXPORT_COLUMN,
     ]) {
-      sheet.getColumn(key).numFmt = "0.############";
+      if (column.numeric) {
+        sheet.getColumn(column.key).numFmt = "0.############";
+      }
     }
 
     const buffer = await workbook.xlsx.writeBuffer();
@@ -1530,68 +1443,36 @@ export class ViewsService {
   }
 
   private buildAllPersonalItemDataCsv(
-    rows: Array<{
-      participant: string;
-      unitId: string;
-      unitLabel: string;
-      itemId: string;
-      subId: string;
-      rowKey: string;
-      category: string;
-      tags: string;
-      note: string;
-      empiricalDifficulty: number | string;
-      infit: number | string;
-      discrimination: number | string;
-      solutionRate: number | string;
-      itemTimeSeconds: number | string;
-      stimulusTimeSeconds: number | string;
-      booklets: string;
-      bookletPositions: string;
-      meanTaskDifficulty: number | string;
-    }>,
+    rows: Array<
+      {
+        participant: string;
+        itemOrder: number;
+      } & ItemExportProjection
+    >,
   ): Buffer {
     const headers = [
       "Teilnehmerkennung",
-      "Unit-ID",
-      "Unit-Label",
-      "Item-ID",
-      "Sub-ID",
-      "Zeilenschlüssel",
+      ...ITEM_EXPORT_IDENTITY_COLUMNS.map((column) => column.header),
       "Kategorie",
       "Tags",
       "Notiz",
-      "Empirische Itemschwierigkeit",
-      "Infit",
-      "Trennschärfe",
-      "Lösungshäufigkeit",
-      "Itemzeit (s)",
-      "Stimuluszeit (s)",
-      "Booklet",
-      "Position im Booklet",
-      "Mittlere Aufgabenschwierigkeit",
+      ...ITEM_EXPORT_PARAMETER_COLUMNS.map((column) => column.header),
+      MEAN_DIFFICULTY_EXPORT_COLUMN.header,
     ];
     const lines = [
       headers,
       ...rows.map((row) => [
         row.participant,
-        row.unitId,
-        row.unitLabel,
-        row.itemId,
-        row.subId,
-        row.rowKey,
-        row.category,
-        row.tags,
-        row.note,
-        row.empiricalDifficulty,
-        row.infit,
-        row.discrimination,
-        row.solutionRate,
-        row.itemTimeSeconds,
-        row.stimulusTimeSeconds,
-        row.booklets,
-        row.bookletPositions,
-        row.meanTaskDifficulty,
+        ...ITEM_EXPORT_IDENTITY_COLUMNS.map((column) =>
+          getItemExportCell(row, column),
+        ),
+        row.category || "",
+        row.tags.join(", "),
+        row.note?.replace(/\n/g, "\\n") || "",
+        ...ITEM_EXPORT_PARAMETER_COLUMNS.map((column) =>
+          getItemExportCell(row, column),
+        ),
+        getItemExportCell(row, MEAN_DIFFICULTY_EXPORT_COLUMN),
       ]),
     ].map((row) => row.map((value) => this.escapeCsvCell(value)).join(";"));
 

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -1,10 +1,12 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
+  NotFoundException,
   UnauthorizedException,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { EntityManager, Repository } from "typeorm";
 import {
   Acp,
   AcpAccessConfig,
@@ -26,9 +28,11 @@ import {
   buildPatchPersonalItemPreferenceRowQuery,
   PreferenceIdentityColumn,
 } from "./personal-item-preferences.query";
+import { v4 as uuidv4 } from "uuid";
 
 const MAX_PERSONAL_ITEM_ROWS = 10_000;
 const MAX_EXPORT_ROW_KEY_LENGTH = 500;
+const MAX_ITEM_COLLECTIONS = 100;
 
 export interface ItemPreferencesPayload {
   [key: string]: unknown;
@@ -41,6 +45,37 @@ interface PreferenceIdentity {
   userId?: string;
   credentialId?: string;
   credentialUsername?: string;
+}
+
+interface StoredItemCollection {
+  id: string;
+  name: string;
+  rowKeys: string[];
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ItemCollectionSummary {
+  rowCount: number;
+  itemCount: number;
+  unitCount: number;
+  itemTimeSeconds: number;
+  stimulusTimeSeconds: number;
+  testTimeSeconds: number;
+  missingItemTimeCount: number;
+  missingStimulusTimeUnitCount: number;
+  complete: boolean;
+}
+
+export interface ItemCollectionView extends StoredItemCollection {
+  unavailableRowKeys: string[];
+  summary: ItemCollectionSummary;
+}
+
+export interface ItemCollectionsPayload {
+  activeCollectionId: string | null;
+  collections: ItemCollectionView[];
 }
 
 @Injectable()
@@ -496,6 +531,289 @@ export class ViewsService {
     };
   }
 
+  async getItemCollections(
+    acpId: string,
+    user: any,
+    canEditExplorerState = false,
+  ): Promise<ItemCollectionsPayload> {
+    const { record } = await this.requireCollectionPreferenceRecord(
+      acpId,
+      user,
+      false,
+    );
+    const state = this.normalizeCollectionState(record?.preferences);
+    return this.resolveCollectionViews(
+      acpId,
+      state.collections,
+      state.activeCollectionId,
+      canEditExplorerState,
+    );
+  }
+
+  async createItemCollection(
+    acpId: string,
+    user: any,
+    rawName?: string,
+    canEditExplorerState = false,
+  ): Promise<ItemCollectionsPayload> {
+    const name = this.normalizeCollectionName(rawName || "Meine Kollektion");
+    const now = new Date().toISOString();
+    const collection: StoredItemCollection = {
+      id: uuidv4(),
+      name,
+      rowKeys: [],
+      version: 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const state = await this.mutateCollectionState(
+      acpId,
+      user,
+      true,
+      (lockedState) => {
+        if (lockedState.collections.length >= MAX_ITEM_COLLECTIONS) {
+          throw new BadRequestException(
+            `At most ${MAX_ITEM_COLLECTIONS} item collections can be stored`,
+          );
+        }
+        lockedState.collections.push(collection);
+        lockedState.activeCollectionId = collection.id;
+      },
+    );
+    return this.resolveCollectionViews(
+      acpId,
+      state.collections,
+      state.activeCollectionId,
+      canEditExplorerState,
+    );
+  }
+
+  async updateItemCollection(
+    acpId: string,
+    user: any,
+    collectionId: string,
+    update: { name?: unknown; rowKeys?: unknown; baseVersion?: unknown },
+    canEditExplorerState = false,
+  ): Promise<ItemCollectionsPayload> {
+    const normalizedName =
+      update.name === undefined
+        ? undefined
+        : this.normalizeCollectionName(update.name);
+    let normalizedRowKeys: string[] | undefined;
+    let knownRowKeys: ReadonlySet<string> | undefined;
+    if (update.rowKeys !== undefined) {
+      normalizedRowKeys = this.normalizeCollectionRowKeys(update.rowKeys);
+      const explorerState =
+        await this.itemExplorerStateService.getStateForViewer(
+          acpId,
+          canEditExplorerState,
+        );
+      knownRowKeys = await this.unitParserService.getItemRowKeysFromFiles(
+        acpId,
+        {
+          itemPropertiesOverride: explorerState.activeState.itemProperties,
+          publishedItemPropertiesOverride:
+            explorerState.publishedState.itemProperties,
+        },
+      );
+    }
+    const baseVersion = Number(update.baseVersion);
+    const state = await this.mutateCollectionState(
+      acpId,
+      user,
+      false,
+      (lockedState) => {
+        const collection = lockedState.collections.find(
+          (candidate) => candidate.id === collectionId,
+        );
+        if (!collection) {
+          throw new NotFoundException("Item collection not found");
+        }
+        if (
+          !Number.isInteger(baseVersion) ||
+          baseVersion !== collection.version
+        ) {
+          throw new ConflictException(
+            "The item collection changed concurrently",
+          );
+        }
+        if (normalizedName !== undefined) collection.name = normalizedName;
+        if (normalizedRowKeys !== undefined && knownRowKeys) {
+          const previouslyStored = new Set(collection.rowKeys);
+          const invalidRowKey = normalizedRowKeys.find(
+            (rowKey) =>
+              !knownRowKeys!.has(rowKey) && !previouslyStored.has(rowKey),
+          );
+          if (invalidRowKey) {
+            throw new BadRequestException(
+              "Collections can only add existing item rows",
+            );
+          }
+          collection.rowKeys = normalizedRowKeys;
+        }
+        collection.version += 1;
+        collection.updatedAt = new Date().toISOString();
+      },
+    );
+    return this.resolveCollectionViews(
+      acpId,
+      state.collections,
+      state.activeCollectionId,
+      canEditExplorerState,
+    );
+  }
+
+  async activateItemCollection(
+    acpId: string,
+    user: any,
+    collectionId: string | null,
+    canEditExplorerState = false,
+  ): Promise<ItemCollectionsPayload> {
+    const state = await this.mutateCollectionState(
+      acpId,
+      user,
+      false,
+      (lockedState) => {
+        if (
+          collectionId &&
+          !lockedState.collections.some(
+            (collection) => collection.id === collectionId,
+          )
+        ) {
+          throw new NotFoundException("Item collection not found");
+        }
+        lockedState.activeCollectionId = collectionId;
+      },
+    );
+    return this.resolveCollectionViews(
+      acpId,
+      state.collections,
+      state.activeCollectionId,
+      canEditExplorerState,
+    );
+  }
+
+  async deleteItemCollection(
+    acpId: string,
+    user: any,
+    collectionId: string,
+    canEditExplorerState = false,
+  ): Promise<ItemCollectionsPayload> {
+    const state = await this.mutateCollectionState(
+      acpId,
+      user,
+      false,
+      (lockedState) => {
+        const nextCollections = lockedState.collections.filter(
+          (collection) => collection.id !== collectionId,
+        );
+        if (nextCollections.length === lockedState.collections.length) {
+          throw new NotFoundException("Item collection not found");
+        }
+        lockedState.collections = nextCollections;
+        if (lockedState.activeCollectionId === collectionId) {
+          lockedState.activeCollectionId = nextCollections[0]?.id || null;
+        }
+      },
+    );
+    return this.resolveCollectionViews(
+      acpId,
+      state.collections,
+      state.activeCollectionId,
+      canEditExplorerState,
+    );
+  }
+
+  async exportItemCollectionCsv(
+    acpId: string,
+    user: any,
+    collectionId: string,
+    canEditExplorerState = false,
+  ): Promise<Buffer> {
+    const { record } = await this.requireCollectionPreferenceRecord(
+      acpId,
+      user,
+      false,
+    );
+    if (!record) throw new NotFoundException("Item collection not found");
+    const state = this.normalizeCollectionState(record.preferences);
+    const collection = state.collections.find(
+      (candidate) => candidate.id === collectionId,
+    );
+    if (!collection) throw new NotFoundException("Item collection not found");
+    const explorerState = await this.itemExplorerStateService.getStateForViewer(
+      acpId,
+      canEditExplorerState,
+    );
+    const itemList = await this.unitParserService.getItemListFromFiles(acpId, {
+      itemPropertiesOverride: explorerState.activeState.itemProperties,
+      publishedItemPropertiesOverride:
+        explorerState.publishedState.itemProperties,
+    });
+    const itemsByRowKey = new Map(
+      itemList.items.map((item) => [item.rowKey, item] as const),
+    );
+    const personalRows = this.normalizeItemPreferences(
+      record.preferences,
+    ).rowData;
+    const headers = [
+      "Kollektion",
+      "Reihenfolge",
+      "Unit-ID",
+      "Unit-Label",
+      "Item-ID",
+      "Item-UUID",
+      "Sub-ID",
+      "Zeilenschlüssel",
+      "Empirische Itemschwierigkeit",
+      "Infit",
+      "Trennschärfe",
+      "Lösungshäufigkeit",
+      "Itemzeit (s)",
+      "Stimuluszeit (s)",
+      "Booklet",
+      "Position im Booklet",
+      "Kategorie",
+      "Tags",
+      "Notiz",
+    ];
+    const rows = collection.rowKeys.flatMap((rowKey, index) => {
+      const item = itemsByRowKey.get(rowKey);
+      if (!item) return [];
+      const personal = personalRows[rowKey] || {};
+      const occurrenceColumns = this.formatBookletOccurrenceColumns(item);
+      return [
+        [
+          collection.name,
+          index + 1,
+          item.unitId,
+          item.unitLabel,
+          item.itemId,
+          item.uuid,
+          item.subId || "",
+          item.rowKey,
+          item.empiricalDifficulty ?? "",
+          item.infit ?? "",
+          item.discrimination ?? "",
+          item.solutionRate ?? "",
+          item.itemTimeSeconds ?? "",
+          item.stimulusTimeSeconds ?? "",
+          occurrenceColumns.booklets,
+          occurrenceColumns.positions,
+          typeof personal.category === "string" ? personal.category : "",
+          Array.isArray(personal.tags) ? personal.tags.join(", ") : "",
+          typeof personal.note === "string"
+            ? personal.note.replace(/\n/g, "\\n")
+            : "",
+        ],
+      ];
+    });
+    const lines = [headers, ...rows].map((row) =>
+      row.map((value) => this.escapeCsvCell(value)).join(";"),
+    );
+    return Buffer.from(`\uFEFF${lines.join("\r\n")}\r\n`, "utf8");
+  }
+
   async exportPersonalItemDataXlsx(
     acpId: string,
     user: any,
@@ -534,6 +852,7 @@ export class ViewsService {
       const tags = Array.isArray(personalRow.tags)
         ? personalRow.tags.map((tag) => String(tag))
         : [];
+      const occurrenceColumns = this.formatBookletOccurrenceColumns(item);
 
       return {
         sequenceNumber: index + 1,
@@ -541,6 +860,8 @@ export class ViewsService {
         unitLabel: item.unitLabel,
         itemId: item.itemId,
         itemUuid: item.uuid,
+        subId: item.subId || null,
+        rowKey: item.rowKey,
         markers: this.formatPersonalMarkers(tags, personalTagColors),
         note: typeof personalRow.note === "string" ? personalRow.note : null,
         competenceLevel:
@@ -551,6 +872,13 @@ export class ViewsService {
           item.empiricalDifficulty === undefined
             ? null
             : item.empiricalDifficulty,
+        infit: item.infit ?? null,
+        discrimination: item.discrimination ?? null,
+        solutionRate: item.solutionRate ?? null,
+        itemTimeSeconds: item.itemTimeSeconds ?? null,
+        stimulusTimeSeconds: item.stimulusTimeSeconds ?? null,
+        booklets: occurrenceColumns.booklets || null,
+        bookletPositions: occurrenceColumns.positions || null,
         meanTaskDifficulty: meanDifficultyByUnit.get(item.unitId) ?? null,
       };
     });
@@ -598,6 +926,9 @@ export class ViewsService {
           const tags = Array.isArray(personalRow.tags)
             ? personalRow.tags.map((tag) => String(tag)).join(", ")
             : "";
+          const occurrenceColumns = item
+            ? this.formatBookletOccurrenceColumns(item)
+            : { booklets: "", positions: "" };
 
           return {
             participant,
@@ -616,6 +947,13 @@ export class ViewsService {
                 ? personalRow.note.replace(/\n/g, "\\n")
                 : "",
             empiricalDifficulty: item?.empiricalDifficulty ?? "",
+            infit: item?.infit ?? "",
+            discrimination: item?.discrimination ?? "",
+            solutionRate: item?.solutionRate ?? "",
+            itemTimeSeconds: item?.itemTimeSeconds ?? "",
+            stimulusTimeSeconds: item?.stimulusTimeSeconds ?? "",
+            booklets: occurrenceColumns.booklets,
+            bookletPositions: occurrenceColumns.positions,
             meanTaskDifficulty: item
               ? (meanDifficultyByUnit.get(item.unitId) ?? "")
               : "",
@@ -633,6 +971,316 @@ export class ViewsService {
     );
 
     return this.buildAllPersonalItemDataCsv(rows);
+  }
+
+  private async requireCollectionPreferenceRecord(
+    acpId: string,
+    user: any,
+    createIfMissing: boolean,
+  ): Promise<{
+    identity: PreferenceIdentity;
+    record: AcpItemPreference | null;
+  }> {
+    const identity = this.requireCollectionIdentity(user);
+    let record = await this.findPreferenceRecord(
+      acpId,
+      "item-explorer",
+      identity,
+    );
+    if (!record && createIfMissing) {
+      record = this.itemPreferenceRepository.create({
+        acpId,
+        viewId: "item-explorer",
+        userId: identity.userId || null,
+        credentialId: identity.credentialId || null,
+        credentialUsername: identity.credentialUsername || null,
+        preferences: { ui: {}, tags: {}, rowData: {} },
+      });
+    }
+    return { identity, record };
+  }
+
+  private getRawPreferences(raw: unknown): Record<string, unknown> {
+    return this.isRecord(raw) ? { ...raw } : {};
+  }
+
+  private normalizeCollectionState(rawPreferences: unknown): {
+    collections: StoredItemCollection[];
+    activeCollectionId: string | null;
+  } {
+    const preferences = this.getRawPreferences(rawPreferences);
+    const seen = new Set<string>();
+    const collections = Array.isArray(preferences.collections)
+      ? preferences.collections
+          .map((rawCollection): StoredItemCollection | null => {
+            if (!this.isRecord(rawCollection)) return null;
+            const id = String(rawCollection.id || "").trim();
+            const name = String(rawCollection.name || "").trim();
+            if (!id || !name || seen.has(id)) return null;
+            seen.add(id);
+            const createdAt = this.normalizeIsoDate(rawCollection.createdAt);
+            return {
+              id,
+              name: name.slice(0, 100),
+              rowKeys: this.normalizeCollectionRowKeys(
+                Array.isArray(rawCollection.rowKeys)
+                  ? rawCollection.rowKeys
+                  : [],
+              ),
+              version: Math.max(1, Number(rawCollection.version) || 1),
+              createdAt,
+              updatedAt: this.normalizeIsoDate(
+                rawCollection.updatedAt,
+                createdAt,
+              ),
+            };
+          })
+          .filter(
+            (collection): collection is StoredItemCollection =>
+              collection !== null,
+          )
+      : [];
+    const requestedActiveId = String(
+      preferences.activeCollectionId || "",
+    ).trim();
+    return {
+      collections,
+      activeCollectionId: collections.some(
+        (collection) => collection.id === requestedActiveId,
+      )
+        ? requestedActiveId
+        : collections[0]?.id || null,
+    };
+  }
+
+  private normalizeCollectionName(value: unknown): string {
+    const name = this.normalizePlainText(value, 100);
+    if (!name) throw new BadRequestException("Collection name is required");
+    return name;
+  }
+
+  private normalizeCollectionRowKeys(value: unknown): string[] {
+    if (!Array.isArray(value) || value.length > MAX_PERSONAL_ITEM_ROWS) {
+      throw new BadRequestException(
+        `At most ${MAX_PERSONAL_ITEM_ROWS} item rows can be stored in a collection`,
+      );
+    }
+    const seen = new Set<string>();
+    const rowKeys: string[] = [];
+    for (const rawRowKey of value) {
+      if (typeof rawRowKey !== "string") {
+        throw new BadRequestException("Collection row keys must be strings");
+      }
+      const rowKey = rawRowKey.trim();
+      if (!rowKey || rowKey.length > MAX_EXPORT_ROW_KEY_LENGTH) {
+        throw new BadRequestException("A valid collection row key is required");
+      }
+      if (!seen.has(rowKey)) {
+        seen.add(rowKey);
+        rowKeys.push(rowKey);
+      }
+    }
+    return rowKeys;
+  }
+
+  private normalizeIsoDate(value: unknown, fallback?: string): string {
+    const parsed = typeof value === "string" ? new Date(value) : null;
+    return parsed && Number.isFinite(parsed.getTime())
+      ? parsed.toISOString()
+      : fallback || new Date().toISOString();
+  }
+
+  private requireCollectionIdentity(user: any): PreferenceIdentity {
+    const identity = this.resolvePreferenceIdentity(user);
+    if (!identity || (!identity.userId && !identity.credentialId)) {
+      throw new UnauthorizedException(
+        "A stable identity is required for item collections",
+      );
+    }
+    return identity;
+  }
+
+  private async mutateCollectionState(
+    acpId: string,
+    user: any,
+    createIfMissing: boolean,
+    mutate: (state: {
+      collections: StoredItemCollection[];
+      activeCollectionId: string | null;
+    }) => void,
+  ): Promise<{
+    collections: StoredItemCollection[];
+    activeCollectionId: string | null;
+  }> {
+    const identity = this.requireCollectionIdentity(user);
+    return this.itemPreferenceRepository.manager.transaction(
+      async (manager) => {
+        if (createIfMissing) {
+          await this.insertCollectionPreferenceIfMissing(
+            manager,
+            acpId,
+            identity,
+          );
+        }
+        const repository = manager.getRepository(AcpItemPreference);
+        const record = await repository.findOne({
+          where: {
+            acpId,
+            viewId: "item-explorer",
+            ...(identity.userId
+              ? { userId: identity.userId }
+              : { credentialId: identity.credentialId }),
+          },
+          lock: { mode: "pessimistic_write" },
+        });
+        if (!record) throw new NotFoundException("Item collection not found");
+
+        const preferences = this.getRawPreferences(record.preferences);
+        const state = this.normalizeCollectionState(preferences);
+        mutate(state);
+        record.preferences = {
+          ...preferences,
+          collections: state.collections,
+          activeCollectionId: state.activeCollectionId,
+        };
+        if (identity.credentialUsername) {
+          record.credentialUsername = identity.credentialUsername;
+        }
+        await repository.save(record);
+        return state;
+      },
+    );
+  }
+
+  private async insertCollectionPreferenceIfMissing(
+    manager: EntityManager,
+    acpId: string,
+    identity: PreferenceIdentity,
+  ): Promise<void> {
+    const identityColumn = identity.userId ? "user_id" : "credential_id";
+    const identityPredicate = identity.userId
+      ? '"user_id" IS NOT NULL'
+      : '"credential_id" IS NOT NULL';
+    await manager.query(
+      `
+        INSERT INTO "acp_item_preferences" (
+          "id", "acp_id", "view_id", "user_id", "credential_id",
+          "credential_username", "preferences", "created_at", "updated_at"
+        )
+        VALUES (
+          uuid_generate_v4(), $1, 'item-explorer', $2, $3, $4,
+          '{"ui":{},"tags":{},"rowData":{}}'::jsonb, now(), now()
+        )
+        ON CONFLICT ("acp_id", "view_id", "${identityColumn}")
+          WHERE ${identityPredicate}
+        DO NOTHING
+      `,
+      [
+        acpId,
+        identity.userId || null,
+        identity.credentialId || null,
+        identity.credentialUsername || null,
+      ],
+    );
+  }
+
+  private async resolveCollectionViews(
+    acpId: string,
+    collections: StoredItemCollection[],
+    activeCollectionId: string | null,
+    canEditExplorerState: boolean,
+  ): Promise<ItemCollectionsPayload> {
+    const explorerState = await this.itemExplorerStateService.getStateForViewer(
+      acpId,
+      canEditExplorerState,
+    );
+    const itemList = await this.unitParserService.getItemListFromFiles(acpId, {
+      itemPropertiesOverride: explorerState.activeState.itemProperties,
+      publishedItemPropertiesOverride:
+        explorerState.publishedState.itemProperties,
+    });
+    const itemsByRowKey = new Map(
+      itemList.items.map((item) => [item.rowKey, item] as const),
+    );
+    return {
+      activeCollectionId,
+      collections: collections.map((collection) => {
+        const unavailableRowKeys = collection.rowKeys.filter(
+          (rowKey) => !itemsByRowKey.has(rowKey),
+        );
+        const items = collection.rowKeys
+          .map((rowKey) => itemsByRowKey.get(rowKey))
+          .filter((item): item is VomdItemData => Boolean(item));
+        return {
+          ...collection,
+          unavailableRowKeys,
+          summary: this.calculateItemCollectionSummary(
+            items,
+            collection.rowKeys.length,
+          ),
+        };
+      }),
+    };
+  }
+
+  private calculateItemCollectionSummary(
+    items: VomdItemData[],
+    selectedRowCount = items.length,
+  ): ItemCollectionSummary {
+    const uniqueItems = new Map<string, VomdItemData[]>();
+    const uniqueUnits = new Map<string, VomdItemData[]>();
+    for (const item of items) {
+      const itemRows = uniqueItems.get(item.uuid) || [];
+      itemRows.push(item);
+      uniqueItems.set(item.uuid, itemRows);
+      const unitRows = uniqueUnits.get(item.unitId) || [];
+      unitRows.push(item);
+      uniqueUnits.set(item.unitId, unitRows);
+    }
+
+    let itemTimeSeconds = 0;
+    let stimulusTimeSeconds = 0;
+    let missingItemTimeCount = 0;
+    let missingStimulusTimeUnitCount = 0;
+    for (const rows of uniqueItems.values()) {
+      const time = rows
+        .map((row) => row.itemTimeSeconds)
+        .find((value): value is number => Number.isFinite(value));
+      if (time === undefined) missingItemTimeCount += 1;
+      else itemTimeSeconds += time;
+    }
+    for (const rows of uniqueUnits.values()) {
+      const time = rows
+        .map((row) => row.stimulusTimeSeconds)
+        .find((value): value is number => Number.isFinite(value));
+      if (time === undefined) missingStimulusTimeUnitCount += 1;
+      else stimulusTimeSeconds += time;
+    }
+    return {
+      rowCount: selectedRowCount,
+      itemCount: uniqueItems.size,
+      unitCount: uniqueUnits.size,
+      itemTimeSeconds,
+      stimulusTimeSeconds,
+      testTimeSeconds: itemTimeSeconds + stimulusTimeSeconds,
+      missingItemTimeCount,
+      missingStimulusTimeUnitCount,
+      complete:
+        missingItemTimeCount === 0 && missingStimulusTimeUnitCount === 0,
+    };
+  }
+
+  private formatBookletOccurrenceColumns(item: VomdItemData): {
+    booklets: string;
+    positions: string;
+  } {
+    const occurrences = item.bookletOccurrences || [];
+    return {
+      booklets: occurrences.map((occurrence) => occurrence.booklet).join(" | "),
+      positions: occurrences
+        .map((occurrence) => String(occurrence.position))
+        .join(" | "),
+    };
   }
 
   private async upsertItemPreferences(
@@ -821,6 +1469,8 @@ export class ViewsService {
       { header: "Unit-Label", key: "unitLabel", width: 30 },
       { header: "Item-ID", key: "itemId", width: 22 },
       { header: "Item-UUID", key: "itemUuid", width: 38 },
+      { header: "Sub-ID", key: "subId", width: 18 },
+      { header: "Zeilenschlüssel", key: "rowKey", width: 45 },
       { header: "Markierung/Farbe", key: "markers", width: 32 },
       { header: "Notiz", key: "note", width: 50 },
       { header: "Kompetenzstufe", key: "competenceLevel", width: 22 },
@@ -829,6 +1479,17 @@ export class ViewsService {
         key: "empiricalDifficulty",
         width: 30,
       },
+      { header: "Infit", key: "infit", width: 16 },
+      { header: "Trennschärfe", key: "discrimination", width: 18 },
+      { header: "Lösungshäufigkeit", key: "solutionRate", width: 22 },
+      { header: "Itemzeit (s)", key: "itemTimeSeconds", width: 18 },
+      { header: "Stimuluszeit (s)", key: "stimulusTimeSeconds", width: 20 },
+      { header: "Booklet", key: "booklets", width: 30 },
+      {
+        header: "Position im Booklet",
+        key: "bookletPositions",
+        width: 25,
+      },
       {
         header: "Mittlere Aufgabenschwierigkeit",
         key: "meanTaskDifficulty",
@@ -836,7 +1497,7 @@ export class ViewsService {
       },
     ];
     sheet.views = [{ state: "frozen", ySplit: 1 }];
-    sheet.autoFilter = { from: "A1", to: "J1" };
+    sheet.autoFilter = { from: "A1", to: "S1" };
 
     const headerRow = sheet.getRow(1);
     headerRow.font = { bold: true, color: { argb: "FFFFFFFF" } };
@@ -854,6 +1515,15 @@ export class ViewsService {
     };
     sheet.getColumn("empiricalDifficulty").numFmt = "0.############";
     sheet.getColumn("meanTaskDifficulty").numFmt = "0.############";
+    for (const key of [
+      "infit",
+      "discrimination",
+      "solutionRate",
+      "itemTimeSeconds",
+      "stimulusTimeSeconds",
+    ]) {
+      sheet.getColumn(key).numFmt = "0.############";
+    }
 
     const buffer = await workbook.xlsx.writeBuffer();
     return Buffer.from(buffer);
@@ -871,6 +1541,13 @@ export class ViewsService {
       tags: string;
       note: string;
       empiricalDifficulty: number | string;
+      infit: number | string;
+      discrimination: number | string;
+      solutionRate: number | string;
+      itemTimeSeconds: number | string;
+      stimulusTimeSeconds: number | string;
+      booklets: string;
+      bookletPositions: string;
       meanTaskDifficulty: number | string;
     }>,
   ): Buffer {
@@ -885,6 +1562,13 @@ export class ViewsService {
       "Tags",
       "Notiz",
       "Empirische Itemschwierigkeit",
+      "Infit",
+      "Trennschärfe",
+      "Lösungshäufigkeit",
+      "Itemzeit (s)",
+      "Stimuluszeit (s)",
+      "Booklet",
+      "Position im Booklet",
       "Mittlere Aufgabenschwierigkeit",
     ];
     const lines = [
@@ -900,6 +1584,13 @@ export class ViewsService {
         row.tags,
         row.note,
         row.empiricalDifficulty,
+        row.infit,
+        row.discrimination,
+        row.solutionRate,
+        row.itemTimeSeconds,
+        row.stimulusTimeSeconds,
+        row.booklets,
+        row.bookletPositions,
         row.meanTaskDifficulty,
       ]),
     ].map((row) => row.map((value) => this.escapeCsvCell(value)).join(";"));

--- a/docs/features/item-explorer.md
+++ b/docs/features/item-explorer.md
@@ -241,8 +241,19 @@ required. Time values are non-negative seconds; decimal point and decimal comma 
 Repeated rows for the same item/Sub-ID represent booklet occurrences. Scalar values on those rows
 must agree, while `booklet` and `position` are collected as ordered 1:n metadata on the stable
 Explorer row. The occurrence columns must always be supplied and filled together. Columns that are
-absent leave stored values unchanged; a supplied but empty value clears that parameter for the
-imported row.
+absent leave stored values unchanged; a supplied but empty value clears that parameter in its
+defined scope:
+
+- difficulty, Infit, discrimination, solution rate, and booklet occurrences belong to the stable
+  Explorer row,
+- item time belongs to the underlying item UUID and is shared by its partial-credit rows,
+- stimulus time belongs to the complete unit and is shared by all of its item rows.
+
+When repeated rows address the same item or unit, one distinct non-empty time value is applied to
+the complete scope and blank repetitions are ignored. If every supplied value in that scope is
+blank, the stored value is cleared. Different non-empty values in one scope are rejected as a
+conflict before any item property is changed. A standard row fans row-scoped values out to existing
+partial-credit rows; importing explicit Sub-IDs does not delete other partial-credit rows.
 
 Infit, discrimination, solution rate, item time, stimulus time, booklet, and position are built-in
 configurable Explorer columns. Numeric columns use numeric filtering and sorting. Booklet and

--- a/docs/features/item-explorer.md
+++ b/docs/features/item-explorer.md
@@ -206,6 +206,8 @@ ACP managers and application admins can additionally download one ACP-wide CSV f
 toolbar. The endpoint rejects read-only users, credential logins, and public access. It exports every
 stored personal row across participants, using a stable participant identifier and including unit,
 item, Sub-ID, stable row key, category, tags, note, empirical difficulty, and mean unit difficulty.
+When present, both personal and manager exports also contain Infit, discrimination, solution rate,
+item/stimulus times, and paired booklet positions.
 Participants without stored rows are skipped without failing the export. Note line breaks are
 written as literal `\\n` sequences so every personal entry remains on one CSV row.
 
@@ -229,6 +231,24 @@ the result later.
 
 The same distinction exists when clearing empirical difficulty values.
 
+### Wide item-parameter import
+
+Managers can also upload a semicolon-separated wide CSV through the Item Explorer. Its canonical
+headers are `item`, `sub_id`, `est`, `infit`, `discrimination`, `solution_rate`, `item_time_s`,
+`stimulus_time_s`, `booklet`, and `position`. Only `item` and at least one parameter column are
+required. Time values are non-negative seconds; decimal point and decimal comma are accepted.
+
+Repeated rows for the same item/Sub-ID represent booklet occurrences. Scalar values on those rows
+must agree, while `booklet` and `position` are collected as ordered 1:n metadata on the stable
+Explorer row. The occurrence columns must always be supplied and filled together. Columns that are
+absent leave stored values unchanged; a supplied but empty value clears that parameter for the
+imported row.
+
+Infit, discrimination, solution rate, item time, stimulus time, booklet, and position are built-in
+configurable Explorer columns. Numeric columns use numeric filtering and sorting. Booklet and
+position filters are paired, so a row only matches two simultaneous filters when one occurrence
+satisfies both.
+
 ### Partial-credit rows
 
 Difficulty CSV files may use the second column as a Sub-ID, category, or score level. The
@@ -249,6 +269,23 @@ use their item UUID as their row key and remain single rows.
 Shared explorer properties, tags, manual ordering, saved response states, and personal
 `rowData` preferences use the stable row key. This prevents two partial-credit rows of the same
 item from overwriting one another and gives exports a unique identifier for every table row.
+
+## Personal Item Collections
+
+When `enableItemCollections` is enabled, authenticated users and credential identities can maintain
+multiple named collections. Collections are stored in the existing `acp_item_preferences` JSONB
+record under the `item-explorer` view and are never exposed to other participants or managers.
+Every collection stores an ordered list of stable row keys and an optimistic-lock version.
+
+The leading duration is combined test time: item time is counted once per underlying item UUID and
+stimulus time once per selected unit. Selecting several partial-credit rows therefore does not
+multiply either time. The UI continues to show the known subtotal when data is incomplete and
+reports how many item and unit time values are missing. Stale row keys remain removable but are
+excluded from totals and exports.
+
+Collections can be created, renamed, cleared, deleted, and exported as semicolon-separated UTF-8
+CSV. Up to 100 named collections can be stored per identity and ACP. Direct generation of ACP
+booklets or task sequences is intentionally outside this feature.
 
 ## Player Preview and Legacy Player Compatibility
 

--- a/docs/features/item-explorer.md
+++ b/docs/features/item-explorer.md
@@ -276,6 +276,7 @@ When `enableItemCollections` is enabled, authenticated users and credential iden
 multiple named collections. Collections are stored in the existing `acp_item_preferences` JSONB
 record under the `item-explorer` view and are never exposed to other participants or managers.
 Every collection stores an ordered list of stable row keys and an optimistic-lock version.
+Non-manager collection access additionally requires the Item Explorer item list to be enabled.
 
 The leading duration is combined test time: item time is counted once per underlying item UUID and
 stimulus time once per selected unit. Selecting several partial-credit rows therefore does not

--- a/frontend/src/app/acp-manager/access-config/access-config.component.ts
+++ b/frontend/src/app/acp-manager/access-config/access-config.component.ts
@@ -498,6 +498,10 @@ import { AcpManagerContextComponent } from '../shared/acp-manager-context.compon
           <input type="checkbox" [(ngModel)]="featureConfig[enablePersonalItemDataKey]" />
           <span>Persönliche Arbeitsdaten im Item-Explorer aktivieren</span>
         </label>
+        <label class="feature-toggle">
+          <input type="checkbox" [(ngModel)]="featureConfig[enableItemCollectionsKey]" />
+          <span>Persönliche Item-Kollektionen aktivieren</span>
+        </label>
         @if (featureConfig[enablePersonalItemDataKey]) {
           <div class="indent-section personal-data-config">
             <label class="help-text" for="personal-item-category-label">
@@ -850,6 +854,7 @@ export class AccessConfigComponent implements OnInit {
   readonly itemSubIdLabelKey = 'itemSubIdLabel';
   readonly itemSubIdLabelsKey = 'itemSubIdLabels';
   readonly enablePersonalItemDataKey = 'enablePersonalItemData';
+  readonly enableItemCollectionsKey = 'enableItemCollections';
   readonly personalItemCategoryLabelKey = 'personalItemCategoryLabel';
   readonly personalItemCategoryValuesKey = 'personalItemCategoryValues';
   readonly personalItemTagLabelKey = 'personalItemTagLabel';
@@ -1123,6 +1128,8 @@ export class AccessConfigComponent implements OnInit {
     this.featureConfig[this.itemSubIdLabelKey] = itemSubIdLabel || 'Sub-ID';
     this.featureConfig[this.enablePersonalItemDataKey] =
       this.featureConfig[this.enablePersonalItemDataKey] === true;
+    this.featureConfig[this.enableItemCollectionsKey] =
+      this.featureConfig[this.enableItemCollectionsKey] === true;
     const personalCategoryLabel = String(
       this.featureConfig[this.personalItemCategoryLabelKey] || '',
     ).trim();

--- a/frontend/src/app/core/models/api.models.ts
+++ b/frontend/src/app/core/models/api.models.ts
@@ -378,6 +378,7 @@ export interface FeatureConfig {
   itemSubIdLabel?: string;
   itemSubIdLabels?: Record<string, string>;
   enablePersonalItemData?: boolean;
+  enableItemCollections?: boolean;
   personalItemCategoryLabel?: string;
   personalItemCategoryValues?: string[];
   personalItemTagLabel?: string;
@@ -449,6 +450,34 @@ export interface ItemViewPreferences {
   ui?: Record<string, unknown>;
   tags?: Record<string, string[]>;
   rowData?: Record<string, Record<string, unknown>>;
+}
+
+export interface ItemCollectionSummary {
+  rowCount: number;
+  itemCount: number;
+  unitCount: number;
+  itemTimeSeconds: number;
+  stimulusTimeSeconds: number;
+  testTimeSeconds: number;
+  missingItemTimeCount: number;
+  missingStimulusTimeUnitCount: number;
+  complete: boolean;
+}
+
+export interface ItemCollection {
+  id: string;
+  name: string;
+  rowKeys: string[];
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  unavailableRowKeys: string[];
+  summary: ItemCollectionSummary;
+}
+
+export interface ItemCollectionsPayload {
+  activeCollectionId: string | null;
+  collections: ItemCollection[];
 }
 
 export interface ItemExplorerMetadataColumns {

--- a/frontend/src/app/core/services/api.service.spec.ts
+++ b/frontend/src/app/core/services/api.service.spec.ts
@@ -1058,6 +1058,39 @@ describe('ApiService', () => {
   });
 
   describe('Items', () => {
+    it('should upload wide item parameters in draft mode', () => {
+      httpClientMock.post.mockReturnValue(of({ updated: 1, failed: [], successes: [] }));
+
+      const file = new File(['item;infit\nx;1'], 'parameters.csv', { type: 'text/csv' });
+      service.uploadItemParameters('acp1', file, { draft: true, baseVersion: 7 }).subscribe();
+
+      expect(httpClientMock.post).toHaveBeenCalledWith(
+        '/api/acp/acp1/items/upload-item-parameters?draft=true&baseVersion=7',
+        expect.any(FormData),
+      );
+    });
+
+    it('should update and export personal item collections', () => {
+      httpClientMock.patch.mockReturnValue(of({ activeCollectionId: 'c1', collections: [] }));
+      httpClientMock.post.mockReturnValue(of(new Blob(['csv'])));
+
+      service
+        .updateItemCollection('acp1', 'c1', { baseVersion: 2, rowKeys: ['uuid-1'] }, 'editor')
+        .subscribe();
+      service.exportItemCollectionCsv('acp1', 'c1', 'editor').subscribe();
+
+      expect(httpClientMock.patch).toHaveBeenCalledWith('/api/view/acp/acp1/items/collections/c1', {
+        baseVersion: 2,
+        rowKeys: ['uuid-1'],
+        perspective: 'editor',
+      });
+      expect(httpClientMock.post).toHaveBeenCalledWith(
+        '/api/view/acp/acp1/items/collections/c1/export.csv?perspective=editor',
+        {},
+        { responseType: 'blob' },
+      );
+    });
+
     it('should upload empirical difficulties in draft mode with baseVersion', () => {
       httpClientMock.post.mockReturnValue(of({ updated: 0, failed: [], successes: [] }));
 

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -29,6 +29,7 @@ import {
   ValidateUnitsResponse,
   FilePreviewResponse,
   FileDeletionResponse,
+  ItemCollectionsPayload,
 } from '../models/api.models';
 
 type ItemExplorerPerspective = 'editor' | 'read-only';
@@ -540,6 +541,32 @@ export class ApiService {
   }
 
   // Items
+  uploadItemParameters(
+    acpId: string,
+    file: File,
+    options?: { draft?: boolean; baseVersion?: number },
+  ): Observable<{
+    updated: number;
+    failed: any[];
+    successes: any[];
+    explorerState?: ItemExplorerStateEnvelope;
+  }> {
+    const formData = new FormData();
+    formData.append('file', file);
+    const query: string[] = [];
+    if (options?.draft) query.push('draft=true');
+    if (typeof options?.baseVersion === 'number') {
+      query.push(`baseVersion=${encodeURIComponent(String(options.baseVersion))}`);
+    }
+    const queryString = query.length ? `?${query.join('&')}` : '';
+    return this.http.post<{
+      updated: number;
+      failed: any[];
+      successes: any[];
+      explorerState?: ItemExplorerStateEnvelope;
+    }>(`${this.API}/acp/${acpId}/items/upload-item-parameters${queryString}`, formData);
+  }
+
   uploadEmpiricalDifficulties(
     acpId: string,
     file: File,
@@ -567,6 +594,71 @@ export class ApiService {
       successes: any[];
       explorerState?: ItemExplorerStateEnvelope;
     }>(`${this.API}/acp/${acpId}/items/upload-empirical-difficulty${queryString}`, formData);
+  }
+
+  getItemCollections(
+    acpId: string,
+    perspective: ItemExplorerPerspective,
+  ): Observable<ItemCollectionsPayload> {
+    return this.http.get<ItemCollectionsPayload>(
+      `${this.API}/view/acp/${acpId}/items/collections?perspective=${encodeURIComponent(perspective)}`,
+    );
+  }
+
+  createItemCollection(
+    acpId: string,
+    name: string,
+    perspective: ItemExplorerPerspective,
+  ): Observable<ItemCollectionsPayload> {
+    return this.http.post<ItemCollectionsPayload>(
+      `${this.API}/view/acp/${acpId}/items/collections`,
+      { name, perspective },
+    );
+  }
+
+  updateItemCollection(
+    acpId: string,
+    collectionId: string,
+    update: { baseVersion: number; name?: string; rowKeys?: string[] },
+    perspective: ItemExplorerPerspective,
+  ): Observable<ItemCollectionsPayload> {
+    return this.http.patch<ItemCollectionsPayload>(
+      `${this.API}/view/acp/${acpId}/items/collections/${encodeURIComponent(collectionId)}`,
+      { ...update, perspective },
+    );
+  }
+
+  activateItemCollection(
+    acpId: string,
+    collectionId: string | null,
+    perspective: ItemExplorerPerspective,
+  ): Observable<ItemCollectionsPayload> {
+    return this.http.put<ItemCollectionsPayload>(
+      `${this.API}/view/acp/${acpId}/items/collections/active`,
+      { collectionId, perspective },
+    );
+  }
+
+  deleteItemCollection(
+    acpId: string,
+    collectionId: string,
+    perspective: ItemExplorerPerspective,
+  ): Observable<ItemCollectionsPayload> {
+    return this.http.delete<ItemCollectionsPayload>(
+      `${this.API}/view/acp/${acpId}/items/collections/${encodeURIComponent(collectionId)}?perspective=${encodeURIComponent(perspective)}`,
+    );
+  }
+
+  exportItemCollectionCsv(
+    acpId: string,
+    collectionId: string,
+    perspective: ItemExplorerPerspective,
+  ): Observable<Blob> {
+    return this.http.post(
+      `${this.API}/view/acp/${acpId}/items/collections/${encodeURIComponent(collectionId)}/export.csv?perspective=${encodeURIComponent(perspective)}`,
+      {},
+      { responseType: 'blob' },
+    );
   }
 
   clearEmpiricalDifficulties(

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -549,6 +549,7 @@ export class ApiService {
     updated: number;
     failed: any[];
     successes: any[];
+    showOnlyItemsWithEmpiricalDifficulty?: boolean;
     explorerState?: ItemExplorerStateEnvelope;
   }> {
     const formData = new FormData();
@@ -563,6 +564,7 @@ export class ApiService {
       updated: number;
       failed: any[];
       successes: any[];
+      showOnlyItemsWithEmpiricalDifficulty?: boolean;
       explorerState?: ItemExplorerStateEnvelope;
     }>(`${this.API}/acp/${acpId}/items/upload-item-parameters${queryString}`, formData);
   }

--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -84,6 +84,9 @@ function createComponent(options?: {
   (component as any).personalDataSessionIdentity = (
     component as any
   ).resolvePersonalItemDataSessionIdentity();
+  (component as any).collectionSessionIdentity = (
+    component as any
+  ).resolvePersonalItemDataSessionIdentity();
   return component;
 }
 
@@ -2826,5 +2829,350 @@ describe('ItemExplorerComponent', () => {
         delete (document as any).exitFullscreen;
       }
     }
+  });
+
+  it('filters imported numeric values and paired booklet occurrences', () => {
+    const component = createComponent();
+    component.items = [
+      {
+        itemId: 'item-1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1',
+        unitId: 'unit-1',
+        unitLabel: 'Aufgabe 1',
+        description: '',
+        variableId: 'v1',
+        metadata: {},
+        infit: 1.05,
+        bookletOccurrences: [
+          { booklet: 'B1', position: 5 },
+          { booklet: 'B2', position: 2 },
+        ],
+      },
+    ];
+    component.allColumns = [
+      { id: 'infit', label: 'Infit', kind: 'number' },
+      { id: 'booklet', label: 'Booklet', kind: 'booklet' },
+      { id: 'bookletPosition', label: 'Position', kind: 'position' },
+    ];
+    component.columnFilters = {
+      infit: '1,0..1,1',
+      booklet: 'B1',
+      bookletPosition: '1..3',
+    };
+
+    component.applyFilter(false);
+    expect(component.filteredItems).toEqual([]);
+
+    component.columnFilters['booklet'] = 'B2';
+    component.applyFilter(false);
+    expect(component.filteredItems).toHaveLength(1);
+  });
+
+  it('calculates combined collection time once per item and unit', () => {
+    const component = createComponent();
+    component.items = [
+      {
+        itemId: 'item-1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1::1',
+        unitId: 'unit-1',
+        unitLabel: 'Aufgabe 1',
+        description: '',
+        variableId: 'v1',
+        metadata: {},
+        itemTimeSeconds: 10,
+        stimulusTimeSeconds: 5,
+      },
+      {
+        itemId: 'item-1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1::2',
+        unitId: 'unit-1',
+        unitLabel: 'Aufgabe 1',
+        description: '',
+        variableId: 'v1',
+        metadata: {},
+        itemTimeSeconds: 10,
+        stimulusTimeSeconds: 5,
+      },
+      {
+        itemId: 'item-2',
+        uuid: 'uuid-2',
+        rowKey: 'uuid-2',
+        unitId: 'unit-1',
+        unitLabel: 'Aufgabe 1',
+        description: '',
+        variableId: 'v2',
+        metadata: {},
+        stimulusTimeSeconds: 5,
+      },
+    ];
+    component.itemCollections = [
+      {
+        id: 'collection-1',
+        name: 'Auswahl',
+        rowKeys: ['uuid-1::1', 'uuid-1::2', 'uuid-2', 'removed'],
+        version: 1,
+        createdAt: '',
+        updatedAt: '',
+        unavailableRowKeys: [],
+        summary: {} as any,
+      },
+    ];
+    component.activeCollectionId = 'collection-1';
+
+    (component as any).recalculateCollectionSummaries();
+
+    expect(component.activeItemCollection?.summary).toEqual({
+      rowCount: 4,
+      itemCount: 2,
+      unitCount: 1,
+      itemTimeSeconds: 10,
+      stimulusTimeSeconds: 5,
+      testTimeSeconds: 15,
+      missingItemTimeCount: 1,
+      missingStimulusTimeUnitCount: 0,
+      complete: false,
+    });
+    expect(component.activeItemCollection?.unavailableRowKeys).toEqual(['removed']);
+  });
+
+  it('persists selection changes against the active collection version', async () => {
+    const response = {
+      activeCollectionId: 'collection-1',
+      collections: [
+        {
+          id: 'collection-1',
+          name: 'Auswahl',
+          rowKeys: ['uuid-1'],
+          version: 2,
+          createdAt: '',
+          updatedAt: '',
+          unavailableRowKeys: [],
+          summary: {
+            rowCount: 1,
+            itemCount: 1,
+            unitCount: 1,
+            itemTimeSeconds: 10,
+            stimulusTimeSeconds: 5,
+            testTimeSeconds: 15,
+            missingItemTimeCount: 0,
+            missingStimulusTimeUnitCount: 0,
+            complete: true,
+          },
+        },
+      ],
+    };
+    const updateItemCollection = vi.fn().mockReturnValue(of(response));
+    const component = createComponent({
+      api: { updateItemCollection },
+      authService: { isLoggedIn: true },
+    });
+    const item = {
+      itemId: 'item-1',
+      uuid: 'uuid-1',
+      rowKey: 'uuid-1',
+      unitId: 'unit-1',
+      unitLabel: 'Aufgabe 1',
+      description: '',
+      variableId: 'v1',
+      metadata: {},
+      itemTimeSeconds: 10,
+      stimulusTimeSeconds: 5,
+    };
+    component.acpId = 'acp-1';
+    component.items = [item];
+    component.itemCollections = [
+      {
+        ...response.collections[0],
+        rowKeys: [],
+        version: 1,
+        summary: { ...response.collections[0].summary, rowCount: 0 },
+      },
+    ];
+    component.activeCollectionId = 'collection-1';
+    component.collectionLoadState = 'loaded';
+
+    await component.toggleItemInActiveCollection(item);
+
+    expect(updateItemCollection).toHaveBeenCalledWith(
+      'acp-1',
+      'collection-1',
+      { baseVersion: 1, rowKeys: ['uuid-1'] },
+      'read-only',
+    );
+    expect(component.activeItemCollection?.version).toBe(2);
+  });
+
+  it('filters empirical difficulty numerically and keeps missing values last', () => {
+    const component = createComponent();
+    const baseItem = {
+      unitId: 'unit-1',
+      unitLabel: 'Aufgabe 1',
+      description: '',
+      variableId: 'v1',
+      metadata: {},
+    };
+    component.items = [
+      { ...baseItem, itemId: 'missing', uuid: 'uuid-0', rowKey: 'uuid-0' },
+      {
+        ...baseItem,
+        itemId: 'negative',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1',
+        empiricalDifficulty: -1,
+      },
+      {
+        ...baseItem,
+        itemId: 'positive',
+        uuid: 'uuid-2',
+        rowKey: 'uuid-2',
+        empiricalDifficulty: 2,
+      },
+    ];
+    component.columnFilters = { empiricalDifficulty: '-2..0' };
+
+    component.applyFilter(false);
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['negative']);
+
+    component.columnFilters = {};
+    component.applyFilter(false);
+    component.sortBy('empiricalDifficulty');
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual([
+      'negative',
+      'positive',
+      'missing',
+    ]);
+  });
+
+  it('keeps all integrated parameter columns configurable when values are missing', () => {
+    const component = createComponent();
+
+    const columns = (component as any).getAvailableMetadataColumns([]);
+
+    expect(columns.map((column: { id: string }) => column.id)).toEqual([
+      'infit',
+      'discrimination',
+      'solutionRate',
+      'itemTimeSeconds',
+      'stimulusTimeSeconds',
+      'booklet',
+      'bookletPosition',
+    ]);
+  });
+
+  it('formats wide and legacy upload successes without losing imported details', () => {
+    const component = createComponent();
+    const wideSuccess = {
+      unitId: 'unit-1',
+      itemId: 'item-1',
+      subId: 'A',
+      fields: ['infit', 'discrimination', 'booklet', 'position'],
+      bookletOccurrences: [
+        { booklet: 'B1', position: 2 },
+        { booklet: 'B2', position: 5 },
+      ],
+    };
+
+    expect(component.getUploadSuccessFieldSummary(wideSuccess)).toBe(
+      'Infit, Trennschärfe, Booklet / Position',
+    );
+    expect(component.getUploadSuccessBookletSummary(wideSuccess)).toBe('B1 / 2 | B2 / 5');
+    const clearedBooklets = {
+      fields: ['booklet', 'position'],
+      bookletOccurrences: [],
+    };
+    expect(component.getUploadSuccessFieldSummary(clearedBooklets)).toBe(
+      'Booklet / Position gelöscht',
+    );
+    expect(component.getUploadSuccessBookletSummary(clearedBooklets)).toBe('Gelöscht');
+    expect(component.getUploadSuccessFieldSummary({ value: -0.4 })).toBe(
+      'Empirische Itemschwierigkeit: -0.4',
+    );
+    expect(component.getUploadSuccessBookletSummary({ value: -0.4 })).toBe('–');
+  });
+
+  it('keeps server collection summaries while the item list is loading', () => {
+    const summary = {
+      rowCount: 2,
+      itemCount: 2,
+      unitCount: 1,
+      itemTimeSeconds: 20,
+      stimulusTimeSeconds: 5,
+      testTimeSeconds: 25,
+      missingItemTimeCount: 0,
+      missingStimulusTimeUnitCount: 0,
+      complete: true,
+    };
+    const getItemCollections = vi.fn().mockReturnValue(
+      of({
+        activeCollectionId: 'collection-1',
+        collections: [
+          {
+            id: 'collection-1',
+            name: 'Auswahl',
+            rowKeys: ['uuid-1', 'uuid-2'],
+            version: 1,
+            createdAt: '',
+            updatedAt: '',
+            unavailableRowKeys: [],
+            summary,
+          },
+        ],
+      }),
+    );
+    const token = createJwt('user-1');
+    const component = createComponent({
+      api: { getItemCollections },
+      authService: { getToken: () => token },
+    });
+    component.enableItemCollections = true;
+    component.itemListLoading = true;
+
+    (component as any).syncItemCollectionSession();
+
+    expect(component.activeItemCollection?.summary).toEqual(summary);
+    expect(component.activeItemCollection?.unavailableRowKeys).toEqual([]);
+  });
+
+  it('clears collections on identity changes and ignores stale responses', () => {
+    const userAResponse = new Subject<any>();
+    const userBResponse = new Subject<any>();
+    const getItemCollections = vi
+      .fn()
+      .mockReturnValueOnce(userAResponse)
+      .mockReturnValueOnce(userBResponse);
+    let token: string | null = createJwt('user-a');
+    const component = createComponent({
+      api: { getItemCollections },
+      authService: { getToken: () => token },
+    });
+    component.enableItemCollections = true;
+
+    (component as any).syncItemCollectionSession();
+    expect(component.collectionLoadState).toBe('loading');
+
+    token = null;
+    (component as any).syncItemCollectionSession();
+    expect(component.itemCollections).toEqual([]);
+    expect(component.collectionLoadState).toBe('error');
+
+    userAResponse.next({
+      activeCollectionId: 'collection-a',
+      collections: [{ id: 'collection-a', name: 'User A', rowKeys: [] }],
+    });
+    expect(component.itemCollections).toEqual([]);
+
+    token = createJwt('user-b');
+    (component as any).syncItemCollectionSession();
+    userBResponse.next({
+      activeCollectionId: 'collection-b',
+      collections: [{ id: 'collection-b', name: 'User B', rowKeys: [] }],
+    });
+    expect(component.itemCollections).toEqual([
+      expect.objectContaining({ id: 'collection-b', name: 'User B' }),
+    ]);
+    expect(component.activeCollectionId).toBe('collection-b');
   });
 });

--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -3102,9 +3102,9 @@ describe('ItemExplorerComponent', () => {
         showOnlyItemsWithEmpiricalDifficulty: true,
       }),
     );
-    const getFileItemList = vi.fn().mockReturnValue(
-      of({ items: [], columns: [], unitMetadata: {}, codingSchemes: {} }),
-    );
+    const getFileItemList = vi
+      .fn()
+      .mockReturnValue(of({ items: [], columns: [], unitMetadata: {}, codingSchemes: {} }));
     const component = createComponent({
       api: { uploadItemParameters, getFileItemList },
     });

--- a/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.spec.ts
@@ -3093,6 +3093,37 @@ describe('ItemExplorerComponent', () => {
     expect(component.getUploadSuccessBookletSummary({ value: -0.4 })).toBe('–');
   });
 
+  it('applies the item-list visibility returned by a wide difficulty import', () => {
+    const uploadItemParameters = vi.fn().mockReturnValue(
+      of({
+        updated: 1,
+        failed: [],
+        successes: [{ fields: ['est'], value: -0.4 }],
+        showOnlyItemsWithEmpiricalDifficulty: true,
+      }),
+    );
+    const getFileItemList = vi.fn().mockReturnValue(
+      of({ items: [], columns: [], unitMetadata: {}, codingSchemes: {} }),
+    );
+    const component = createComponent({
+      api: { uploadItemParameters, getFileItemList },
+    });
+    component.acpId = 'acp-1';
+    component.explorerVersion = 7;
+    component.showOnlyItemsWithEmpiricalDifficulty = false;
+    const file = new File(['item;est\nI1;-0.4'], 'parameters.csv', { type: 'text/csv' });
+    const input = { files: [file], value: 'parameters.csv' };
+
+    component.onCsvFileSelected({ target: input } as unknown as Event);
+
+    expect(uploadItemParameters).toHaveBeenCalledWith('acp-1', file, {
+      draft: true,
+      baseVersion: 7,
+    });
+    expect(component.showOnlyItemsWithEmpiricalDifficulty).toBe(true);
+    expect(input.value).toBe('');
+  });
+
   it('keeps server collection summaries while the item list is loading', () => {
     const summary = {
       rowCount: 2,

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -4565,9 +4565,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
         (label) => label !== 'Booklet' && label !== 'Position im Booklet',
       );
       withoutSeparateBookletFields.push(
-        success.bookletOccurrences?.length
-          ? 'Booklet / Position'
-          : 'Booklet / Position gelöscht',
+        success.bookletOccurrences?.length ? 'Booklet / Position' : 'Booklet / Position gelöscht',
       );
       return [...new Set(withoutSeparateBookletFields)].join(', ') || '–';
     }
@@ -4603,8 +4601,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
           this.uploadResult = result;
           this.showUploadReport = true;
           if (typeof result.showOnlyItemsWithEmpiricalDifficulty === 'boolean') {
-            this.showOnlyItemsWithEmpiricalDifficulty =
-              result.showOnlyItemsWithEmpiricalDifficulty;
+            this.showOnlyItemsWithEmpiricalDifficulty = result.showOnlyItemsWithEmpiricalDifficulty;
           }
           if (result.explorerState) {
             this.applySharedExplorerEnvelope(result.explorerState, true);

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -18,6 +18,8 @@ import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog.c
 import { CodingSchemeTextFactory, CodingAsText } from '@iqb/responses';
 import { finalize, firstValueFrom, Subscription } from 'rxjs';
 import {
+  ItemCollection,
+  ItemCollectionSummary,
   ItemExplorerChangeLogEntry,
   ItemExplorerSharedState,
   ItemExplorerStateEnvelope,
@@ -27,6 +29,7 @@ interface MetadataColumn {
   id: string;
   label: string;
   visible?: boolean;
+  kind?: 'text' | 'number' | 'booklet' | 'position';
 }
 
 interface ExplorerItem {
@@ -43,6 +46,12 @@ interface ExplorerItem {
   sourceVariable?: string;
   metadata: Record<string, string>;
   empiricalDifficulty?: number;
+  infit?: number;
+  discrimination?: number;
+  solutionRate?: number;
+  itemTimeSeconds?: number;
+  stimulusTimeSeconds?: number;
+  bookletOccurrences?: Array<{ booklet: string; position: number }>;
   tags?: string[];
   previewTargetId?: string;
   excluded?: boolean;
@@ -74,6 +83,21 @@ interface PendingPersonalRowUpdate {
 interface SuspendedPersonalSession {
   identity: string;
   updates: Array<[string, PendingPersonalRowUpdate]>;
+}
+
+interface ItemParameterUploadSuccess {
+  unitId?: string;
+  itemId?: string;
+  subId?: string;
+  value?: number;
+  fields?: string[];
+  bookletOccurrences?: Array<{ booklet: string; position: number }>;
+}
+
+interface ItemParameterUploadResult {
+  updated: number;
+  failed: Array<{ csvRow: string; reason: string }>;
+  successes: ItemParameterUploadSuccess[];
 }
 
 type PersonalDataLoadState = 'idle' | 'loading' | 'loaded' | 'error';
@@ -109,6 +133,29 @@ type ItemExplorerPerspective = 'editor' | 'read-only';
 
 const DEFAULT_EXPLORER_SORT_FIELD = 'unitLabel';
 const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
+const IMPORTED_PARAMETER_COLUMNS: MetadataColumn[] = [
+  { id: 'infit', label: 'Infit', kind: 'number' },
+  { id: 'discrimination', label: 'Trennschärfe', kind: 'number' },
+  { id: 'solutionRate', label: 'Lösungshäufigkeit', kind: 'number' },
+  { id: 'itemTimeSeconds', label: 'Itemzeit (s)', kind: 'number' },
+  { id: 'stimulusTimeSeconds', label: 'Stimuluszeit (s)', kind: 'number' },
+  { id: 'booklet', label: 'Booklet', kind: 'booklet' },
+  { id: 'bookletPosition', label: 'Position im Booklet', kind: 'position' },
+];
+const UPLOAD_FIELD_LABELS: Record<string, string> = {
+  est: 'Empirische Itemschwierigkeit',
+  empiricalDifficulty: 'Empirische Itemschwierigkeit',
+  infit: 'Infit',
+  discrimination: 'Trennschärfe',
+  solution_rate: 'Lösungshäufigkeit',
+  solutionRate: 'Lösungshäufigkeit',
+  item_time_s: 'Itemzeit (s)',
+  itemTimeSeconds: 'Itemzeit (s)',
+  stimulus_time_s: 'Stimuluszeit (s)',
+  stimulusTimeSeconds: 'Stimuluszeit (s)',
+  booklet: 'Booklet',
+  position: 'Position im Booklet',
+};
 
 @Component({
   selector: 'app-item-explorer',
@@ -203,7 +250,7 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
               (change)="onCsvFileSelected($event)"
             />
             <button class="btn btn-outline btn-sm" (click)="csvUploadInput.click()">
-              📄 Item-Schwierigkeiten (CSV) hochladen
+              📄 Itemparameter (CSV) hochladen
             </button>
             <button
               class="btn btn-outline btn-sm"
@@ -532,6 +579,115 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
             }
           </div>
 
+          @if (enableItemCollections) {
+            <div class="collection-bar">
+              @if (collectionLoadState === 'loading') {
+                <span>Kollektionen werden geladen …</span>
+              } @else if (collectionLoadState === 'error') {
+                <span class="personal-data-error">{{ collectionError }}</span>
+                <button class="btn btn-outline btn-sm" (click)="loadItemCollections()">
+                  Erneut laden
+                </button>
+              } @else {
+                <select
+                  class="tag-input collection-select"
+                  [ngModel]="activeCollectionId"
+                  (ngModelChange)="activateCollection($event)"
+                  [disabled]="collectionBusy || itemCollections.length === 0"
+                >
+                  @if (itemCollections.length === 0) {
+                    <option [ngValue]="null">Noch keine Kollektion</option>
+                  }
+                  @for (collection of itemCollections; track collection.id) {
+                    <option [value]="collection.id">{{ collection.name }}</option>
+                  }
+                </select>
+                <button class="btn btn-outline btn-sm" (click)="createCollection()">Neu</button>
+                <button
+                  class="btn btn-outline btn-sm"
+                  [disabled]="!activeItemCollection || collectionBusy"
+                  (click)="renameActiveCollection()"
+                >
+                  Umbenennen
+                </button>
+                <button
+                  class="btn btn-outline btn-sm"
+                  [disabled]="!activeItemCollection || collectionBusy"
+                  (click)="clearActiveCollection()"
+                >
+                  Leeren
+                </button>
+                <button
+                  class="btn btn-outline btn-sm"
+                  [disabled]="!activeItemCollection || collectionBusy"
+                  (click)="showCollectionDrawer = !showCollectionDrawer"
+                >
+                  {{ showCollectionDrawer ? 'Details schließen' : 'Details' }}
+                </button>
+                @if (activeItemCollection; as collection) {
+                  <span class="collection-summary">
+                    <strong>{{ formatDuration(collection.summary.testTimeSeconds) }}</strong>
+                    · {{ collection.summary.rowCount }} Zeilen ·
+                    {{ collection.summary.itemCount }} Items ·
+                    {{ collection.summary.unitCount }} Units
+                    @if (!collection.summary.complete) {
+                      <span class="collection-warning">
+                        · unvollständig: {{ collection.summary.missingItemTimeCount }} Itemzeiten,
+                        {{ collection.summary.missingStimulusTimeUnitCount }} Stimuluszeiten fehlen
+                      </span>
+                    }
+                  </span>
+                }
+              }
+            </div>
+            @if (collectionError && collectionLoadState !== 'error') {
+              <div class="alert alert-error collection-error">{{ collectionError }}</div>
+            }
+            @if (showCollectionDrawer && activeItemCollection) {
+              <div class="collection-drawer">
+                <div class="collection-drawer-header">
+                  <strong>{{ activeItemCollection.name }}</strong>
+                  <div>
+                    <button class="btn btn-outline btn-sm" (click)="exportActiveCollection()">
+                      CSV exportieren
+                    </button>
+                    <button class="btn btn-danger btn-sm" (click)="deleteActiveCollection()">
+                      Kollektion löschen
+                    </button>
+                  </div>
+                </div>
+                @if (activeCollectionItems.length === 0) {
+                  <p class="help-text">Noch keine Items ausgewählt.</p>
+                } @else {
+                  <ol class="collection-items">
+                    @for (entry of activeCollectionItems; track entry.rowKey) {
+                      <li>
+                        @if (entry.item) {
+                          <span>
+                            {{ entry.item.unitLabel }} · {{ entry.item.itemId }}
+                            @if (entry.item.subIdDisplay || entry.item.subId) {
+                              · {{ entry.item.subIdDisplay || entry.item.subId }}
+                            }
+                          </span>
+                        } @else {
+                          <span class="collection-warning"
+                            >Nicht verfügbar: {{ entry.rowKey }}</span
+                          >
+                        }
+                        <button
+                          class="btn btn-outline btn-sm"
+                          (click)="removeRowFromActiveCollection(entry.rowKey)"
+                        >
+                          Entfernen
+                        </button>
+                      </li>
+                    }
+                  </ol>
+                }
+              </div>
+            }
+          }
+
           <div
             #tableScroll
             class="table-scroll"
@@ -543,6 +699,11 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
             <table class="table explorer-table">
               <thead>
                 <tr>
+                  @if (enableItemCollections) {
+                    <th class="collection-select-col" title="Zur aktiven Kollektion hinzufügen">
+                      ✓
+                    </th>
+                  }
                   <th (click)="sortBy('rowNumber')" class="sortable number-col">
                     Nr. {{ getSortIndicator('rowNumber') }}
                   </th>
@@ -577,6 +738,9 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                   }
                 </tr>
                 <tr class="filter-row">
+                  @if (enableItemCollections) {
+                    <th class="collection-select-col"></th>
+                  }
                   <th class="number-col"></th>
                   <th class="sticky-col">
                     <input
@@ -607,10 +771,9 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                   @if (hasEmpiricalDifficulty) {
                     <th>
                       <input
-                        type="number"
                         class="col-filter-input"
                         [(ngModel)]="columnFilters['empiricalDifficulty']"
-                        placeholder="🔍 Wert..."
+                        placeholder="Min..Max"
                         (input)="applyFilter()"
                       />
                     </th>
@@ -620,7 +783,11 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                       <input
                         class="col-filter-input"
                         [(ngModel)]="columnFilters[col.id]"
-                        [placeholder]="'🔍 ' + col.label + '...'"
+                        [placeholder]="
+                          col.kind === 'number' || col.kind === 'position'
+                            ? 'Min..Max'
+                            : '🔍 ' + col.label + '...'
+                        "
                         (input)="applyFilter()"
                       />
                     </th>
@@ -676,6 +843,17 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                     [attr.aria-selected]="selectedItem?.rowKey === item.rowKey"
                     (click)="selectItem(item, i)"
                   >
+                    @if (enableItemCollections) {
+                      <td class="collection-select-col" (click)="$event.stopPropagation()">
+                        <input
+                          type="checkbox"
+                          [checked]="isItemInActiveCollection(item)"
+                          [disabled]="collectionBusy || collectionLoadState !== 'loaded'"
+                          (change)="toggleItemInActiveCollection(item)"
+                          [attr.aria-label]="'Item ' + item.itemId + ' in Kollektion auswählen'"
+                        />
+                      </td>
+                    }
                     <td class="number-col">{{ item.rowNumber }}</td>
                     <td class="sticky-col">
                       <div class="item-id-cell">
@@ -709,12 +887,14 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                           item.empiricalDifficulty !== undefined &&
                           item.empiricalDifficulty !== null
                             ? item.empiricalDifficulty
-                            : '–'
+                            : ''
                         }}
                       </td>
                     }
                     @for (col of columns; track col.id) {
-                      <td class="meta-cell">{{ item.metadata[col.id] || '–' }}</td>
+                      <td class="meta-cell">
+                        {{ getMetadataColumnDisplayValue(item, col) }}
+                      </td>
                     }
                     @if (enableTags) {
                       <td class="tags-cell" (click)="$event.stopPropagation()">
@@ -1310,9 +1490,19 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                             Item-ID
                           </th>
                           <th
-                            style="text-align: right; padding: 4px 8px; border-bottom: 1px solid var(--color-border);"
+                            style="text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--color-border);"
                           >
-                            Wert (est)
+                            Sub-ID
+                          </th>
+                          <th
+                            style="text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--color-border);"
+                          >
+                            Aktualisierte Felder
+                          </th>
+                          <th
+                            style="text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--color-border);"
+                          >
+                            Booklet / Position
                           </th>
                         </tr>
                       </thead>
@@ -1330,9 +1520,19 @@ const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
                               <code>{{ success.itemId }}</code>
                             </td>
                             <td
-                              style="text-align: right; padding: 4px 8px; border-bottom: 1px dotted var(--color-border);"
+                              style="padding: 4px 8px; border-bottom: 1px dotted var(--color-border);"
                             >
-                              {{ success.value }}
+                              {{ success.subId || '–' }}
+                            </td>
+                            <td
+                              style="padding: 4px 8px; border-bottom: 1px dotted var(--color-border);"
+                            >
+                              {{ getUploadSuccessFieldSummary(success) }}
+                            </td>
+                            <td
+                              style="padding: 4px 8px; border-bottom: 1px dotted var(--color-border);"
+                            >
+                              {{ getUploadSuccessBookletSummary(success) }}
                             </td>
                           </tr>
                         }
@@ -2951,8 +3151,20 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   private readonly authStorageListener = (event: StorageEvent) => {
     if (!event.key || event.key === 'cp_token') {
       this.syncPersonalItemDataSession();
+      this.syncItemCollectionSession();
     }
   };
+
+  // Personal named item collections
+  enableItemCollections = false;
+  itemCollections: ItemCollection[] = [];
+  activeCollectionId: string | null = null;
+  collectionLoadState: 'idle' | 'loading' | 'loaded' | 'error' = 'idle';
+  collectionBusy = false;
+  collectionError = '';
+  showCollectionDrawer = false;
+  private collectionSessionIdentity: string | null = null;
+  private collectionSessionVersion = 0;
 
   private readonly draftPatchDebounceMs = 250;
   private draftPatchTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -2974,7 +3186,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
 
   // File Upload
   showUploadReport = false;
-  uploadResult: { updated: number; failed: any[]; successes: any[] } | null = null;
+  uploadResult: ItemParameterUploadResult | null = null;
   isUploading = false;
   showErrorDialog = false;
   errorMessage = '';
@@ -3191,6 +3403,22 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     return this.items.filter((item) => this.isItemVisibleByBaseRules(item)).length;
   }
 
+  get activeItemCollection(): ItemCollection | null {
+    return (
+      this.itemCollections.find((collection) => collection.id === this.activeCollectionId) || null
+    );
+  }
+
+  get activeCollectionItems(): Array<{
+    rowKey: string;
+    item: ExplorerItem | null;
+  }> {
+    const collection = this.activeItemCollection;
+    if (!collection) return [];
+    const itemMap = new Map(this.items.map((item) => [item.rowKey, item] as const));
+    return collection.rowKeys.map((rowKey) => ({ rowKey, item: itemMap.get(rowKey) || null }));
+  }
+
   get selectedPreviewTarget(): string {
     const storedId = this.getStoredPreviewTargetId(this.selectedItem);
     if (storedId) {
@@ -3393,6 +3621,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     window.addEventListener('storage', this.authStorageListener);
     this.authSessionSubscription = this.authService.currentUser$.subscribe(() => {
       this.syncPersonalItemDataSession();
+      this.syncItemCollectionSession();
     });
 
     // Check if user is ACP Manager
@@ -3411,6 +3640,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       this.showOnlyItemsWithEmpiricalDifficulty = fc.showOnlyItemsWithEmpiricalDifficulty === true;
       this.itemSubIdLabel = String(fc.itemSubIdLabel || 'Sub-ID').trim() || 'Sub-ID';
       this.enablePersonalItemData = fc.enablePersonalItemData === true;
+      this.enableItemCollections = fc.enableItemCollections === true;
       this.personalItemCategoryLabel =
         String(fc.personalItemCategoryLabel || 'Kompetenzstufe').trim() || 'Kompetenzstufe';
       this.personalItemCategoryValues = this.normalizeStringList(fc.personalItemCategoryValues);
@@ -3425,6 +3655,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       this.metadataSettings = this.resolveMetadataSettings(fc);
       this.loadSharedExplorerState();
       this.syncPersonalItemDataSession();
+      this.syncItemCollectionSession();
       this.startPlayerIfReady();
     });
 
@@ -3448,12 +3679,15 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
             onSettled?.();
             return;
           }
-          this.allColumns = result.columns || [];
-          this.columns = this.filterVisibleColumns(this.allColumns);
           this.items = (result.items || []).map((item: ExplorerItem) => ({
             ...item,
             rowKey: item.rowKey || item.uuid || `${item.unitId}_${item.itemId}`,
+            bookletOccurrences: Array.isArray(item.bookletOccurrences)
+              ? item.bookletOccurrences
+              : [],
           }));
+          this.allColumns = this.getAvailableMetadataColumns(result.columns || []);
+          this.columns = this.filterVisibleColumns(this.allColumns);
           this.itemSubIdLabel = String(result.subIdLabel || this.itemSubIdLabel).trim() || 'Sub-ID';
           this.hasPartialCredit = this.items.some((item) => !!item.subId);
           this.hydrateItemTagsFromItems();
@@ -3466,6 +3700,9 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
           this.unitMetadataCache = result.unitMetadata || {};
           this.codingSchemeCache = result.codingSchemes || {};
           this.applyFilter(false); // re-apply current filters and sort
+          if (this.enableItemCollections && this.collectionLoadState === 'loaded') {
+            this.recalculateCollectionSummaries();
+          }
           this.itemListLoading = false;
           onSettled?.();
         },
@@ -3500,6 +3737,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     window.removeEventListener('storage', this.authStorageListener);
     this.authSessionSubscription?.unsubscribe();
     this.authSessionSubscription = null;
+    this.collectionSessionVersion += 1;
     this.stopAutoResize();
     this.clearFocusRetryTimer();
     this.clearLegacyPageNavigationTimers();
@@ -3587,6 +3825,417 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
     return this.confirmLeaveWithUnsavedChanges();
   }
 
+  private getAvailableMetadataColumns(sourceColumns: MetadataColumn[]): MetadataColumn[] {
+    const importedIds = new Set(IMPORTED_PARAMETER_COLUMNS.map((column) => column.id));
+    const normalizedSourceColumns = sourceColumns.filter((column) => !importedIds.has(column.id));
+    return [
+      ...normalizedSourceColumns.map((column) => ({ ...column, kind: 'text' as const })),
+      ...IMPORTED_PARAMETER_COLUMNS,
+    ];
+  }
+
+  getMetadataColumnDisplayValue(item: ExplorerItem, column: MetadataColumn): string {
+    if (column.kind === 'booklet') {
+      return (item.bookletOccurrences || []).map((occurrence) => occurrence.booklet).join(' | ');
+    }
+    if (column.kind === 'position') {
+      return (item.bookletOccurrences || [])
+        .map((occurrence) => String(occurrence.position))
+        .join(' | ');
+    }
+    const value = this.getMetadataColumnRawValue(item, column);
+    return value === undefined || value === null ? '' : String(value);
+  }
+
+  private getMetadataColumnRawValue(
+    item: ExplorerItem,
+    column: MetadataColumn,
+  ): string | number | undefined {
+    switch (column.id) {
+      case 'infit':
+        return item.infit;
+      case 'discrimination':
+        return item.discrimination;
+      case 'solutionRate':
+        return item.solutionRate;
+      case 'itemTimeSeconds':
+        return item.itemTimeSeconds;
+      case 'stimulusTimeSeconds':
+        return item.stimulusTimeSeconds;
+      case 'booklet':
+        return item.bookletOccurrences?.[0]?.booklet;
+      case 'bookletPosition':
+        return item.bookletOccurrences?.length
+          ? Math.min(...item.bookletOccurrences.map((occurrence) => occurrence.position))
+          : undefined;
+      default:
+        return item.metadata[column.id];
+    }
+  }
+
+  private matchesNumericFilter(value: number, rawFilter: string): boolean {
+    const filter = rawFilter.trim().replace(/,/g, '.');
+    const range = filter.match(/^(-?\d+(?:\.\d+)?)?\.\.(-?\d+(?:\.\d+)?)?$/);
+    if (range) {
+      const minimum = range[1] === undefined ? -Infinity : Number(range[1]);
+      const maximum = range[2] === undefined ? Infinity : Number(range[2]);
+      return value >= minimum && value <= maximum;
+    }
+    const comparison = filter.match(/^(>=|<=|>|<)\s*(-?\d+(?:\.\d+)?)$/);
+    if (comparison) {
+      const expected = Number(comparison[2]);
+      if (comparison[1] === '>=') return value >= expected;
+      if (comparison[1] === '<=') return value <= expected;
+      if (comparison[1] === '>') return value > expected;
+      return value < expected;
+    }
+    const expected = Number(filter);
+    return Number.isFinite(expected) && value === expected;
+  }
+
+  private syncItemCollectionSession() {
+    const nextIdentity = this.enableItemCollections
+      ? this.pendingPersonalSessionStorage.resolveIdentityFromToken(this.authService.getToken())
+      : null;
+    if (nextIdentity === this.collectionSessionIdentity) {
+      if (nextIdentity && this.collectionLoadState === 'idle') {
+        this.loadItemCollections();
+      } else if (
+        !nextIdentity &&
+        this.enableItemCollections &&
+        this.collectionLoadState === 'idle'
+      ) {
+        this.collectionLoadState = 'error';
+        this.collectionError = 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.';
+      }
+      return;
+    }
+
+    this.collectionSessionVersion += 1;
+    this.collectionSessionIdentity = nextIdentity;
+    this.itemCollections = [];
+    this.activeCollectionId = null;
+    this.collectionBusy = false;
+    this.collectionError = '';
+    this.collectionLoadState = 'idle';
+    this.showCollectionDrawer = false;
+    if (nextIdentity) {
+      this.loadItemCollections();
+    } else if (this.enableItemCollections) {
+      this.collectionLoadState = 'error';
+      this.collectionError = 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.';
+    }
+  }
+
+  private getItemCollectionSession(): { identity: string | null; version: number } {
+    return {
+      identity: this.collectionSessionIdentity,
+      version: this.collectionSessionVersion,
+    };
+  }
+
+  private isCurrentItemCollectionSession(session: {
+    identity: string | null;
+    version: number;
+  }): boolean {
+    return (
+      session.identity !== null &&
+      session.identity === this.collectionSessionIdentity &&
+      session.version === this.collectionSessionVersion
+    );
+  }
+
+  loadItemCollections() {
+    if (!this.enableItemCollections) return;
+    const session = this.getItemCollectionSession();
+    if (!session.identity) {
+      this.collectionLoadState = 'error';
+      this.collectionError = 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.';
+      return;
+    }
+    this.collectionLoadState = 'loading';
+    this.collectionError = '';
+    this.api.getItemCollections(this.acpId, this.getPerspectiveForViewerRequests()).subscribe({
+      next: (payload) => {
+        if (!this.isCurrentItemCollectionSession(session)) return;
+        this.itemCollections = payload.collections || [];
+        this.activeCollectionId = payload.activeCollectionId || null;
+        this.collectionLoadState = 'loaded';
+        if (!this.itemListLoading && !this.itemListError) {
+          this.recalculateCollectionSummaries();
+        }
+      },
+      error: (error) => {
+        if (!this.isCurrentItemCollectionSession(session)) return;
+        this.collectionLoadState = 'error';
+        this.collectionError =
+          error?.status === 401
+            ? 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.'
+            : 'Kollektionen konnten nicht geladen werden.';
+      },
+    });
+  }
+
+  async createCollection(): Promise<ItemCollection | null> {
+    if (this.collectionBusy) return null;
+    const session = this.getItemCollectionSession();
+    if (!session.identity) {
+      this.collectionError = 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.';
+      return null;
+    }
+    this.collectionBusy = true;
+    this.collectionError = '';
+    const name =
+      this.itemCollections.length === 0
+        ? 'Meine Kollektion'
+        : `Kollektion ${this.itemCollections.length + 1}`;
+    try {
+      const payload = await firstValueFrom(
+        this.api.createItemCollection(this.acpId, name, this.getPerspectiveForViewerRequests()),
+      );
+      if (!this.isCurrentItemCollectionSession(session)) return null;
+      this.applyItemCollectionsPayload(payload);
+      return this.activeItemCollection;
+    } catch {
+      if (!this.isCurrentItemCollectionSession(session)) return null;
+      this.collectionError = 'Die Kollektion konnte nicht erstellt werden.';
+      return null;
+    } finally {
+      if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
+    }
+  }
+
+  async activateCollection(collectionId: string | null) {
+    if (this.collectionBusy) return;
+    const session = this.getItemCollectionSession();
+    if (!session.identity) return;
+    this.collectionBusy = true;
+    this.collectionError = '';
+    try {
+      const payload = await firstValueFrom(
+        this.api.activateItemCollection(
+          this.acpId,
+          collectionId || null,
+          this.getPerspectiveForViewerRequests(),
+        ),
+      );
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      this.applyItemCollectionsPayload(payload);
+    } catch {
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      this.collectionError = 'Die aktive Kollektion konnte nicht gespeichert werden.';
+    } finally {
+      if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
+    }
+  }
+
+  isItemInActiveCollection(item: ExplorerItem): boolean {
+    return this.activeItemCollection?.rowKeys.includes(item.rowKey) === true;
+  }
+
+  async toggleItemInActiveCollection(item: ExplorerItem) {
+    let collection = this.activeItemCollection;
+    if (!collection) collection = await this.createCollection();
+    if (!collection) return;
+    const nextRowKeys = collection.rowKeys.includes(item.rowKey)
+      ? collection.rowKeys.filter((rowKey) => rowKey !== item.rowKey)
+      : [...collection.rowKeys, item.rowKey];
+    await this.persistActiveCollectionRows(nextRowKeys);
+  }
+
+  async removeRowFromActiveCollection(rowKey: string) {
+    const collection = this.activeItemCollection;
+    if (!collection) return;
+    await this.persistActiveCollectionRows(
+      collection.rowKeys.filter((candidate) => candidate !== rowKey),
+    );
+  }
+
+  async clearActiveCollection() {
+    if (!this.activeItemCollection?.rowKeys.length) return;
+    await this.persistActiveCollectionRows([]);
+  }
+
+  async renameActiveCollection() {
+    const collection = this.activeItemCollection;
+    if (!collection || this.collectionBusy) return;
+    const name = window.prompt('Name der Kollektion', collection.name)?.trim();
+    if (!name || name === collection.name) return;
+    await this.persistActiveCollectionUpdate({ name });
+  }
+
+  async deleteActiveCollection() {
+    const collection = this.activeItemCollection;
+    if (!collection || this.collectionBusy) return;
+    if (!window.confirm(`Kollektion „${collection.name}“ löschen?`)) return;
+    const session = this.getItemCollectionSession();
+    if (!session.identity) return;
+    this.collectionBusy = true;
+    this.collectionError = '';
+    try {
+      const payload = await firstValueFrom(
+        this.api.deleteItemCollection(
+          this.acpId,
+          collection.id,
+          this.getPerspectiveForViewerRequests(),
+        ),
+      );
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      this.applyItemCollectionsPayload(payload);
+      if (!this.activeItemCollection) this.showCollectionDrawer = false;
+    } catch {
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      this.collectionError = 'Die Kollektion konnte nicht gelöscht werden.';
+    } finally {
+      if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
+    }
+  }
+
+  async exportActiveCollection() {
+    const collection = this.activeItemCollection;
+    if (!collection || this.collectionBusy) return;
+    const session = this.getItemCollectionSession();
+    if (!session.identity) return;
+    this.collectionBusy = true;
+    this.collectionError = '';
+    try {
+      const blob = await firstValueFrom(
+        this.api.exportItemCollectionCsv(
+          this.acpId,
+          collection.id,
+          this.getPerspectiveForViewerRequests(),
+        ),
+      );
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `item-collection-${collection.id}.csv`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      this.collectionError = 'Die Kollektion konnte nicht exportiert werden.';
+    } finally {
+      if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
+    }
+  }
+
+  formatDuration(rawSeconds: number): string {
+    const seconds = Math.max(0, Math.round(Number(rawSeconds) || 0));
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const remainingSeconds = seconds % 60;
+    return hours > 0
+      ? `${hours}:${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`
+      : `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
+  }
+
+  private async persistActiveCollectionRows(rowKeys: string[]) {
+    await this.persistActiveCollectionUpdate({ rowKeys });
+  }
+
+  private async persistActiveCollectionUpdate(update: { name?: string; rowKeys?: string[] }) {
+    const collection = this.activeItemCollection;
+    if (!collection || this.collectionBusy) return;
+    const session = this.getItemCollectionSession();
+    if (!session.identity) return;
+    const previous = structuredClone(collection);
+    if (update.name !== undefined) collection.name = update.name;
+    if (update.rowKeys !== undefined) collection.rowKeys = [...update.rowKeys];
+    this.recalculateCollectionSummaries();
+    this.collectionBusy = true;
+    this.collectionError = '';
+    try {
+      const payload = await firstValueFrom(
+        this.api.updateItemCollection(
+          this.acpId,
+          collection.id,
+          { baseVersion: previous.version, ...update },
+          this.getPerspectiveForViewerRequests(),
+        ),
+      );
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      this.applyItemCollectionsPayload(payload);
+    } catch (error: any) {
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      const index = this.itemCollections.findIndex((candidate) => candidate.id === previous.id);
+      if (index >= 0) this.itemCollections[index] = previous;
+      this.collectionError =
+        error?.status === 409
+          ? 'Die Kollektion wurde parallel geändert und wird neu geladen.'
+          : 'Die Kollektion konnte nicht gespeichert werden.';
+      if (error?.status === 409) this.loadItemCollections();
+    } finally {
+      if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
+    }
+  }
+
+  private applyItemCollectionsPayload(payload: {
+    activeCollectionId: string | null;
+    collections: ItemCollection[];
+  }) {
+    this.itemCollections = payload.collections || [];
+    this.activeCollectionId = payload.activeCollectionId || null;
+    this.collectionLoadState = 'loaded';
+    if (!this.itemListLoading && !this.itemListError) {
+      this.recalculateCollectionSummaries();
+    }
+  }
+
+  private recalculateCollectionSummaries() {
+    const itemMap = new Map(this.items.map((item) => [item.rowKey, item] as const));
+    this.itemCollections = this.itemCollections.map((collection) => {
+      const items = collection.rowKeys
+        .map((rowKey) => itemMap.get(rowKey))
+        .filter((item): item is ExplorerItem => Boolean(item));
+      return {
+        ...collection,
+        unavailableRowKeys: collection.rowKeys.filter((rowKey) => !itemMap.has(rowKey)),
+        summary: this.calculateCollectionSummary(items, collection.rowKeys.length),
+      };
+    });
+  }
+
+  private calculateCollectionSummary(
+    items: ExplorerItem[],
+    selectedRowCount = items.length,
+  ): ItemCollectionSummary {
+    const itemsByUuid = new Map<string, ExplorerItem[]>();
+    const itemsByUnit = new Map<string, ExplorerItem[]>();
+    items.forEach((item) => {
+      itemsByUuid.set(item.uuid, [...(itemsByUuid.get(item.uuid) || []), item]);
+      itemsByUnit.set(item.unitId, [...(itemsByUnit.get(item.unitId) || []), item]);
+    });
+    let itemTimeSeconds = 0;
+    let stimulusTimeSeconds = 0;
+    let missingItemTimeCount = 0;
+    let missingStimulusTimeUnitCount = 0;
+    itemsByUuid.forEach((rows) => {
+      const value = rows.map((row) => row.itemTimeSeconds).find((time) => Number.isFinite(time));
+      if (value === undefined) missingItemTimeCount += 1;
+      else itemTimeSeconds += value;
+    });
+    itemsByUnit.forEach((rows) => {
+      const value = rows
+        .map((row) => row.stimulusTimeSeconds)
+        .find((time) => Number.isFinite(time));
+      if (value === undefined) missingStimulusTimeUnitCount += 1;
+      else stimulusTimeSeconds += value;
+    });
+    return {
+      rowCount: selectedRowCount,
+      itemCount: itemsByUuid.size,
+      unitCount: itemsByUnit.size,
+      itemTimeSeconds,
+      stimulusTimeSeconds,
+      testTimeSeconds: itemTimeSeconds + stimulusTimeSeconds,
+      missingItemTimeCount,
+      missingStimulusTimeUnitCount,
+      complete: missingItemTimeCount === 0 && missingStimulusTimeUnitCount === 0,
+    };
+  }
+
   // --- Filtering ---
   applyFilter(shouldPersist = true) {
     const term = this.filterText.toLowerCase();
@@ -3638,8 +4287,24 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
           .includes(term) ||
         item.unitLabel.toLowerCase().includes(term) ||
         item.description.toLowerCase().includes(term) ||
-        Object.values(item.metadata).some((val) => val && val.toLowerCase().includes(term));
+        Object.values(item.metadata).some((val) => val && val.toLowerCase().includes(term)) ||
+        IMPORTED_PARAMETER_COLUMNS.some((column) =>
+          this.getMetadataColumnDisplayValue(item, column).toLowerCase().includes(term),
+        );
       if (!matchesGlobal) return false;
+    }
+
+    const bookletFilter = (this.columnFilters['booklet'] || '').trim().toLowerCase();
+    const positionFilter = (this.columnFilters['bookletPosition'] || '').trim();
+    if (bookletFilter || positionFilter) {
+      const matchesOccurrence = (item.bookletOccurrences || []).some((occurrence) => {
+        const matchesBooklet =
+          !bookletFilter || occurrence.booklet.toLowerCase().includes(bookletFilter);
+        const matchesPosition =
+          !positionFilter || this.matchesNumericFilter(occurrence.position, positionFilter);
+        return matchesBooklet && matchesPosition;
+      });
+      if (!matchesOccurrence) return false;
     }
 
     // 2. Column Filters
@@ -3661,11 +4326,22 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       } else if (colId === 'empiricalDifficulty') {
         if (item.empiricalDifficulty === undefined || item.empiricalDifficulty === null)
           return false;
-        if (item.empiricalDifficulty.toString() !== filterValue) return false;
+        if (!this.matchesNumericFilter(item.empiricalDifficulty, filterValue)) return false;
+      } else if (colId === 'booklet' || colId === 'bookletPosition') {
+        continue;
       } else {
-        // Metadata column
-        const val = item.metadata[colId] || '';
-        if (!val.toLowerCase().includes(subTerm)) return false;
+        const column = this.allColumns.find((candidate) => candidate.id === colId);
+        if (column?.kind === 'number') {
+          const value = this.getMetadataColumnRawValue(item, column);
+          if (typeof value !== 'number' || !this.matchesNumericFilter(value, filterValue)) {
+            return false;
+          }
+        } else {
+          const val = column
+            ? this.getMetadataColumnDisplayValue(item, column)
+            : item.metadata[colId] || '';
+          if (!val.toLowerCase().includes(subTerm)) return false;
+        }
       }
     }
 
@@ -3809,16 +4485,20 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
       let bVal: any = '';
 
       if (this.sortIsMeta) {
-        aVal = a.metadata[this.sortField] || '';
-        bVal = b.metadata[this.sortField] || '';
+        const column = this.allColumns.find((candidate) => candidate.id === this.sortField);
+        aVal = column ? this.getMetadataColumnRawValue(a, column) : a.metadata[this.sortField];
+        bVal = column ? this.getMetadataColumnRawValue(b, column) : b.metadata[this.sortField];
       } else if (this.sortField === 'empiricalDifficulty') {
-        aVal = a.empiricalDifficulty ?? -Infinity;
-        bVal = b.empiricalDifficulty ?? -Infinity;
+        aVal = a.empiricalDifficulty;
+        bVal = b.empiricalDifficulty;
       } else {
         aVal = (a as any)[this.sortField] || '';
         bVal = (b as any)[this.sortField] || '';
       }
 
+      const aMissing = aVal === undefined || aVal === null || aVal === '';
+      const bMissing = bVal === undefined || bVal === null || bVal === '';
+      if (aMissing !== bMissing) return aMissing ? 1 : -1;
       const primaryCmp = this.compareSortValues(aVal, bVal, this.sortDir);
       if (primaryCmp !== 0) {
         return primaryCmp;
@@ -3862,6 +4542,49 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
   }
 
   // --- CSV Upload Handling ---
+  getUploadSuccessFieldSummary(success: ItemParameterUploadSuccess): string {
+    const fields = Array.isArray(success.fields) ? success.fields : [];
+    const labels = fields.map((field) => UPLOAD_FIELD_LABELS[field] || field);
+    const difficultyIndex = fields.findIndex(
+      (field) => field === 'est' || field === 'empiricalDifficulty',
+    );
+
+    if (success.value !== undefined && success.value !== null) {
+      const valueLabel = `Empirische Itemschwierigkeit: ${success.value}`;
+      if (difficultyIndex >= 0) labels[difficultyIndex] = valueLabel;
+      else labels.unshift(valueLabel);
+    }
+
+    const hasBookletUpdate =
+      fields.includes('booklet') ||
+      fields.includes('position') ||
+      Array.isArray(success.bookletOccurrences);
+    if (hasBookletUpdate) {
+      const withoutSeparateBookletFields = labels.filter(
+        (label) => label !== 'Booklet' && label !== 'Position im Booklet',
+      );
+      withoutSeparateBookletFields.push(
+        success.bookletOccurrences?.length
+          ? 'Booklet / Position'
+          : 'Booklet / Position gelöscht',
+      );
+      return [...new Set(withoutSeparateBookletFields)].join(', ') || '–';
+    }
+
+    return [...new Set(labels)].join(', ') || '–';
+  }
+
+  getUploadSuccessBookletSummary(success: ItemParameterUploadSuccess): string {
+    if (!Array.isArray(success.bookletOccurrences)) {
+      return '–';
+    }
+    if (!success.bookletOccurrences.length) return 'Gelöscht';
+
+    return success.bookletOccurrences
+      .map((occurrence) => `${occurrence.booklet} / ${occurrence.position}`)
+      .join(' | ');
+  }
+
   onCsvFileSelected(event: Event) {
     const input = event.target as HTMLInputElement;
     if (!input.files || input.files.length === 0) return;
@@ -3869,7 +4592,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
 
     this.isUploading = true;
     this.api
-      .uploadEmpiricalDifficulties(this.acpId, file, {
+      .uploadItemParameters(this.acpId, file, {
         draft: true,
         baseVersion: this.explorerVersion,
       })
@@ -3878,9 +4601,6 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
           this.isUploading = false;
           this.uploadResult = result;
           this.showUploadReport = true;
-          if (typeof result.showOnlyItemsWithEmpiricalDifficulty === 'boolean') {
-            this.showOnlyItemsWithEmpiricalDifficulty = result.showOnlyItemsWithEmpiricalDifficulty;
-          }
           if (result.explorerState) {
             this.applySharedExplorerEnvelope(result.explorerState, true);
           }
@@ -3895,7 +4615,7 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
           } else {
             this.errorMessage =
               err.error?.message ||
-              'Fehler beim Hochladen der CSV-Datei. Bitte stelle sicher, dass die Spalten "item" und "est" vorhanden sind.';
+              'Fehler beim Hochladen der CSV-Datei. Bitte prüfe die Spalte "item" und die unterstützten Itemparameter.';
           }
           this.showErrorDialog = true;
         },

--- a/frontend/src/app/views/item-explorer/item-explorer.component.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.component.ts
@@ -98,6 +98,7 @@ interface ItemParameterUploadResult {
   updated: number;
   failed: Array<{ csvRow: string; reason: string }>;
   successes: ItemParameterUploadSuccess[];
+  showOnlyItemsWithEmpiricalDifficulty?: boolean;
 }
 
 type PersonalDataLoadState = 'idle' | 'loading' | 'loaded' | 'error';
@@ -4601,6 +4602,10 @@ export class ItemExplorerComponent implements OnInit, OnDestroy {
           this.isUploading = false;
           this.uploadResult = result;
           this.showUploadReport = true;
+          if (typeof result.showOnlyItemsWithEmpiricalDifficulty === 'boolean') {
+            this.showOnlyItemsWithEmpiricalDifficulty =
+              result.showOnlyItemsWithEmpiricalDifficulty;
+          }
           if (result.explorerState) {
             this.applySharedExplorerEnvelope(result.explorerState, true);
           }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -320,6 +320,72 @@ a:hover {
 /* Item Explorer tags and personal row data. Kept global so the already large Explorer
    component stylesheet stays below Angular's per-component budget. */
 app-item-explorer {
+  .collection-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-primary) 6%, var(--color-surface));
+    flex-shrink: 0;
+    font-size: 0.82rem;
+  }
+
+  .collection-select {
+    min-width: 170px;
+    max-width: 260px;
+  }
+
+  .collection-summary {
+    color: var(--color-text-secondary);
+  }
+
+  .collection-warning {
+    color: #b9770e;
+  }
+
+  .collection-error {
+    margin: 6px 12px;
+  }
+
+  .collection-drawer {
+    padding: 12px;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface);
+    max-height: 240px;
+    overflow: auto;
+    flex-shrink: 0;
+  }
+
+  .collection-drawer-header,
+  .collection-items li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .collection-drawer-header > div {
+    display: flex;
+    gap: 6px;
+  }
+
+  .collection-items {
+    margin: 10px 0 0;
+    padding-left: 24px;
+  }
+
+  .collection-items li {
+    padding: 5px 0;
+  }
+
+  .collection-select-col {
+    width: 38px;
+    min-width: 38px;
+    text-align: center;
+  }
+
   .overlay-content,
   .coding-scheme-view,
   .coding-item,


### PR DESCRIPTION
## Summary

- add the wide semicolon-separated item-parameter import with empirical metrics, item and stimulus times, and paired booklet occurrences
- keep partial-credit rows stable while applying item- and unit-scoped time semantics
- add configurable Explorer columns, numeric filters and sorting, enhanced XLSX/CSV exports, and detailed upload reports
- add isolated, versioned personal item collections with ordered row keys, time summaries, unavailable-item handling, CRUD, and CSV export
- add the independent `enableItemCollections` feature option and document the behavior

## Why

Items need additional psychometric and timing metadata without multiplying Explorer rows for booklet occurrences. Users also need private named selections with a deterministic combined test-time summary.

## Impact

Managers can import and publish the additional metadata through the existing draft workflow. Authenticated users and credentials can maintain multiple private collections; anonymous access remains non-persistent and managers cannot address another user's collection data.

Related to #46 and #47. Both issues intentionally remain open; this PR does not use automatic closing keywords.

## Validation

- backend: 560 tests passed
- frontend: 364 tests passed
- backend production build passed
- frontend production build passed
- `git diff --check` passed
