### PR TITLE
Add mean task difficulty to item lists

### DIFF
--- a/backend/src/files/unit-parser.service.spec.ts
+++ b/backend/src/files/unit-parser.service.spec.ts
@@ -548,6 +548,7 @@ describe("UnitParserService", () => {
         uuid: "uuid-1",
         rowKey: "uuid-1",
         empiricalDifficulty: 0.75,
+        meanTaskDifficulty: 0.75,
         infit: 1.04,
         discrimination: 0.41,
         solutionRate: 0.68,
@@ -597,6 +598,7 @@ describe("UnitParserService", () => {
         subId: "1",
         subIdDisplay: "teilweise richtig",
         empiricalDifficulty: 0,
+        meanTaskDifficulty: 0.375,
       }),
       expect.objectContaining({
         uuid: "u1_i1",
@@ -604,6 +606,7 @@ describe("UnitParserService", () => {
         subId: "2",
         subIdDisplay: "vollständig richtig",
         empiricalDifficulty: 0.75,
+        meanTaskDifficulty: 0.375,
       }),
     ]);
   });

--- a/backend/src/files/unit-parser.service.ts
+++ b/backend/src/files/unit-parser.service.ts
@@ -20,6 +20,7 @@ import {
 } from "../items/item-row-key.util";
 import { ItemRowNumberingService } from "./item-row-numbering.service";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
+import { calculateMeanTaskDifficultyByUnit } from "../items/mean-task-difficulty";
 
 /** Parsed reference data from a unit .xml file */
 export interface UnitXmlData {
@@ -66,6 +67,7 @@ export interface VomdItemData {
   sourceVariable?: string;
   metadata: Record<string, string>;
   empiricalDifficulty?: number;
+  meanTaskDifficulty?: number;
   infit?: number;
   discrimination?: number;
   solutionRate?: number;
@@ -925,6 +927,11 @@ export class UnitParserService {
           );
         }
       }
+    }
+
+    const meanTaskDifficultyByUnit = calculateMeanTaskDifficultyByUnit(items);
+    for (const item of items) {
+      item.meanTaskDifficulty = meanTaskDifficultyByUnit.get(item.unitId);
     }
 
     // Build columns array

--- a/backend/src/items/mean-task-difficulty.spec.ts
+++ b/backend/src/items/mean-task-difficulty.spec.ts
@@ -1,0 +1,26 @@
+import { calculateMeanTaskDifficultyByUnit } from "./mean-task-difficulty";
+
+describe("calculateMeanTaskDifficultyByUnit", () => {
+  it("assigns one mean to all finite item difficulties of a task", () => {
+    const means = calculateMeanTaskDifficultyByUnit([
+      { unitId: "unit-1", empiricalDifficulty: -0.5 },
+      { unitId: "unit-1", empiricalDifficulty: 0.5 },
+      { unitId: "unit-1" },
+      { unitId: "unit-2", empiricalDifficulty: 0.75 },
+    ]);
+
+    expect(Array.from(means.entries())).toEqual([
+      ["unit-1", 0],
+      ["unit-2", 0.75],
+    ]);
+  });
+
+  it("does not create a value for tasks without a finite difficulty", () => {
+    const means = calculateMeanTaskDifficultyByUnit([
+      { unitId: "unit-1" },
+      { unitId: "unit-1", empiricalDifficulty: Number.NaN },
+    ]);
+
+    expect(means.has("unit-1")).toBe(false);
+  });
+});

--- a/backend/src/items/mean-task-difficulty.ts
+++ b/backend/src/items/mean-task-difficulty.ts
@@ -1,0 +1,31 @@
+export interface ItemDifficultyValue {
+  unitId: string;
+  empiricalDifficulty?: number;
+}
+
+export function calculateMeanTaskDifficultyByUnit(
+  items: readonly ItemDifficultyValue[],
+): Map<string, number> {
+  const totals = new Map<string, { sum: number; count: number }>();
+
+  for (const item of items) {
+    if (
+      item.empiricalDifficulty === undefined ||
+      !Number.isFinite(item.empiricalDifficulty)
+    ) {
+      continue;
+    }
+
+    const total = totals.get(item.unitId) || { sum: 0, count: 0 };
+    total.sum += item.empiricalDifficulty;
+    total.count += 1;
+    totals.set(item.unitId, total);
+  }
+
+  return new Map(
+    Array.from(totals.entries()).map(([unitId, total]) => [
+      unitId,
+      total.sum / total.count,
+    ]),
+  );
+}

--- a/backend/src/views/views.controller.spec.ts
+++ b/backend/src/views/views.controller.spec.ts
@@ -185,6 +185,13 @@ describe("ViewsController", () => {
     await expect(
       controller.getItems("acp-1", { acpAccessLevel: "PUBLIC" }),
     ).resolves.toEqual([{ itemId: "item-1" }]);
+    expect(viewsService.getItemList).toHaveBeenCalledWith("acp-1", false);
+  });
+
+  it("uses the active Item Explorer state for manager item lists", async () => {
+    await controller.getItems("acp-1", { acpAccessLevel: "MANAGER" });
+
+    expect(viewsService.getItemList).toHaveBeenCalledWith("acp-1", true);
   });
 
   it("blocks item list when explicitly disabled", async () => {

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -281,7 +281,9 @@ export class ViewsController {
       throw new ForbiddenException("Item list is not enabled for this ACP");
     }
 
-    return this.viewsService.getItemList(acpId);
+    const canEdit =
+      req?.acpAccessLevel === "MANAGER" || req?.acpAccessLevel === "ADMIN";
+    return this.viewsService.getItemList(acpId, canEdit);
   }
 
   @Get("acp/:acpId/item-explorer/state")

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -791,6 +791,118 @@ describe("ViewsService", () => {
     await expect(service.getItemList("missing")).resolves.toEqual([]);
   });
 
+  it("projects mean task difficulty from the published Explorer item list", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      acpIndex: {
+        assessmentParts: [
+          {
+            units: [
+              {
+                id: "unit-1",
+                name: "Aufgabe 1",
+                items: [
+                  { id: "item-1", name: "Item 1" },
+                  { id: "item-2", name: "Item 2" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValueOnce({
+      items: [
+        {
+          itemId: "item-1",
+          uuid: "uuid-1",
+          rowKey: "uuid-1",
+          unitId: "unit-1",
+          unitLabel: "Aufgabe 1",
+          description: "Item 1",
+          sourceVariable: "V1",
+          empiricalDifficulty: -1,
+          meanTaskDifficulty: -0.25,
+        },
+        {
+          itemId: "item-2",
+          uuid: "uuid-2",
+          rowKey: "uuid-2",
+          unitId: "unit-1",
+          unitLabel: "Aufgabe 1",
+          description: "Item 2",
+          sourceVariable: "V2",
+          meanTaskDifficulty: -0.25,
+        },
+      ],
+    });
+
+    await expect(service.getItemList("acp-1")).resolves.toEqual([
+      expect.objectContaining({
+        itemId: "unit-1_item-1",
+        meanTaskDifficulty: -0.25,
+      }),
+      expect.objectContaining({
+        itemId: "unit-1_item-2",
+        meanTaskDifficulty: -0.25,
+      }),
+    ]);
+    expect(itemExplorerStateService.getStateForViewer).toHaveBeenCalledWith(
+      "acp-1",
+      false,
+    );
+  });
+
+  it("keeps one simple-list entry per index item for partial-credit rows", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp-1",
+      acpIndex: {
+        assessmentParts: [
+          {
+            units: [
+              {
+                id: "unit-1",
+                name: "Aufgabe 1",
+                items: [{ id: "item-1", name: "Item 1" }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValueOnce({
+      items: [
+        {
+          itemId: "item-1",
+          rowKey: "uuid-1::A",
+          subId: "A",
+          unitId: "unit-1",
+          sourceVariable: "V1",
+          meanTaskDifficulty: 0.25,
+        },
+        {
+          itemId: "item-1",
+          rowKey: "uuid-1::B",
+          subId: "B",
+          unitId: "unit-1",
+          sourceVariable: "V1",
+          meanTaskDifficulty: 0.25,
+        },
+      ],
+    });
+
+    await expect(service.getItemList("acp-1")).resolves.toEqual([
+      {
+        itemId: "unit-1_item-1",
+        unitId: "unit-1",
+        unitName: "Aufgabe 1",
+        name: "Item 1",
+        sourceVariable: undefined,
+        meanTaskDifficulty: 0.25,
+      },
+    ]);
+  });
+
   it("returns sorted sequence units and falls back to raw ids when units are missing", async () => {
     acpRepository.findOne.mockResolvedValue({
       id: "acp-1",

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -333,7 +333,8 @@ export class ViewsService {
           item.useUnitAliasAsPrefix !== false
             ? `${unit.id}_${item.id}`
             : item.id;
-        const parsedRows = parsedRowsByItem.get(`${unit.id}\u0000${item.id}`) || [];
+        const parsedRows =
+          parsedRowsByItem.get(`${unit.id}\u0000${item.id}`) || [];
         const meanTaskDifficulty = parsedRows.find(
           (row) => row.meanTaskDifficulty !== undefined,
         )?.meanTaskDifficulty;

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -41,6 +41,8 @@ import {
   MEAN_DIFFICULTY_EXPORT_COLUMN,
   projectItemExportRow,
 } from "../item-explorer/item-export-projection";
+import { calculateMeanTaskDifficultyByUnit } from "../items/mean-task-difficulty";
+
 const MAX_PERSONAL_ITEM_ROWS = 10_000;
 const MAX_EXPORT_ROW_KEY_LENGTH = 500;
 
@@ -290,12 +292,40 @@ export class ViewsService {
   /**
    * Get all items across all units in an ACP.
    */
-  async getItemList(acpId: string): Promise<any[]> {
+  async getItemList(
+    acpId: string,
+    canEditExplorerState = false,
+  ): Promise<any[]> {
     const acp = await this.acpRepository.findOne({ where: { id: acpId } });
     if (!acp) return [];
 
     const index = toRuntimeAcpIndex(acp.acpIndex);
-    const items: any[] = [];
+    const explorerState = await this.itemExplorerStateService.getStateForViewer(
+      acpId,
+      canEditExplorerState,
+    );
+    const parsedItemList = await this.unitParserService.getItemListFromFiles(
+      acpId,
+      {
+        itemPropertiesOverride: explorerState.activeState.itemProperties,
+        publishedItemPropertiesOverride:
+          explorerState.publishedState.itemProperties,
+      },
+    );
+    const parsedRowsByItem = new Map<string, VomdItemData[]>();
+    for (const row of parsedItemList.items || []) {
+      const key = `${row.unitId}\u0000${row.itemId}`;
+      parsedRowsByItem.set(key, [...(parsedRowsByItem.get(key) || []), row]);
+    }
+
+    const items: Array<{
+      itemId: string;
+      unitId: string;
+      unitName: string;
+      name?: string;
+      sourceVariable?: string;
+      meanTaskDifficulty?: number;
+    }> = [];
 
     for (const unit of getIndexUnits(index)) {
       for (const item of unit.items || []) {
@@ -303,14 +333,23 @@ export class ViewsService {
           item.useUnitAliasAsPrefix !== false
             ? `${unit.id}_${item.id}`
             : item.id;
-
-        items.push({
+        const parsedRows = parsedRowsByItem.get(`${unit.id}\u0000${item.id}`) || [];
+        const meanTaskDifficulty = parsedRows.find(
+          (row) => row.meanTaskDifficulty !== undefined,
+        )?.meanTaskDifficulty;
+        const projectedItem = {
           itemId,
           unitId: unit.id,
           unitName: unit.name,
           name: item.name,
           sourceVariable: item.sourceVariable,
-        });
+        };
+
+        items.push(
+          meanTaskDifficulty === undefined
+            ? projectedItem
+            : { ...projectedItem, meanTaskDifficulty },
+        );
       }
     }
 
@@ -491,7 +530,7 @@ export class ViewsService {
     const items = rowKeys
       .map((rowKey) => itemsByRowKey.get(rowKey))
       .filter((item): item is VomdItemData => Boolean(item));
-    const meanDifficultyByUnit = this.calculateMeanDifficultyByUnit(
+    const meanDifficultyByUnit = calculateMeanTaskDifficultyByUnit(
       itemList.items,
     );
     const personalTagColors = this.getPersonalTagColors(
@@ -542,7 +581,7 @@ export class ViewsService {
     const itemOrder = new Map(
       itemList.items.map((item, index) => [item.rowKey, index] as const),
     );
-    const meanDifficultyByUnit = this.calculateMeanDifficultyByUnit(
+    const meanDifficultyByUnit = calculateMeanTaskDifficultyByUnit(
       itemList.items,
     );
 
@@ -703,31 +742,6 @@ export class ViewsService {
       }
     }
     return rowKeys;
-  }
-
-  private calculateMeanDifficultyByUnit(
-    items: VomdItemData[],
-  ): Map<string, number> {
-    const totals = new Map<string, { sum: number; count: number }>();
-    for (const item of items) {
-      if (
-        item.empiricalDifficulty === undefined ||
-        !Number.isFinite(item.empiricalDifficulty)
-      ) {
-        continue;
-      }
-      const total = totals.get(item.unitId) || { sum: 0, count: 0 };
-      total.sum += item.empiricalDifficulty;
-      total.count += 1;
-      totals.set(item.unitId, total);
-    }
-
-    return new Map(
-      Array.from(totals.entries()).map(([unitId, total]) => [
-        unitId,
-        total.sum / total.count,
-      ]),
-    );
   }
 
   private getPersonalTagColors(rawFeatureConfig: unknown): Map<string, string> {

--- a/frontend/src/app/core/utils/numeric-filter.util.spec.ts
+++ b/frontend/src/app/core/utils/numeric-filter.util.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { matchesNumericFilter } from './numeric-filter.util';
+
+describe('matchesNumericFilter', () => {
+  it('supports decimal commas on both range boundaries', () => {
+    expect(matchesNumericFilter(0, '-0,5..0,5')).toBe(true);
+    expect(matchesNumericFilter(1, '-0,5..0,5')).toBe(false);
+  });
+
+  it('supports open and reversed ranges', () => {
+    expect(matchesNumericFilter(-1, '..0')).toBe(true);
+    expect(matchesNumericFilter(1, '0,5..')).toBe(true);
+    expect(matchesNumericFilter(0, '1..-1')).toBe(true);
+  });
+
+  it('supports comparisons and exact values', () => {
+    expect(matchesNumericFilter(1, '>= 1')).toBe(true);
+    expect(matchesNumericFilter(1, '<1')).toBe(false);
+    expect(matchesNumericFilter(-0.25, '-0,25')).toBe(true);
+  });
+});

--- a/frontend/src/app/core/utils/numeric-filter.util.ts
+++ b/frontend/src/app/core/utils/numeric-filter.util.ts
@@ -1,0 +1,23 @@
+export function matchesNumericFilter(value: number, rawFilter: string): boolean {
+  const filter = rawFilter.trim().replace(/,/g, '.');
+  const range = filter.match(
+    /^(-?\d+(?:\.\d+)?)?\s*\.\.\s*(-?\d+(?:\.\d+)?)?$/,
+  );
+  if (range) {
+    const minimum = range[1] === undefined ? -Infinity : Number(range[1]);
+    const maximum = range[2] === undefined ? Infinity : Number(range[2]);
+    return value >= Math.min(minimum, maximum) && value <= Math.max(minimum, maximum);
+  }
+
+  const comparison = filter.match(/^(>=|<=|>|<)\s*(-?\d+(?:\.\d+)?)$/);
+  if (comparison) {
+    const expected = Number(comparison[2]);
+    if (comparison[1] === '>=') return value >= expected;
+    if (comparison[1] === '<=') return value <= expected;
+    if (comparison[1] === '>') return value > expected;
+    return value < expected;
+  }
+
+  const expected = Number(filter);
+  return Number.isFinite(expected) && value === expected;
+}

--- a/frontend/src/app/core/utils/numeric-filter.util.ts
+++ b/frontend/src/app/core/utils/numeric-filter.util.ts
@@ -1,8 +1,6 @@
 export function matchesNumericFilter(value: number, rawFilter: string): boolean {
   const filter = rawFilter.trim().replace(/,/g, '.');
-  const range = filter.match(
-    /^(-?\d+(?:\.\d+)?)?\s*\.\.\s*(-?\d+(?:\.\d+)?)?$/,
-  );
+  const range = filter.match(/^(-?\d+(?:\.\d+)?)?\s*\.\.\s*(-?\d+(?:\.\d+)?)?$/);
   if (range) {
     const minimum = range[1] === undefined ? -Infinity : Number(range[1]);
     const maximum = range[2] === undefined ? Infinity : Number(range[2]);

--- a/frontend/src/app/views/item-explorer/components/table/item-explorer-table.component.html
+++ b/frontend/src/app/views/item-explorer/components/table/item-explorer-table.component.html
@@ -107,6 +107,11 @@
               Empirische Itemschwierigkeit {{ vm.getSortIndicator('empiricalDifficulty') }}
             </th>
           }
+          @if (vm.hasMeanTaskDifficulty) {
+            <th (click)="vm.sortBy('meanTaskDifficulty')" class="sortable">
+              Mittlere Aufgabenschwierigkeit {{ vm.getSortIndicator('meanTaskDifficulty') }}
+            </th>
+          }
           @for (col of vm.columns; track col.id) {
             <th (click)="vm.sortByMeta(col.id)" class="sortable">
               {{ col.label }} {{ vm.getMetaSortIndicator(col.id) }}
@@ -161,6 +166,17 @@
                 class="col-filter-input"
                 [ngModel]="vm.columnFilters['empiricalDifficulty']"
                 (ngModelChange)="vm.setColumnFilter('empiricalDifficulty', $event)"
+                placeholder="Min..Max"
+                (input)="vm.applyFilter()"
+              />
+            </th>
+          }
+          @if (vm.hasMeanTaskDifficulty) {
+            <th>
+              <input
+                class="col-filter-input"
+                [ngModel]="vm.columnFilters['meanTaskDifficulty']"
+                (ngModelChange)="vm.setColumnFilter('meanTaskDifficulty', $event)"
                 placeholder="Min..Max"
                 (input)="vm.applyFilter()"
               />
@@ -280,6 +296,9 @@
                     : ''
                 }}
               </td>
+            }
+            @if (vm.hasMeanTaskDifficulty) {
+              <td>{{ item.meanTaskDifficulty ?? '' }}</td>
             }
             @for (col of vm.columns; track col.id) {
               <td class="meta-cell">

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
@@ -3116,6 +3116,128 @@ describe('ItemExplorerFacade', () => {
     ]);
   });
 
+  it('derives one mean task difficulty per unit and filters and sorts it numerically', () => {
+    const component = createFacade();
+    const baseItem = {
+      unitLabel: 'Aufgabe',
+      description: '',
+      variableId: 'v1',
+      metadata: {},
+    };
+    component.items = [
+      {
+        ...baseItem,
+        itemId: 'unit-1-a',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1',
+        unitId: 'unit-1',
+        empiricalDifficulty: -1,
+      },
+      {
+        ...baseItem,
+        itemId: 'unit-1-b',
+        uuid: 'uuid-2',
+        rowKey: 'uuid-2',
+        unitId: 'unit-1',
+        empiricalDifficulty: 0.5,
+      },
+      {
+        ...baseItem,
+        itemId: 'unit-1-missing',
+        uuid: 'uuid-3',
+        rowKey: 'uuid-3',
+        unitId: 'unit-1',
+      },
+      {
+        ...baseItem,
+        itemId: 'unit-2',
+        uuid: 'uuid-4',
+        rowKey: 'uuid-4',
+        unitId: 'unit-2',
+        empiricalDifficulty: 1,
+      },
+      {
+        ...baseItem,
+        itemId: 'unit-3-missing',
+        uuid: 'uuid-5',
+        rowKey: 'uuid-5',
+        unitId: 'unit-3',
+      },
+    ];
+
+    (component as any).updateMeanTaskDifficulties();
+
+    expect(component.hasMeanTaskDifficulty).toBe(true);
+    expect(component.items.slice(0, 3).map((item) => item.meanTaskDifficulty)).toEqual([
+      -0.25, -0.25, -0.25,
+    ]);
+    expect(component.items[4].meanTaskDifficulty).toBeUndefined();
+
+    component.columnFilters = { meanTaskDifficulty: '-0.5..0' };
+    component.applyFilter(false);
+    expect(component.filteredItems.map((item) => item.unitId)).toEqual([
+      'unit-1',
+      'unit-1',
+      'unit-1',
+    ]);
+
+    component.columnFilters = {};
+    component.applyFilter(false);
+    component.sortBy('meanTaskDifficulty');
+    expect(component.filteredItems.map((item) => item.unitId)).toEqual([
+      'unit-1',
+      'unit-1',
+      'unit-1',
+      'unit-2',
+      'unit-3',
+    ]);
+  });
+
+  it('removes a hidden mean task difficulty filter after all difficulties are cleared', () => {
+    const component = createFacade();
+    component.canEditExplorer = true;
+    component.items = [
+      {
+        itemId: 'item-1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1',
+        unitId: 'unit-1',
+        unitLabel: 'Aufgabe 1',
+        description: '',
+        variableId: 'v1',
+        metadata: {},
+        empiricalDifficulty: 0.5,
+      },
+    ];
+    component.columnFilters = { meanTaskDifficulty: '0..1' };
+    component.sortField = 'meanTaskDifficulty';
+    component.sortIsMeta = false;
+    component.sortDir = 'desc';
+    const queueDraftPatch = vi.spyOn(component as any, 'queueDraftPatch');
+
+    (component as any).updateMeanTaskDifficulties();
+    component.applyFilter(false);
+    expect(component.filteredItems).toHaveLength(1);
+
+    delete component.items[0].empiricalDifficulty;
+    (component as any).updateMeanTaskDifficulties();
+    component.applyFilter(false);
+
+    expect(component.hasMeanTaskDifficulty).toBe(false);
+    expect(component.columnFilters['meanTaskDifficulty']).toBeUndefined();
+    expect(component.sortField).toBe('unitLabel');
+    expect(component.sortIsMeta).toBe(false);
+    expect(component.sortDir).toBe('asc');
+    expect(component.filteredItems).toHaveLength(1);
+    expect(queueDraftPatch).toHaveBeenCalledWith('UI_STATE_CHANGED', {
+      ui: expect.objectContaining({
+        sortField: 'unitLabel',
+        sortDir: 'asc',
+        columnFilters: {},
+      }),
+    });
+  });
+
   it('keeps all integrated parameter columns configurable when values are missing', () => {
     const component = createFacade();
 

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.ts
@@ -58,6 +58,7 @@ import {
   ItemExplorerShellDomPort,
   ItemExplorerTableDomPort,
 } from './item-explorer.dom-ports';
+import { matchesNumericFilter } from '../../core/utils/numeric-filter.util';
 
 const DEFAULT_EXPLORER_SORT_FIELD = 'unitLabel';
 const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
@@ -101,6 +102,7 @@ export class ItemExplorerFacade implements OnDestroy {
   items: ExplorerItem[] = [];
   filteredItems: ExplorerItem[] = [];
   hasEmpiricalDifficulty = false;
+  hasMeanTaskDifficulty = false;
   hasPartialCredit = false;
   itemSubIdLabel = 'Sub-ID';
   filterText = '';
@@ -874,6 +876,7 @@ export class ItemExplorerFacade implements OnDestroy {
             (item: any) =>
               item.empiricalDifficulty !== undefined && item.empiricalDifficulty !== null,
           );
+          this.updateMeanTaskDifficulties();
           this.filteredItems = [...this.items];
           this.unitMetadataCache = result.unitMetadata || {};
           this.codingSchemeCache = result.codingSchemes || {};
@@ -900,6 +903,7 @@ export class ItemExplorerFacade implements OnDestroy {
           this.filteredItems = [];
           this.itemTags = {};
           this.hasEmpiricalDifficulty = false;
+          this.hasMeanTaskDifficulty = false;
           this.hasPartialCredit = false;
           this.unitMetadataCache = {};
           this.codingSchemeCache = {};
@@ -1065,26 +1069,6 @@ export class ItemExplorerFacade implements OnDestroy {
       default:
         return item.metadata[column.id];
     }
-  }
-
-  private matchesNumericFilter(value: number, rawFilter: string): boolean {
-    const filter = rawFilter.trim().replace(/,/g, '.');
-    const range = filter.match(/^(-?\d+(?:\.\d+)?)?\.\.(-?\d+(?:\.\d+)?)?$/);
-    if (range) {
-      const minimum = range[1] === undefined ? -Infinity : Number(range[1]);
-      const maximum = range[2] === undefined ? Infinity : Number(range[2]);
-      return value >= minimum && value <= maximum;
-    }
-    const comparison = filter.match(/^(>=|<=|>|<)\s*(-?\d+(?:\.\d+)?)$/);
-    if (comparison) {
-      const expected = Number(comparison[2]);
-      if (comparison[1] === '>=') return value >= expected;
-      if (comparison[1] === '<=') return value <= expected;
-      if (comparison[1] === '>') return value > expected;
-      return value < expected;
-    }
-    const expected = Number(filter);
-    return Number.isFinite(expected) && value === expected;
   }
 
   private syncItemCollectionSession() {
@@ -1498,7 +1482,7 @@ export class ItemExplorerFacade implements OnDestroy {
         const matchesBooklet =
           !bookletFilter || occurrence.booklet.toLowerCase().includes(bookletFilter);
         const matchesPosition =
-          !positionFilter || this.matchesNumericFilter(occurrence.position, positionFilter);
+          !positionFilter || matchesNumericFilter(occurrence.position, positionFilter);
         return matchesBooklet && matchesPosition;
       });
       if (!matchesOccurrence) return false;
@@ -1523,14 +1507,17 @@ export class ItemExplorerFacade implements OnDestroy {
       } else if (colId === 'empiricalDifficulty') {
         if (item.empiricalDifficulty === undefined || item.empiricalDifficulty === null)
           return false;
-        if (!this.matchesNumericFilter(item.empiricalDifficulty, filterValue)) return false;
+        if (!matchesNumericFilter(item.empiricalDifficulty, filterValue)) return false;
+      } else if (colId === 'meanTaskDifficulty') {
+        if (item.meanTaskDifficulty === undefined || item.meanTaskDifficulty === null) return false;
+        if (!matchesNumericFilter(item.meanTaskDifficulty, filterValue)) return false;
       } else if (colId === 'booklet' || colId === 'bookletPosition') {
         continue;
       } else {
         const column = this.allColumns.find((candidate) => candidate.id === colId);
         if (column?.kind === 'number') {
           const value = this.getMetadataColumnRawValue(item, column);
-          if (typeof value !== 'number' || !this.matchesNumericFilter(value, filterValue)) {
+          if (typeof value !== 'number' || !matchesNumericFilter(value, filterValue)) {
             return false;
           }
         } else {
@@ -1681,9 +1668,14 @@ export class ItemExplorerFacade implements OnDestroy {
         const column = this.allColumns.find((candidate) => candidate.id === this.sortField);
         aVal = column ? this.getMetadataColumnRawValue(a, column) : a.metadata[this.sortField];
         bVal = column ? this.getMetadataColumnRawValue(b, column) : b.metadata[this.sortField];
-      } else if (this.sortField === 'empiricalDifficulty') {
-        aVal = a.empiricalDifficulty;
-        bVal = b.empiricalDifficulty;
+      } else if (
+        this.sortField === 'empiricalDifficulty' ||
+        this.sortField === 'meanTaskDifficulty'
+      ) {
+        aVal =
+          this.sortField === 'empiricalDifficulty' ? a.empiricalDifficulty : a.meanTaskDifficulty;
+        bVal =
+          this.sortField === 'empiricalDifficulty' ? b.empiricalDifficulty : b.meanTaskDifficulty;
       } else {
         aVal = (a as any)[this.sortField] || '';
         bVal = (b as any)[this.sortField] || '';
@@ -4277,7 +4269,49 @@ export class ItemExplorerFacade implements OnDestroy {
     this.hasEmpiricalDifficulty = this.items.some(
       (item: any) => item.empiricalDifficulty !== undefined && item.empiricalDifficulty !== null,
     );
+    this.updateMeanTaskDifficulties();
     this.applyFilter(false);
+  }
+
+  private updateMeanTaskDifficulties(): void {
+    const totals = new Map<string, { sum: number; count: number }>();
+
+    for (const item of this.items) {
+      if (item.empiricalDifficulty === undefined || !Number.isFinite(item.empiricalDifficulty)) {
+        continue;
+      }
+      const total = totals.get(item.unitId) || { sum: 0, count: 0 };
+      total.sum += item.empiricalDifficulty;
+      total.count += 1;
+      totals.set(item.unitId, total);
+    }
+
+    for (const item of this.items) {
+      const total = totals.get(item.unitId);
+      if (total) {
+        item.meanTaskDifficulty = total.sum / total.count;
+      } else {
+        delete item.meanTaskDifficulty;
+      }
+    }
+
+    this.hasMeanTaskDifficulty = this.items.some((item) => item.meanTaskDifficulty !== undefined);
+    if (!this.hasMeanTaskDifficulty) {
+      let uiStateChanged = false;
+      if (this.columnFilters['meanTaskDifficulty'] !== undefined) {
+        delete this.columnFilters['meanTaskDifficulty'];
+        uiStateChanged = true;
+      }
+      if (this.sortField === 'meanTaskDifficulty') {
+        this.sortField = DEFAULT_EXPLORER_SORT_FIELD;
+        this.sortIsMeta = false;
+        this.sortDir = DEFAULT_EXPLORER_SORT_DIR;
+        uiStateChanged = true;
+      }
+      if (uiStateChanged) {
+        this.saveUiPreferences();
+      }
+    }
   }
 
   private getItemStateKeys(item: ExplorerItem): string[] {

--- a/frontend/src/app/views/item-explorer/item-explorer.models.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.models.ts
@@ -30,6 +30,7 @@ export interface ExplorerItem {
   sourceVariable?: string;
   metadata: Record<string, string>;
   empiricalDifficulty?: number;
+  meanTaskDifficulty?: number;
   infit?: number;
   discrimination?: number;
   solutionRate?: number;

--- a/frontend/src/app/views/item-explorer/item-explorer.view-models.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.view-models.ts
@@ -108,6 +108,7 @@ export type ItemExplorerTableViewModel = ReadonlyViewModelSlice<
     | 'getPlayerTarget'
     | 'getSortIndicator'
     | 'hasEmpiricalDifficulty'
+    | 'hasMeanTaskDifficulty'
     | 'hasPartialCredit'
     | 'isItemExcluded'
     | 'isItemInActiveCollection'

--- a/frontend/src/app/views/item-list/item-list.component.spec.ts
+++ b/frontend/src/app/views/item-list/item-list.component.spec.ts
@@ -1,0 +1,175 @@
+import { of, Subject } from 'rxjs';
+import { afterEach, vi } from 'vitest';
+import { ItemListComponent } from './item-list.component';
+
+describe('ItemListComponent', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  const createComponent = () =>
+    new ItemListComponent(
+      { snapshot: { paramMap: { get: () => 'acp-1' } } } as any,
+      {
+        getAcpStartPage: () => of({ featureConfig: {} }),
+        getViewItems: () => of([]),
+      } as any,
+      { isLoggedIn: false, currentUser: null } as any,
+    );
+
+  it('filters and sorts mean task difficulty numerically with missing values last', () => {
+    const component = createComponent();
+    component.items = [
+      { itemId: 'a', unitId: 'A', meanTaskDifficulty: -0.25 },
+      { itemId: 'b', unitId: 'B', meanTaskDifficulty: 1 },
+      { itemId: 'c', unitId: 'C' },
+    ];
+    component.meanTaskDifficultyFilter = '-0.5..0';
+
+    component.applyFilter(false);
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['a']);
+
+    component.meanTaskDifficultyFilter = '';
+    component.applyFilter(false);
+    component.sortBy('meanTaskDifficulty');
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['a', 'b', 'c']);
+
+    component.sortBy('meanTaskDifficulty');
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('uses the same numeric filter grammar as the Item Explorer', () => {
+    const component = createComponent();
+    component.items = [
+      { itemId: 'negative', unitId: 'A', meanTaskDifficulty: -0.25 },
+      { itemId: 'positive', unitId: 'B', meanTaskDifficulty: 1 },
+    ];
+
+    component.meanTaskDifficultyFilter = '-0,5..0,5';
+    component.applyFilter(false);
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['negative']);
+
+    component.meanTaskDifficultyFilter = '>=1';
+    component.applyFilter(false);
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['positive']);
+
+    component.meanTaskDifficultyFilter = '..0';
+    component.applyFilter(false);
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['negative']);
+  });
+
+  it('removes a restored mean filter when preferences arrive after a list without values', () => {
+    vi.useFakeTimers();
+    const startPage$ = new Subject<any>();
+    const items$ = new Subject<any[]>();
+    const preferences$ = new Subject<any>();
+    const saveViewItemPreferences = vi.fn((_: string, preferences: any) => of(preferences));
+    const component = new ItemListComponent(
+      { snapshot: { paramMap: { get: () => 'acp-1' } } } as any,
+      {
+        getAcpStartPage: () => startPage$,
+        getViewItems: () => items$,
+        getViewItemPreferences: () => preferences$,
+        saveViewItemPreferences,
+      } as any,
+      { isLoggedIn: true, currentUser: { id: 'user-1' } } as any,
+    );
+
+    component.ngOnInit();
+    items$.next([{ itemId: 'a', unitId: 'A' }]);
+    startPage$.next({ featureConfig: { persistUserPreferences: true } });
+    preferences$.next({
+      ui: {
+        meanTaskDifficultyFilter: '-0.5..0',
+        sortField: 'meanTaskDifficulty',
+        sortDir: 'desc',
+      },
+    });
+
+    expect(component.meanTaskDifficultyFilter).toBe('');
+    expect(component.sortField).toBe('itemId');
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['a']);
+
+    vi.advanceTimersByTime(250);
+    expect(saveViewItemPreferences).toHaveBeenCalledWith(
+      'acp-1',
+      {
+        ui: expect.objectContaining({
+          meanTaskDifficultyFilter: '',
+          sortField: 'itemId',
+        }),
+        tags: {},
+      },
+      'item-list',
+    );
+    component.ngOnDestroy();
+  });
+
+  it('persists reconciled mean preferences in local storage', () => {
+    localStorage.setItem(
+      'cp:item-list:prefs:acp-1:anonymous',
+      JSON.stringify({
+        meanTaskDifficultyFilter: '-0.5..0',
+        sortField: 'meanTaskDifficulty',
+        sortDir: 'desc',
+      }),
+    );
+    const startPage$ = new Subject<any>();
+    const items$ = new Subject<any[]>();
+    const component = new ItemListComponent(
+      { snapshot: { paramMap: { get: () => 'acp-1' } } } as any,
+      {
+        getAcpStartPage: () => startPage$,
+        getViewItems: () => items$,
+      } as any,
+      { isLoggedIn: false, currentUser: null } as any,
+    );
+
+    component.ngOnInit();
+    items$.next([{ itemId: 'a', unitId: 'A' }]);
+    startPage$.next({ featureConfig: { persistUserPreferences: true } });
+
+    expect(
+      JSON.parse(localStorage.getItem('cp:item-list:prefs:acp-1:anonymous') || '{}'),
+    ).toEqual({
+      filterText: '',
+      meanTaskDifficultyFilter: '',
+      sortField: 'itemId',
+      sortDir: 'desc',
+    });
+  });
+
+  it('keeps a restored mean filter when preferences arrive before a list with values', () => {
+    const startPage$ = new Subject<any>();
+    const items$ = new Subject<any[]>();
+    const preferences$ = new Subject<any>();
+    const component = new ItemListComponent(
+      { snapshot: { paramMap: { get: () => 'acp-1' } } } as any,
+      {
+        getAcpStartPage: () => startPage$,
+        getViewItems: () => items$,
+        getViewItemPreferences: () => preferences$,
+      } as any,
+      { isLoggedIn: true, currentUser: { id: 'user-1' } } as any,
+    );
+
+    component.ngOnInit();
+    startPage$.next({ featureConfig: { persistUserPreferences: true } });
+    preferences$.next({
+      ui: {
+        meanTaskDifficultyFilter: '-0.5..0',
+        sortField: 'meanTaskDifficulty',
+        sortDir: 'asc',
+      },
+    });
+    items$.next([
+      { itemId: 'a', unitId: 'A', meanTaskDifficulty: -0.25 },
+      { itemId: 'b', unitId: 'B', meanTaskDifficulty: 1 },
+    ]);
+
+    expect(component.meanTaskDifficultyFilter).toBe('-0.5..0');
+    expect(component.sortField).toBe('meanTaskDifficulty');
+    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['a']);
+  });
+});

--- a/frontend/src/app/views/item-list/item-list.component.spec.ts
+++ b/frontend/src/app/views/item-list/item-list.component.spec.ts
@@ -130,9 +130,7 @@ describe('ItemListComponent', () => {
     items$.next([{ itemId: 'a', unitId: 'A' }]);
     startPage$.next({ featureConfig: { persistUserPreferences: true } });
 
-    expect(
-      JSON.parse(localStorage.getItem('cp:item-list:prefs:acp-1:anonymous') || '{}'),
-    ).toEqual({
+    expect(JSON.parse(localStorage.getItem('cp:item-list:prefs:acp-1:anonymous') || '{}')).toEqual({
       filterText: '',
       meanTaskDifficultyFilter: '',
       sortField: 'itemId',

--- a/frontend/src/app/views/item-list/item-list.component.ts
+++ b/frontend/src/app/views/item-list/item-list.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../core/services/api.service';
 import { AuthService } from '../../core/services/auth.service';
+import { matchesNumericFilter } from '../../core/utils/numeric-filter.util';
 import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/breadcrumb.component';
 
 @Component({
@@ -27,12 +28,23 @@ import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/bre
             placeholder="🔍 Items filtern..."
             (input)="applyFilter()"
           />
+          @if (hasMeanTaskDifficulty) {
+            <input
+              class="filter-input difficulty-filter"
+              [(ngModel)]="meanTaskDifficultyFilter"
+              placeholder="Mittlere Schwierigkeit: Min..Max"
+              (input)="applyFilter()"
+            />
+          }
         }
         @if (enableSort) {
           <select [(ngModel)]="sortField" (change)="applySort()" class="sort-select">
             <option value="itemId">Item-ID</option>
             <option value="unitId">Aufgabe</option>
             <option value="name">Name</option>
+            @if (hasMeanTaskDifficulty) {
+              <option value="meanTaskDifficulty">Mittlere Aufgabenschwierigkeit</option>
+            }
           </select>
           <button class="btn btn-sm btn-outline" (click)="toggleSortDir()">
             {{ sortDir === 'asc' ? '↑ A-Z' : '↓ Z-A' }}
@@ -55,6 +67,12 @@ import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/bre
               Name {{ sortField === 'name' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
             </th>
             <th>Quellvariable</th>
+            @if (hasMeanTaskDifficulty) {
+              <th (click)="sortBy('meanTaskDifficulty')" class="sortable">
+                Mittlere Aufgabenschwierigkeit
+                {{ sortField === 'meanTaskDifficulty' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
+              </th>
+            }
             @if (enableTags) {
               <th>Tags</th>
             }
@@ -62,7 +80,7 @@ import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/bre
           </tr>
         </thead>
         <tbody>
-          @for (item of filteredItems; track item.itemId) {
+          @for (item of filteredItems; track item.rowKey || item.itemId) {
             <tr [class.clickable]="enableClick" (click)="enableClick && navigateToItem(item)">
               <td>
                 <code>{{ item.itemId }}</code>
@@ -72,6 +90,9 @@ import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/bre
               <td>
                 <code>{{ item.sourceVariable || '–' }}</code>
               </td>
+              @if (hasMeanTaskDifficulty) {
+                <td>{{ item.meanTaskDifficulty ?? '' }}</td>
+              }
               @if (enableTags) {
                 <td class="tags-cell" (click)="$event.stopPropagation()">
                   @for (tag of itemTags[item.itemId] || []; track tag) {
@@ -176,6 +197,8 @@ export class ItemListComponent implements OnInit, OnDestroy {
   filterText = '';
   sortField = 'itemId';
   sortDir: 'asc' | 'desc' = 'asc';
+  meanTaskDifficultyFilter = '';
+  hasMeanTaskDifficulty = false;
   breadcrumbs: BreadcrumbItem[] = [];
 
   // Feature flags
@@ -193,6 +216,7 @@ export class ItemListComponent implements OnInit, OnDestroy {
   private pendingServerUiPreferences: Record<string, unknown> = {};
   private pendingServerTagPreferences: Record<string, string[]> = {};
   private serverSaveTimeout: ReturnType<typeof setTimeout> | null = null;
+  private itemListLoaded = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -223,6 +247,11 @@ export class ItemListComponent implements OnInit, OnDestroy {
 
     this.api.getViewItems(this.acpId).subscribe((items) => {
       this.items = items;
+      this.itemListLoaded = true;
+      this.hasMeanTaskDifficulty = items.some(
+        (item) => item.meanTaskDifficulty !== undefined && item.meanTaskDifficulty !== null,
+      );
+      this.reconcileMeanTaskDifficultyPreferences();
       this.filteredItems = [...items];
       this.applyFilter(false);
     });
@@ -237,13 +266,19 @@ export class ItemListComponent implements OnInit, OnDestroy {
 
   applyFilter(shouldPersist = true) {
     const term = this.filterText.toLowerCase();
-    this.filteredItems = this.items.filter(
-      (i) =>
+    this.filteredItems = this.items.filter((i) => {
+      const matchesText =
         i.itemId.toLowerCase().includes(term) ||
         (i.name || '').toLowerCase().includes(term) ||
         (i.unitId || '').toLowerCase().includes(term) ||
-        (i.unitName || '').toLowerCase().includes(term),
-    );
+        (i.unitName || '').toLowerCase().includes(term);
+      if (!matchesText) return false;
+      if (!this.meanTaskDifficultyFilter) return true;
+      return (
+        typeof i.meanTaskDifficulty === 'number' &&
+        matchesNumericFilter(i.meanTaskDifficulty, this.meanTaskDifficultyFilter)
+      );
+    });
     this.applySort(false);
     if (shouldPersist) {
       this.saveUiPreferences();
@@ -270,9 +305,15 @@ export class ItemListComponent implements OnInit, OnDestroy {
 
   applySort(shouldPersist = true) {
     this.filteredItems.sort((a, b) => {
-      const aVal = (a[this.sortField] || '').toLowerCase();
-      const bVal = (b[this.sortField] || '').toLowerCase();
-      const cmp = aVal.localeCompare(bVal);
+      const aVal = a[this.sortField];
+      const bVal = b[this.sortField];
+      const aMissing = aVal === undefined || aVal === null || aVal === '';
+      const bMissing = bVal === undefined || bVal === null || bVal === '';
+      if (aMissing !== bMissing) return aMissing ? 1 : -1;
+      const cmp =
+        typeof aVal === 'number' && typeof bVal === 'number'
+          ? aVal - bVal
+          : String(aVal || '').localeCompare(String(bVal || ''), undefined, { numeric: true });
       return this.sortDir === 'asc' ? cmp : -cmp;
     });
 
@@ -431,6 +472,7 @@ export class ItemListComponent implements OnInit, OnDestroy {
   private buildUiPreferences(): Record<string, unknown> {
     return {
       filterText: this.filterText,
+      meanTaskDifficultyFilter: this.meanTaskDifficultyFilter,
       sortField: this.sortField,
       sortDir: this.sortDir,
     };
@@ -442,16 +484,42 @@ export class ItemListComponent implements OnInit, OnDestroy {
     const filterText = rawUi['filterText'];
     const sortField = rawUi['sortField'];
     const sortDir = rawUi['sortDir'];
+    const meanTaskDifficultyFilter = rawUi['meanTaskDifficultyFilter'];
 
     if (typeof filterText === 'string') {
       this.filterText = filterText;
     }
 
-    if (typeof sortField === 'string' && ['itemId', 'unitId', 'name'].includes(sortField)) {
+    if (
+      typeof sortField === 'string' &&
+      ['itemId', 'unitId', 'name', 'meanTaskDifficulty'].includes(sortField)
+    ) {
       this.sortField = sortField;
     }
 
+    if (typeof meanTaskDifficultyFilter === 'string') {
+      this.meanTaskDifficultyFilter = meanTaskDifficultyFilter;
+    }
+
     this.sortDir = sortDir === 'desc' ? 'desc' : 'asc';
+    this.reconcileMeanTaskDifficultyPreferences();
+  }
+
+  private reconcileMeanTaskDifficultyPreferences(): void {
+    if (!this.itemListLoaded || this.hasMeanTaskDifficulty) return;
+
+    let preferencesChanged = false;
+    if (this.meanTaskDifficultyFilter) {
+      this.meanTaskDifficultyFilter = '';
+      preferencesChanged = true;
+    }
+    if (this.sortField === 'meanTaskDifficulty') {
+      this.sortField = 'itemId';
+      preferencesChanged = true;
+    }
+    if (preferencesChanged) {
+      this.saveUiPreferences();
+    }
   }
 
   private parseJsonObject(raw: string): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- calculate the mean empirical difficulty per task and expose it consistently in parsed item rows, the standalone item list, the Item Explorer, and exports
- show the value in both item-list UIs with numeric sorting, range/comparator filtering, consistent empty-value handling, and identical values for every item of a task
- remove stale hidden filter/sort preferences when difficulty data disappears, for both local and server-side persistence
- preserve one row per indexed item when enriching the standalone item list, including partial-credit data

## Why

Issue #45 requires mean task difficulty to be available as a first-class item-list value. The implementation centralizes the calculation and keeps the manager, public/read-only, standalone-list, Item Explorer, and export views aligned.

Closes #45

## Impact and risk

The new field is additive. The difficulty column is only visible when at least one calculable value exists. Tasks without a value remain visible and sort after numeric values. Existing stale preferences are cleaned up when the column becomes unavailable.

The main risk areas were row cardinality, numeric filtering, and preference persistence. These are covered by backend/frontend tests and manual browser acceptance.

## Validation

- backend: 50 suites, 596 tests passed
- frontend: 35 files, 434 tests passed
- frontend lint passed
- backend and frontend production builds passed
- browser acceptance passed for manager, read-only/public, standalone item list, Item Explorer, desktop and narrow widths
- browser persistence passed for local storage and server preferences across reload, difficulty deletion/reimport, logout, and login
- no application console or network errors observed during acceptance testing
