### PR TITLE
Refactor backend mean difficulty projections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [master, develop]
   pull_request:
-    branches:
-      - master
-      - refactor/backend-mean-projection
-      - refactor/item-list-state
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - refactor/backend-mean-projection
+      - refactor/item-list-state
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,64 @@ jobs:
       - run: npm ci
       - run: npm run test -- --watch=false --browsers=ChromeHeadless || npx vitest run
 
+  browser-e2e:
+    name: Browser E2E
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: contentpool_e2e
+          POSTGRES_USER: contentpool
+          POSTGRES_PASSWORD: contentpool_dev
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U contentpool -d contentpool_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      NODE_ENV: test
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: contentpool
+      DB_PASSWORD: contentpool_dev
+      DB_DATABASE: contentpool_e2e
+      DB_SYNCHRONIZE: true
+      DB_RUN_MIGRATIONS: false
+      JWT_SECRET: ci-test-secret-at-least-32-characters
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: |
+            backend/package-lock.json
+            frontend/package-lock.json
+      - run: npm ci
+        working-directory: backend
+      - run: npm ci
+        working-directory: frontend
+      - run: npx playwright install --with-deps chromium
+        working-directory: frontend
+      - run: npm run e2e
+        working-directory: frontend
+        env:
+          BROWSER_E2E_USE_EXISTING_DATABASE: true
+          BROWSER_E2E_DATABASE_PORT: 5432
+      - name: Upload Playwright diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-diagnostics
+          path: |
+            frontend/playwright-report
+            frontend/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
   backend-build:
     name: Backend Build Check
     runs-on: ubuntu-latest

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e:seed-browser": "ts-node -r tsconfig-paths/register test/browser-e2e/seed.ts",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
     "typeorm:dist": "node ./node_modules/typeorm/cli.js",
     "migration:generate": "npm run typeorm -- migration:generate -d src/database/data-source.ts",

--- a/backend/src/files/files.controller.spec.ts
+++ b/backend/src/files/files.controller.spec.ts
@@ -81,7 +81,10 @@ describe("FilesController", () => {
       validateUnitFiles: jest
         .fn()
         .mockResolvedValue([{ unitId: "u-1", valid: true }]),
-      getItemListFromFiles: jest.fn().mockResolvedValue([{ itemId: "item-1" }]),
+      getItemListFromFiles: jest.fn().mockResolvedValue({
+        columns: [],
+        items: [{ itemId: "item-1" }],
+      }),
       recalculatePublishedItemRowNumbers: jest
         .fn()
         .mockResolvedValue({ renumberedCount: 1 }),
@@ -136,6 +139,8 @@ describe("FilesController", () => {
     itemExplorerStateService = {
       getStateForViewer: jest.fn().mockResolvedValue({
         status: "CLEAN",
+        version: 4,
+        publishedVersion: 3,
         activeState: { itemProperties: {} },
         publishedState: { itemProperties: {} },
       }),
@@ -434,7 +439,11 @@ describe("FilesController", () => {
       undefined,
     );
 
-    expect(result).toEqual([{ itemId: "item-1" }]);
+    expect(result).toEqual({
+      columns: [],
+      items: [{ itemId: "item-1" }],
+      itemExplorerStateVersion: 4,
+    });
     expect(filesService.getFeatureConfig).not.toHaveBeenCalled();
     expect(unitParserService.getItemListFromFiles).toHaveBeenCalledWith(
       "acp-1",
@@ -448,6 +457,8 @@ describe("FilesController", () => {
   it("passes the active manager draft to the centrally initialized item list", async () => {
     itemExplorerStateService.getStateForViewer.mockResolvedValueOnce({
       status: "DIRTY",
+      version: 8,
+      publishedVersion: 5,
       canEdit: true,
       activeState: { itemProperties: { draft: {} } },
       publishedState: { itemProperties: { published: {} } },
@@ -465,6 +476,32 @@ describe("FilesController", () => {
         itemPropertiesOverride: { draft: {} },
         publishedItemPropertiesOverride: { published: {} },
       },
+    );
+  });
+
+  it("returns the published state version for a read-only item list", async () => {
+    filesService.getFeatureConfig.mockResolvedValueOnce({
+      enableItemList: true,
+    });
+    itemExplorerStateService.getStateForViewer.mockResolvedValueOnce({
+      status: "DIRTY",
+      version: 8,
+      publishedVersion: 5,
+      canEdit: false,
+      activeState: { itemProperties: { published: {} } },
+      publishedState: { itemProperties: { published: {} } },
+    });
+
+    const result = await controller.getItemList(
+      "acp-1",
+      { acpAccessLevel: "MANAGER" },
+      "read-only",
+    );
+
+    expect(result.itemExplorerStateVersion).toBe(5);
+    expect(itemExplorerStateService.getStateForViewer).toHaveBeenCalledWith(
+      "acp-1",
+      false,
     );
   });
 

--- a/backend/src/files/files.controller.ts
+++ b/backend/src/files/files.controller.ts
@@ -152,11 +152,17 @@ export class FilesController {
       acpId,
       isManager,
     );
-    return this.unitParserService.getItemListFromFiles(acpId, {
+    const itemList = await this.unitParserService.getItemListFromFiles(acpId, {
       itemPropertiesOverride: explorerState.activeState.itemProperties,
       publishedItemPropertiesOverride:
         explorerState.publishedState.itemProperties,
     });
+    return {
+      ...itemList,
+      itemExplorerStateVersion: isManager
+        ? explorerState.version
+        : explorerState.publishedVersion,
+    };
   }
 
   @Post("item-list/renumber")

--- a/backend/src/item-explorer/item-export-projection.spec.ts
+++ b/backend/src/item-explorer/item-export-projection.spec.ts
@@ -46,6 +46,7 @@ describe("item export projection", () => {
         unitId: "unit-1",
         unitLabel: "Aufgabe 1",
         empiricalDifficulty: -0.25,
+        meanTaskDifficulty: 0.5,
         infit: 1.05,
         discrimination: 0.4,
         solutionRate: 0.75,
@@ -61,7 +62,6 @@ describe("item export projection", () => {
         tags: ["Prüfen"],
         note: "Notiz",
       },
-      meanDifficultyByUnit: new Map([["unit-1", 0.5]]),
     });
 
     expect(projection).toEqual(

--- a/backend/src/item-explorer/item-export-projection.ts
+++ b/backend/src/item-explorer/item-export-projection.ts
@@ -104,7 +104,6 @@ export function projectItemExportRow(input: {
   rowKey: string;
   item?: VomdItemData;
   personalRow?: Record<string, unknown>;
-  meanDifficultyByUnit?: ReadonlyMap<string, number>;
 }): ItemExportProjection {
   const { item } = input;
   const personalRow = input.personalRow || {};
@@ -134,9 +133,7 @@ export function projectItemExportRow(input: {
     bookletPositions: occurrences.length
       ? occurrences.map((occurrence) => String(occurrence.position)).join(" | ")
       : null,
-    meanTaskDifficulty: item
-      ? (input.meanDifficultyByUnit?.get(item.unitId) ?? null)
-      : null,
+    meanTaskDifficulty: item?.meanTaskDifficulty ?? null,
   };
 }
 

--- a/backend/src/views/dto/simple-item-list-entry.dto.ts
+++ b/backend/src/views/dto/simple-item-list-entry.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+export class SimpleItemListEntryDto {
+  @ApiProperty()
+  itemId!: string;
+
+  @ApiProperty()
+  unitId!: string;
+
+  @ApiProperty()
+  unitName!: string;
+
+  @ApiPropertyOptional()
+  name?: string;
+
+  @ApiPropertyOptional()
+  sourceVariable?: string;
+
+  @ApiPropertyOptional({ type: Number })
+  meanTaskDifficulty?: number;
+}

--- a/backend/src/views/simple-item-list-projection.spec.ts
+++ b/backend/src/views/simple-item-list-projection.spec.ts
@@ -1,0 +1,41 @@
+import {
+  projectSimpleItemListEntry,
+  simpleItemListKey,
+} from "./simple-item-list-projection";
+
+describe("simple item list projection", () => {
+  it("projects an index item with its backend-provided mean", () => {
+    expect(
+      projectSimpleItemListEntry(
+        { id: "unit-1", name: "Aufgabe 1" },
+        { id: "item-1", name: "Item 1", sourceVariable: "V1" },
+        -0.25,
+      ),
+    ).toEqual({
+      itemId: "unit-1_item-1",
+      unitId: "unit-1",
+      unitName: "Aufgabe 1",
+      name: "Item 1",
+      sourceVariable: "V1",
+      meanTaskDifficulty: -0.25,
+    });
+  });
+
+  it("keeps unprefixed ids and omits a missing mean", () => {
+    expect(
+      projectSimpleItemListEntry(
+        { id: "unit-1" },
+        { id: "item-1", useUnitAliasAsPrefix: false },
+      ),
+    ).toEqual({
+      itemId: "item-1",
+      unitId: "unit-1",
+      unitName: "unit-1",
+      name: undefined,
+      sourceVariable: undefined,
+    });
+    expect(simpleItemListKey("unit-1", "item-1")).not.toBe(
+      simpleItemListKey("unit-1-item", "1"),
+    );
+  });
+});

--- a/backend/src/views/simple-item-list-projection.ts
+++ b/backend/src/views/simple-item-list-projection.ts
@@ -1,0 +1,36 @@
+import { SimpleItemListEntryDto } from "./dto/simple-item-list-entry.dto";
+
+export interface SimpleItemListIndexUnit {
+  id: string;
+  name?: string;
+}
+
+export interface SimpleItemListIndexItem {
+  id: string;
+  name?: string;
+  sourceVariable?: string;
+  useUnitAliasAsPrefix?: boolean;
+}
+
+export function projectSimpleItemListEntry(
+  unit: SimpleItemListIndexUnit,
+  item: SimpleItemListIndexItem,
+  meanTaskDifficulty?: number,
+): SimpleItemListEntryDto {
+  const projected: SimpleItemListEntryDto = {
+    itemId:
+      item.useUnitAliasAsPrefix !== false ? `${unit.id}_${item.id}` : item.id,
+    unitId: unit.id,
+    unitName: unit.name || unit.id,
+    name: item.name,
+    sourceVariable: item.sourceVariable,
+  };
+
+  return meanTaskDifficulty === undefined
+    ? projected
+    : { ...projected, meanTaskDifficulty };
+}
+
+export function simpleItemListKey(unitId: string, itemId: string): string {
+  return `${unitId}\u0000${itemId}`;
+}

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -17,6 +17,7 @@ import {
 import {
   ApiBody,
   ApiOperation,
+  ApiOkResponse,
   ApiProperty,
   ApiPropertyOptional,
   ApiTags,
@@ -40,6 +41,7 @@ import {
   requireStablePreferenceIdentity,
   resolveStablePreferenceIdentity,
 } from "../item-preferences/preference-identity";
+import { SimpleItemListEntryDto } from "./dto/simple-item-list-entry.dto";
 
 class SaveItemPreferencesDto {
   @ApiPropertyOptional({
@@ -276,6 +278,7 @@ export class ViewsController {
   @Get("acp/:acpId/items")
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get item list for an ACP" })
+  @ApiOkResponse({ type: SimpleItemListEntryDto, isArray: true })
   async getItems(@Param("acpId") acpId: string, @Request() req: any) {
     if (!(await this.canUseFeature(acpId, req, "enableItemList", true))) {
       throw new ForbiddenException("Item list is not enabled for this ACP");

--- a/backend/src/views/views.service.spec.ts
+++ b/backend/src/views/views.service.spec.ts
@@ -308,6 +308,7 @@ describe("ViewsService", () => {
           variableId: "var-1",
           metadata: {},
           empiricalDifficulty: 0.25,
+          meanTaskDifficulty: 0.6,
         },
         {
           itemId: "item-2",
@@ -320,6 +321,7 @@ describe("ViewsService", () => {
           variableId: "var-2",
           metadata: {},
           empiricalDifficulty: 0.75,
+          meanTaskDifficulty: 0.6,
         },
       ],
     });
@@ -384,7 +386,7 @@ describe("ViewsService", () => {
     expect(sheet!.getCell("F2").value).toBe("1");
     expect(sheet!.getCell("G2").value).toBe("uuid-2::1");
     expect(sheet!.getCell("H2").value).toBeNull();
-    expect(sheet!.getCell("S2").value).toBe(0.5);
+    expect(sheet!.getCell("S2").value).toBe(0.6);
     expect(sheet!.getCell("A3").value).toBe(2);
     expect(sheet!.getCell("E3").value).toBe("uuid-1");
     expect(sheet!.getCell("F3").value).toBe("1");
@@ -445,6 +447,7 @@ describe("ViewsService", () => {
           variableId: "var-1",
           metadata: {},
           empiricalDifficulty: -0.25,
+          meanTaskDifficulty: -0.125,
         },
         {
           itemId: "item-2",
@@ -456,6 +459,7 @@ describe("ViewsService", () => {
           variableId: "var-2",
           metadata: {},
           empiricalDifficulty: 0.75,
+          meanTaskDifficulty: -0.125,
         },
       ],
     });
@@ -477,10 +481,10 @@ describe("ViewsService", () => {
       '"Teilnehmerkennung";"Unit-ID";"Unit-Label";"Item-ID";"Sub-ID";"Zeilenschlüssel"',
     );
     expect(csv).toContain(
-      '"teilnehmer-a";"unit-1";"Aufgabe 1";"item-1";"A";"uuid-1::A";"\'=II";"Prüfen, Sicher";"Erste Zeile\\nZweite Zeile";"-0.25";"";"";"";"";"";"";"";"0.25"',
+      '"teilnehmer-a";"unit-1";"Aufgabe 1";"item-1";"A";"uuid-1::A";"\'=II";"Prüfen, Sicher";"Erste Zeile\\nZweite Zeile";"-0.25";"";"";"";"";"";"";"";"-0.125"',
     );
     expect(csv).toContain(
-      '"teilnehmer-b";"unit-1";"Aufgabe 1";"item-2";"";"uuid-2";"III";"";"Fertig";"0.75";"";"";"";"";"";"";"";"0.25"',
+      '"teilnehmer-b";"unit-1";"Aufgabe 1";"item-2";"";"uuid-2";"III";"";"Fertig";"0.75";"";"";"";"";"";"";"";"-0.125"',
     );
     expect(csv).not.toContain("ohne-eintrag");
   });
@@ -814,7 +818,7 @@ describe("ViewsService", () => {
     unitParserService.getItemListFromFiles.mockResolvedValueOnce({
       items: [
         {
-          itemId: "item-1",
+          itemId: "unit-1_item-1",
           uuid: "uuid-1",
           rowKey: "uuid-1",
           unitId: "unit-1",

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -41,7 +41,11 @@ import {
   MEAN_DIFFICULTY_EXPORT_COLUMN,
   projectItemExportRow,
 } from "../item-explorer/item-export-projection";
-import { calculateMeanTaskDifficultyByUnit } from "../items/mean-task-difficulty";
+import { SimpleItemListEntryDto } from "./dto/simple-item-list-entry.dto";
+import {
+  projectSimpleItemListEntry,
+  simpleItemListKey,
+} from "./simple-item-list-projection";
 
 const MAX_PERSONAL_ITEM_ROWS = 10_000;
 const MAX_EXPORT_ROW_KEY_LENGTH = 500;
@@ -295,7 +299,7 @@ export class ViewsService {
   async getItemList(
     acpId: string,
     canEditExplorerState = false,
-  ): Promise<any[]> {
+  ): Promise<SimpleItemListEntryDto[]> {
     const acp = await this.acpRepository.findOne({ where: { id: acpId } });
     if (!acp) return [];
 
@@ -312,45 +316,32 @@ export class ViewsService {
           explorerState.publishedState.itemProperties,
       },
     );
-    const parsedRowsByItem = new Map<string, VomdItemData[]>();
+    const meanDifficultyByItem = new Map<string, number>();
     for (const row of parsedItemList.items || []) {
-      const key = `${row.unitId}\u0000${row.itemId}`;
-      parsedRowsByItem.set(key, [...(parsedRowsByItem.get(key) || []), row]);
+      if (
+        row.meanTaskDifficulty === undefined ||
+        meanDifficultyByItem.has(simpleItemListKey(row.unitId, row.itemId))
+      ) {
+        continue;
+      }
+      meanDifficultyByItem.set(
+        simpleItemListKey(row.unitId, row.itemId),
+        row.meanTaskDifficulty,
+      );
     }
 
-    const items: Array<{
-      itemId: string;
-      unitId: string;
-      unitName: string;
-      name?: string;
-      sourceVariable?: string;
-      meanTaskDifficulty?: number;
-    }> = [];
+    const items: SimpleItemListEntryDto[] = [];
 
     for (const unit of getIndexUnits(index)) {
       for (const item of unit.items || []) {
-        const itemId =
+        const projectedItemId =
           item.useUnitAliasAsPrefix !== false
             ? `${unit.id}_${item.id}`
             : item.id;
-        const parsedRows =
-          parsedRowsByItem.get(`${unit.id}\u0000${item.id}`) || [];
-        const meanTaskDifficulty = parsedRows.find(
-          (row) => row.meanTaskDifficulty !== undefined,
-        )?.meanTaskDifficulty;
-        const projectedItem = {
-          itemId,
-          unitId: unit.id,
-          unitName: unit.name,
-          name: item.name,
-          sourceVariable: item.sourceVariable,
-        };
-
-        items.push(
-          meanTaskDifficulty === undefined
-            ? projectedItem
-            : { ...projectedItem, meanTaskDifficulty },
-        );
+        const meanTaskDifficulty =
+          meanDifficultyByItem.get(simpleItemListKey(unit.id, item.id)) ??
+          meanDifficultyByItem.get(simpleItemListKey(unit.id, projectedItemId));
+        items.push(projectSimpleItemListEntry(unit, item, meanTaskDifficulty));
       }
     }
 
@@ -531,9 +522,6 @@ export class ViewsService {
     const items = rowKeys
       .map((rowKey) => itemsByRowKey.get(rowKey))
       .filter((item): item is VomdItemData => Boolean(item));
-    const meanDifficultyByUnit = calculateMeanTaskDifficultyByUnit(
-      itemList.items,
-    );
     const personalTagColors = this.getPersonalTagColors(
       accessConfig?.featureConfig,
     );
@@ -543,7 +531,6 @@ export class ViewsService {
         rowKey: item.rowKey,
         item,
         personalRow: preferences.rowData[item.rowKey],
-        meanDifficultyByUnit,
       });
 
       return {
@@ -582,10 +569,6 @@ export class ViewsService {
     const itemOrder = new Map(
       itemList.items.map((item, index) => [item.rowKey, index] as const),
     );
-    const meanDifficultyByUnit = calculateMeanTaskDifficultyByUnit(
-      itemList.items,
-    );
-
     const rows = preferenceRecords.flatMap((record) => {
       const participant = this.getPreferenceParticipantIdentifier(record);
       if (!participant) return [];
@@ -598,7 +581,6 @@ export class ViewsService {
             rowKey,
             item,
             personalRow,
-            meanDifficultyByUnit,
           });
 
           return {

--- a/backend/test/browser-e2e/seed.ts
+++ b/backend/test/browser-e2e/seed.ts
@@ -1,0 +1,201 @@
+import { NestFactory } from "@nestjs/core";
+import { mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { DataSource } from "typeorm";
+import * as bcrypt from "bcryptjs";
+import { AppModule } from "../../src/app.module";
+import {
+  AccessModel,
+  Acp,
+  AcpAccessConfig,
+  AcpCredential,
+  AcpFile,
+  AcpItemExplorerState,
+  AcpRole,
+  AcpUserRole,
+  User,
+} from "../../src/database/entities";
+
+const ACP_ID = "10000000-0000-4000-8000-000000000001";
+const MANAGER_ID = "10000000-0000-4000-8000-000000000002";
+const MANAGER_USERNAME = "e2e-manager";
+const MANAGER_PASSWORD = "Manager-E2E-123!";
+const CREDENTIAL_USERNAME = "e2e-reviewer";
+const CREDENTIAL_PASSWORD = "Reviewer-E2E-123!";
+
+async function seed(): Promise<void> {
+  const database = process.env.DB_DATABASE || "";
+  if (
+    process.env.NODE_ENV !== "test" ||
+    !database.toLowerCase().includes("e2e")
+  ) {
+    throw new Error(
+      "Browser E2E fixtures require NODE_ENV=test and a DB_DATABASE containing 'e2e'.",
+    );
+  }
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: false,
+  });
+  try {
+    const dataSource = app.get(DataSource);
+    await dataSource.synchronize(true);
+
+    const itemProperties = {
+      "item-uuid-1": { empiricalDifficulty: -0.5 },
+      "item-uuid-2": { empiricalDifficulty: 0.5 },
+    };
+    const acp = await dataSource.getRepository(Acp).save(
+      dataSource.getRepository(Acp).create({
+        id: ACP_ID,
+        packageId: "browser-e2e-package",
+        name: "Browser E2E ACP",
+        description: "Isolated Playwright fixture",
+        acpIndex: {
+          version: "0.5.0",
+          packageId: "browser-e2e-package",
+          assessmentParts: [
+            {
+              id: "part-1",
+              name: "Teil 1",
+              units: [
+                {
+                  id: "u1",
+                  name: "Aufgabe 1",
+                  items: [
+                    { id: "i1", name: "Item 1", sourceVariable: "V1" },
+                    { id: "i2", name: "Item 2", sourceVariable: "V2" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        itemProperties,
+        settings: {},
+      }),
+    );
+
+    const manager = await dataSource.getRepository(User).save(
+      dataSource.getRepository(User).create({
+        id: MANAGER_ID,
+        username: MANAGER_USERNAME,
+        passwordHash: await bcrypt.hash(MANAGER_PASSWORD, 4),
+        displayName: "E2E Manager",
+        isAppAdmin: false,
+      }),
+    );
+    await dataSource.getRepository(AcpUserRole).save(
+      dataSource.getRepository(AcpUserRole).create({
+        userId: manager.id,
+        acpId: acp.id,
+        role: AcpRole.ACP_MANAGER,
+      }),
+    );
+
+    const accessConfig = await dataSource.getRepository(AcpAccessConfig).save(
+      dataSource.getRepository(AcpAccessConfig).create({
+        acpId: acp.id,
+        accessModel: AccessModel.CREDENTIALS_LIST,
+        allowRegistered: false,
+        featureConfig: {
+          enableItemList: true,
+          enableItemListFilter: true,
+          enableItemListSort: true,
+          enableItemClick: true,
+          persistUserPreferences: true,
+        },
+      }),
+    );
+    await dataSource.getRepository(AcpCredential).save(
+      dataSource.getRepository(AcpCredential).create({
+        accessConfigId: accessConfig.id,
+        username: CREDENTIAL_USERNAME,
+        passwordHash: await bcrypt.hash(CREDENTIAL_PASSWORD, 4),
+      }),
+    );
+
+    const sharedState = {
+      ui: {},
+      tags: {},
+      metadataColumns: { visible: [], order: [] },
+      itemOrder: [],
+      itemProperties,
+    };
+    await dataSource.getRepository(AcpItemExplorerState).save(
+      dataSource.getRepository(AcpItemExplorerState).create({
+        acpId: acp.id,
+        publishedState: sharedState,
+        draftState: sharedState,
+        status: "CLEAN",
+        version: 1,
+        publishedVersion: 1,
+      }),
+    );
+
+    const fixtureDirectory =
+      process.env.BROWSER_E2E_FIXTURE_DIR || "/tmp/content-pool-browser-e2e";
+    await mkdir(fixtureDirectory, { recursive: true });
+    const unitXml = `<?xml version="1.0" encoding="UTF-8"?>
+<Unit>
+  <Id>u1</Id>
+  <Label>Aufgabe 1</Label>
+  <Description>Browser E2E Unit</Description>
+  <DefinitionRef player="iqb-player-aspect@2.11">u1.voud</DefinitionRef>
+  <Reference>u1.vomd</Reference>
+</Unit>`;
+    const itemMetadata = JSON.stringify({
+      profiles: [],
+      items: [
+        {
+          id: "i1",
+          uuid: "item-uuid-1",
+          description: "Item 1",
+          variableId: "V1",
+          useUnitAliasAsPrefix: true,
+          profiles: [],
+        },
+        {
+          id: "i2",
+          uuid: "item-uuid-2",
+          description: "Item 2",
+          variableId: "V2",
+          useUnitAliasAsPrefix: true,
+          profiles: [],
+        },
+      ],
+    });
+    const files = [
+      { name: "u1.xml", content: unitXml, type: "UNIT_XML" },
+      { name: "u1.vomd", content: itemMetadata, type: "ITEM_METADATA" },
+    ];
+    for (const file of files) {
+      const filePath = join(fixtureDirectory, file.name);
+      await writeFile(filePath, file.content, "utf8");
+      await dataSource.getRepository(AcpFile).save(
+        dataSource.getRepository(AcpFile).create({
+          acpId: acp.id,
+          filePath,
+          originalName: file.name,
+          fileType: file.type,
+          fileSize: Buffer.byteLength(file.content),
+        }),
+      );
+    }
+
+    process.stdout.write(
+      JSON.stringify({
+        acpId: ACP_ID,
+        managerUsername: MANAGER_USERNAME,
+        credentialUsername: CREDENTIAL_USERNAME,
+      }) + "\n",
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+void seed().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -37,6 +37,21 @@ npm run lint
 
 The frontend uses Vitest for tests and Angular ESLint tooling for lint checks.
 
+### Full-stack browser tests
+
+The Playwright suite runs Chromium against the real Angular frontend, NestJS backend, and an
+isolated PostgreSQL database. From the repository root, run:
+
+```bash
+(cd frontend && npm run e2e)
+```
+
+The wrapper starts a disposable PostgreSQL container, seeds it, and uses dedicated ports for both
+application servers. The seed and Playwright configuration refuse non-E2E database settings, and
+existing application servers are never reused. Trace, screenshot, and video diagnostics are kept
+only for failed tests. CI supplies its own isolated PostgreSQL service and performs browser
+installation automatically.
+
 ## What to Test for Common Change Types
 
 ### Authentication or access changes

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,6 +34,8 @@ yarn-error.log
 .sass-cache/
 /connect.lock
 /coverage
+/playwright-report
+/test-results
 /libpeerconnection.log
 testem.log
 /typings

--- a/frontend/e2e/item-list-preferences.spec.ts
+++ b/frontend/e2e/item-list-preferences.spec.ts
@@ -1,0 +1,163 @@
+import { expect, Page, test } from '@playwright/test';
+
+const ACP_ID = '10000000-0000-4000-8000-000000000001';
+const MANAGER_USERNAME = 'e2e-manager';
+const MANAGER_PASSWORD = 'Manager-E2E-123!';
+const CREDENTIAL_USERNAME = 'e2e-reviewer';
+const CREDENTIAL_PASSWORD = 'Reviewer-E2E-123!';
+
+async function publishExplorerDraft(page: Page): Promise<void> {
+  const saveButton = page.getByRole('button', { name: /Speichern/ });
+  await expect(saveButton).toBeEnabled();
+  await saveButton.click();
+  await expect(
+    page.getByRole('heading', { name: 'Änderungsübersicht vor Speichern' }),
+  ).toBeVisible();
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/item-explorer/draft/save') &&
+        response.ok(),
+    ),
+    page.getByRole('button', { name: 'Veröffentlichen' }).click(),
+  ]);
+}
+
+async function loginWithCredential(page: Page): Promise<void> {
+  await page.goto(`/credential-login/${ACP_ID}`);
+  await page.getByLabel('Benutzername').fill(CREDENTIAL_USERNAME);
+  await page.getByLabel('Kennwort').fill(CREDENTIAL_PASSWORD);
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().endsWith('/api/auth/credential-login') &&
+        response.ok(),
+    ),
+    page.getByRole('button', { name: 'Zugang öffnen' }).click(),
+  ]);
+  await expect(page).toHaveURL(new RegExp(`/view/${ACP_ID}`));
+}
+
+test('reconciles mean filters across clear, reimport, reload and credential relogin', async ({
+  browser,
+  page,
+  request,
+}) => {
+  await loginWithCredential(page);
+  await page.goto(`/view/${ACP_ID}/items`);
+
+  const meanFilter = page.getByPlaceholder('Mittlere Schwierigkeit: Min..Max');
+  await expect(meanFilter).toBeVisible();
+  await expect(
+    page.getByRole('columnheader', { name: /Mittlere Aufgabenschwierigkeit/ }),
+  ).toBeVisible();
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        response.url().includes('/items/preferences') &&
+        response.ok(),
+    ),
+    meanFilter.fill('-0.1..0.1'),
+  ]);
+  await expect(page.locator('tbody tr')).toHaveCount(2);
+  await page.reload();
+  await expect(meanFilter).toHaveValue('-0.1..0.1');
+
+  const managerLogin = await request.post('/api/auth/login', {
+    data: { username: MANAGER_USERNAME, password: MANAGER_PASSWORD },
+  });
+  expect(managerLogin.ok()).toBeTruthy();
+  const managerToken = (await managerLogin.json()).accessToken as string;
+  const managerContext = await browser.newContext();
+  await managerContext.addInitScript((token) => {
+    localStorage.setItem('cp_token', token);
+    localStorage.setItem('cp_auth_type', 'local');
+  }, managerToken);
+  const managerPage = await managerContext.newPage();
+
+  await managerPage.goto(`/view/${ACP_ID}/item-explorer`);
+  await expect(managerPage.getByRole('heading', { name: 'Item-Explorer' })).toBeVisible();
+  await managerPage.getByRole('button', { name: /Werte bereinigen/ }).click();
+  await Promise.all([
+    managerPage.waitForResponse(
+      (response) =>
+        response.request().method() === 'DELETE' &&
+        response.url().includes('/empirical-difficulty') &&
+        response.ok(),
+    ),
+    managerPage.getByRole('button', { name: 'Alle Werte entfernen' }).click(),
+  ]);
+  await publishExplorerDraft(managerPage);
+
+  const preferenceCleanup = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PUT' &&
+      response.url().includes('/items/preferences') &&
+      response.ok(),
+  );
+  await page.reload();
+  await preferenceCleanup;
+  await expect(page.getByPlaceholder('Mittlere Schwierigkeit: Min..Max')).toBeHidden();
+  await expect(
+    page.getByRole('columnheader', { name: /Mittlere Aufgabenschwierigkeit/ }),
+  ).toBeHidden();
+
+  const credentialToken = await page.evaluate(() => localStorage.getItem('cp_token'));
+  expect(credentialToken).toBeTruthy();
+  const cleanedPreferences = await request.get(
+    `/api/view/acp/${ACP_ID}/items/preferences?viewId=item-list`,
+    { headers: { Authorization: `Bearer ${credentialToken}` } },
+  );
+  expect(cleanedPreferences.ok()).toBeTruthy();
+  expect((await cleanedPreferences.json()).ui).toMatchObject({
+    meanTaskDifficultyFilter: '',
+    sortField: 'itemId',
+  });
+
+  const uploadInput = managerPage.locator('input[type="file"][accept=".csv"]');
+  await Promise.all([
+    managerPage.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/upload-item-parameters') &&
+        response.ok(),
+    ),
+    uploadInput.setInputFiles({
+      name: 'difficulty.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from('item;est\ni1;0.2\ni2;0.8'),
+    }),
+  ]);
+  await expect(managerPage.getByRole('heading', { name: 'Upload Bericht' })).toBeVisible();
+  await managerPage.getByRole('button', { name: /Schließen/ }).click();
+  await publishExplorerDraft(managerPage);
+
+  await page.reload();
+  const restoredMeanFilter = page.getByPlaceholder('Mittlere Schwierigkeit: Min..Max');
+  await expect(restoredMeanFilter).toBeVisible();
+  await expect(restoredMeanFilter).toHaveValue('');
+  await expect(page.getByText('0.5', { exact: true })).toHaveCount(2);
+
+  await page.getByRole('button', { name: 'Abmelden' }).click();
+  await expect(page).toHaveURL(/\/login/);
+  await loginWithCredential(page);
+  await page.goto(`/view/${ACP_ID}/items`);
+  await expect(page.getByPlaceholder('Mittlere Schwierigkeit: Min..Max')).toHaveValue('');
+  await expect(page.getByText('0.5', { exact: true })).toHaveCount(2);
+
+  const reloginToken = await page.evaluate(() => localStorage.getItem('cp_token'));
+  const persistedPreferences = await request.get(
+    `/api/view/acp/${ACP_ID}/items/preferences?viewId=item-list`,
+    { headers: { Authorization: `Bearer ${reloginToken}` } },
+  );
+  expect(persistedPreferences.ok()).toBeTruthy();
+  expect((await persistedPreferences.json()).ui).toMatchObject({
+    meanTaskDifficultyFilter: '',
+    sortField: 'itemId',
+  });
+
+  await managerContext.close();
+});

--- a/frontend/e2e/proxy.conf.json
+++ b/frontend/e2e/proxy.conf.json
@@ -1,0 +1,10 @@
+{
+  "/api": {
+    "target": "http://127.0.0.1:3100",
+    "secure": false
+  },
+  "/assets/GeoGebra": {
+    "target": "http://127.0.0.1:3100",
+    "secure": false
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "@angular/cli": "^21.2.7",
         "@angular/compiler-cli": "^21.2.7",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.61.1",
         "@vitest/coverage-v8": "^4.1.2",
         "angular-eslint": "21.3.1",
         "eslint": "^10.0.3",
@@ -3517,6 +3518,22 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.4",
@@ -8795,6 +8812,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,8 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "vitest",
+    "e2e": "../scripts/run-browser-e2e.sh",
+    "e2e:playwright": "playwright test",
     "lint": "ng lint"
   },
   "private": true,
@@ -33,6 +35,7 @@
     "@angular/cli": "^21.2.7",
     "@angular/compiler-cli": "^21.2.7",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.61.1",
     "@vitest/coverage-v8": "^4.1.2",
     "angular-eslint": "21.3.1",
     "eslint": "^10.0.3",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const backendPort = 3100;
+const frontendPort = 4300;
+const databaseName = process.env['DB_DATABASE'] || '';
+
+if (process.env['NODE_ENV'] !== 'test' || !databaseName.toLowerCase().includes('e2e')) {
+  throw new Error('Run browser tests through `npm run e2e` to use the isolated E2E environment.');
+}
+if (
+  process.env['PORT'] !== String(backendPort) ||
+  process.env['BROWSER_E2E_BACKEND_PORT'] !== String(backendPort) ||
+  process.env['BROWSER_E2E_FRONTEND_PORT'] !== String(frontendPort)
+) {
+  throw new Error('Browser E2E tests require the dedicated backend and frontend ports.');
+}
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: `http://127.0.0.1:${frontendPort}`,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command: 'npm run start',
+      cwd: '../backend',
+      url: `http://127.0.0.1:${backendPort}/api/health/live`,
+      reuseExistingServer: false,
+      timeout: 120_000,
+    },
+    {
+      command: `npm start -- --host 127.0.0.1 --port ${frontendPort} --proxy-config e2e/proxy.conf.json`,
+      cwd: '.',
+      url: `http://127.0.0.1:${frontendPort}`,
+      reuseExistingServer: false,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/frontend/src/app/core/models/api.models.ts
+++ b/frontend/src/app/core/models/api.models.ts
@@ -452,6 +452,15 @@ export interface ItemViewPreferences {
   rowData?: Record<string, Record<string, unknown>>;
 }
 
+export interface SimpleItemListEntry {
+  itemId: string;
+  unitId: string;
+  unitName: string;
+  name?: string;
+  sourceVariable?: string;
+  meanTaskDifficulty?: number;
+}
+
 export type ItemExplorerPerspective = 'editor' | 'read-only';
 
 export interface ItemCollectionSummary {

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -31,6 +31,7 @@ import {
   FileDeletionResponse,
   ItemCollectionsPayload,
   ItemExplorerPerspective,
+  SimpleItemListEntry,
 } from '../models/api.models';
 
 @Injectable({ providedIn: 'root' })
@@ -425,8 +426,8 @@ export class ApiService {
   getViewUnit(acpId: string, unitId: string): Observable<UnitViewData> {
     return this.http.get<UnitViewData>(`${this.API}/view/acp/${acpId}/units/${unitId}`);
   }
-  getViewItems(acpId: string): Observable<any[]> {
-    return this.http.get<any[]>(`${this.API}/view/acp/${acpId}/items`);
+  getViewItems(acpId: string): Observable<SimpleItemListEntry[]> {
+    return this.http.get<SimpleItemListEntry[]>(`${this.API}/view/acp/${acpId}/items`);
   }
   getViewItemPreferences(acpId: string, viewId = 'item-list'): Observable<ItemViewPreferences> {
     return this.http.get<ItemViewPreferences>(

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
@@ -199,6 +199,31 @@ describe('ItemExplorerFacade', () => {
     expect((component as any).collectionSessionIdentity).toBeNull();
   });
 
+  it('shows a visible error and skips dependent loads when feature configuration fails', () => {
+    const error = new Error('configuration unavailable');
+    const getAcpStartPage = vi.fn(() => throwError(() => error));
+    const getItemExplorerState = vi.fn();
+    const getFileItemList = vi.fn();
+    const component = createFacade({
+      api: { getAcpStartPage, getItemExplorerState, getFileItemList },
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    component.init('acp-1');
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to load Item Explorer feature configuration',
+      error,
+    );
+    expect(component.itemListError).toBe(
+      'Die Konfiguration des Item-Explorers konnte nicht geladen werden.',
+    );
+    expect(component.explorerUiStatus).toBe('ERROR');
+    expect(getItemExplorerState).not.toHaveBeenCalled();
+    expect(getFileItemList).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   it('rejects an item list from another explorer-state version and reloads a consistent pair', async () => {
     const firstEnvelope = createExplorerEnvelope();
     const secondEnvelope = { ...createExplorerEnvelope(), version: 4 };

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
@@ -151,14 +151,16 @@ describe('ItemExplorerFacade', () => {
     sessionStorage.clear();
   });
 
-  it('initializes exactly once and ignores pending responses after destroy', () => {
+  it('initializes exactly once and ignores pending responses after destroy', async () => {
     const startPage$ = new Subject<any>();
+    const explorerState$ = new Subject<any>();
     const itemList$ = new Subject<any>();
     const currentUser$ = new Subject<unknown>();
     const getAcpStartPage = vi.fn(() => startPage$);
+    const getItemExplorerState = vi.fn(() => explorerState$);
     const getFileItemList = vi.fn(() => itemList$);
     const component = createFacade({
-      api: { getAcpStartPage, getFileItemList },
+      api: { getAcpStartPage, getItemExplorerState, getFileItemList },
       authService: { currentUser$ },
     });
 
@@ -167,10 +169,13 @@ describe('ItemExplorerFacade', () => {
 
     expect(getAcpStartPage).toHaveBeenCalledOnce();
     expect(getAcpStartPage).toHaveBeenCalledWith('');
-    expect(getFileItemList).toHaveBeenCalledOnce();
+    expect(getFileItemList).not.toHaveBeenCalled();
+
+    startPage$.next({ featureConfig: { enableItemListTags: true } });
+    explorerState$.next(createExplorerEnvelope());
+    await vi.waitFor(() => expect(getFileItemList).toHaveBeenCalledOnce());
 
     component.ngOnDestroy();
-    startPage$.next({ featureConfig: { enableItemListTags: true } });
     itemList$.next({
       items: [
         {
@@ -188,10 +193,70 @@ describe('ItemExplorerFacade', () => {
     });
     currentUser$.next(null);
 
-    expect(component.enableTags).toBe(false);
+    expect(component.enableTags).toBe(true);
     expect(component.items).toEqual([]);
     expect((component as any).personalDataSessionIdentity).toBeNull();
     expect((component as any).collectionSessionIdentity).toBeNull();
+  });
+
+  it('rejects an item list from another explorer-state version and reloads a consistent pair', async () => {
+    const firstEnvelope = createExplorerEnvelope();
+    const secondEnvelope = { ...createExplorerEnvelope(), version: 4 };
+    const getItemExplorerState = vi
+      .fn()
+      .mockReturnValueOnce(of(firstEnvelope))
+      .mockReturnValueOnce(of(secondEnvelope));
+    const getFileItemList = vi
+      .fn()
+      .mockReturnValueOnce(
+        of({
+          itemExplorerStateVersion: 2,
+          columns: [],
+          items: [
+            {
+              itemId: 'stale',
+              unitId: 'u1',
+              unitLabel: 'Unit 1',
+              description: '',
+              metadata: {},
+              meanTaskDifficulty: -1,
+            },
+          ],
+          unitMetadata: {},
+          codingSchemes: {},
+        }),
+      )
+      .mockReturnValueOnce(
+        of({
+          itemExplorerStateVersion: 4,
+          columns: [],
+          items: [
+            {
+              itemId: 'current',
+              unitId: 'u1',
+              unitLabel: 'Unit 1',
+              description: '',
+              metadata: {},
+              meanTaskDifficulty: 0.75,
+            },
+          ],
+          unitMetadata: {},
+          codingSchemes: {},
+        }),
+      );
+    const component = createFacade({ api: { getItemExplorerState, getFileItemList } });
+    component.acpId = 'acp-1';
+
+    await (component as any).reloadSharedExplorerStateAndItems();
+
+    expect(getItemExplorerState).toHaveBeenCalledTimes(2);
+    expect(getFileItemList).toHaveBeenCalledTimes(2);
+    expect(component.items).toEqual([
+      expect.objectContaining({
+        itemId: 'current',
+        meanTaskDifficulty: 0.75,
+      }),
+    ]);
   });
 
   it('suspends pending personal changes instead of saving after destroy', () => {

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
@@ -906,7 +906,7 @@ describe('ItemExplorerFacade', () => {
     expect(reloadItems).toHaveBeenCalledTimes(1);
   });
 
-  it('reloads shared state after a renumbering conflict', () => {
+  it('reloads shared state and canonical item projections after a renumbering conflict', () => {
     const recalculateItemRowNumbers = vi.fn(() =>
       throwError(() => ({ status: 409, error: { message: 'Source files changed' } })),
     );
@@ -914,14 +914,14 @@ describe('ItemExplorerFacade', () => {
     component.acpId = 'acp-1';
     component.latestExplorerState = createExplorerEnvelope({ status: 'CLEAN' });
     component.showRenumberDialog = true;
-    const loadSharedExplorerState = vi
-      .spyOn(component as any, 'loadSharedExplorerState')
+    const reloadSharedExplorerStateAndItems = vi
+      .spyOn(component as any, 'reloadSharedExplorerStateAndItems')
       .mockResolvedValue(undefined);
 
     component.confirmRenumber();
 
     expect(component.renumberError).toBe('Source files changed');
-    expect(loadSharedExplorerState).toHaveBeenCalledTimes(1);
+    expect(reloadSharedExplorerStateAndItems).toHaveBeenCalledTimes(1);
   });
 
   it('keeps a draft patch conflict visible after reloading the shared state', async () => {
@@ -935,6 +935,9 @@ describe('ItemExplorerFacade', () => {
     component.canEditExplorer = true;
     component.explorerVersion = 3;
     (component as any).pendingDraftPatch = { tags: { 'row-1': ['QA'] } };
+    const reloadItems = vi
+      .spyOn(component, 'reloadItems')
+      .mockImplementation((onSettled) => onSettled?.());
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     const flushed = await (component as any).flushDraftPatch();
@@ -944,6 +947,7 @@ describe('ItemExplorerFacade', () => {
       'Konflikt beim Aktualisieren des Entwurfs. Der Explorer wurde neu geladen.',
     );
     expect(component.explorerUiStatus).toBe('ERROR');
+    expect(reloadItems).toHaveBeenCalledTimes(1);
     consoleError.mockRestore();
   });
 

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
@@ -3116,7 +3116,7 @@ describe('ItemExplorerFacade', () => {
     ]);
   });
 
-  it('derives one mean task difficulty per unit and filters and sorts it numerically', () => {
+  it('uses backend-provided mean task difficulties without deriving replacements', () => {
     const component = createFacade();
     const baseItem = {
       unitLabel: 'Aufgabe',
@@ -3132,6 +3132,7 @@ describe('ItemExplorerFacade', () => {
         rowKey: 'uuid-1',
         unitId: 'unit-1',
         empiricalDifficulty: -1,
+        meanTaskDifficulty: 0.4,
       },
       {
         ...baseItem,
@@ -3140,6 +3141,7 @@ describe('ItemExplorerFacade', () => {
         rowKey: 'uuid-2',
         unitId: 'unit-1',
         empiricalDifficulty: 0.5,
+        meanTaskDifficulty: 0.4,
       },
       {
         ...baseItem,
@@ -3147,6 +3149,7 @@ describe('ItemExplorerFacade', () => {
         uuid: 'uuid-3',
         rowKey: 'uuid-3',
         unitId: 'unit-1',
+        meanTaskDifficulty: 0.4,
       },
       {
         ...baseItem,
@@ -3155,6 +3158,7 @@ describe('ItemExplorerFacade', () => {
         rowKey: 'uuid-4',
         unitId: 'unit-2',
         empiricalDifficulty: 1,
+        meanTaskDifficulty: -0.2,
       },
       {
         ...baseItem,
@@ -3165,15 +3169,15 @@ describe('ItemExplorerFacade', () => {
       },
     ];
 
-    (component as any).updateMeanTaskDifficulties();
+    (component as any).reconcileMeanTaskDifficultyState();
 
     expect(component.hasMeanTaskDifficulty).toBe(true);
     expect(component.items.slice(0, 3).map((item) => item.meanTaskDifficulty)).toEqual([
-      -0.25, -0.25, -0.25,
+      0.4, 0.4, 0.4,
     ]);
     expect(component.items[4].meanTaskDifficulty).toBeUndefined();
 
-    component.columnFilters = { meanTaskDifficulty: '-0.5..0' };
+    component.columnFilters = { meanTaskDifficulty: '0.3..0.5' };
     component.applyFilter(false);
     expect(component.filteredItems.map((item) => item.unitId)).toEqual([
       'unit-1',
@@ -3185,10 +3189,10 @@ describe('ItemExplorerFacade', () => {
     component.applyFilter(false);
     component.sortBy('meanTaskDifficulty');
     expect(component.filteredItems.map((item) => item.unitId)).toEqual([
-      'unit-1',
-      'unit-1',
-      'unit-1',
       'unit-2',
+      'unit-1',
+      'unit-1',
+      'unit-1',
       'unit-3',
     ]);
   });
@@ -3207,6 +3211,7 @@ describe('ItemExplorerFacade', () => {
         variableId: 'v1',
         metadata: {},
         empiricalDifficulty: 0.5,
+        meanTaskDifficulty: 0.5,
       },
     ];
     component.columnFilters = { meanTaskDifficulty: '0..1' };
@@ -3215,12 +3220,12 @@ describe('ItemExplorerFacade', () => {
     component.sortDir = 'desc';
     const queueDraftPatch = vi.spyOn(component as any, 'queueDraftPatch');
 
-    (component as any).updateMeanTaskDifficulties();
+    (component as any).reconcileMeanTaskDifficultyState();
     component.applyFilter(false);
     expect(component.filteredItems).toHaveLength(1);
 
-    delete component.items[0].empiricalDifficulty;
-    (component as any).updateMeanTaskDifficulties();
+    delete component.items[0].meanTaskDifficulty;
+    (component as any).reconcileMeanTaskDifficultyState();
     component.applyFilter(false);
 
     expect(component.hasMeanTaskDifficulty).toBe(false);

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.ts
@@ -876,7 +876,7 @@ export class ItemExplorerFacade implements OnDestroy {
             (item: any) =>
               item.empiricalDifficulty !== undefined && item.empiricalDifficulty !== null,
           );
-          this.updateMeanTaskDifficulties();
+          this.reconcileMeanTaskDifficultyState();
           this.filteredItems = [...this.items];
           this.unitMetadataCache = result.unitMetadata || {};
           this.codingSchemeCache = result.codingSchemes || {};
@@ -4269,32 +4269,11 @@ export class ItemExplorerFacade implements OnDestroy {
     this.hasEmpiricalDifficulty = this.items.some(
       (item: any) => item.empiricalDifficulty !== undefined && item.empiricalDifficulty !== null,
     );
-    this.updateMeanTaskDifficulties();
+    this.reconcileMeanTaskDifficultyState();
     this.applyFilter(false);
   }
 
-  private updateMeanTaskDifficulties(): void {
-    const totals = new Map<string, { sum: number; count: number }>();
-
-    for (const item of this.items) {
-      if (item.empiricalDifficulty === undefined || !Number.isFinite(item.empiricalDifficulty)) {
-        continue;
-      }
-      const total = totals.get(item.unitId) || { sum: 0, count: 0 };
-      total.sum += item.empiricalDifficulty;
-      total.count += 1;
-      totals.set(item.unitId, total);
-    }
-
-    for (const item of this.items) {
-      const total = totals.get(item.unitId);
-      if (total) {
-        item.meanTaskDifficulty = total.sum / total.count;
-      } else {
-        delete item.meanTaskDifficulty;
-      }
-    }
-
+  private reconcileMeanTaskDifficultyState(): void {
     this.hasMeanTaskDifficulty = this.items.some((item) => item.meanTaskDifficulty !== undefined);
     if (!this.hasMeanTaskDifficulty) {
       let uiStateChanged = false;

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.ts
@@ -62,6 +62,7 @@ import { matchesNumericFilter } from '../../core/utils/numeric-filter.util';
 
 const DEFAULT_EXPLORER_SORT_FIELD = 'unitLabel';
 const DEFAULT_EXPLORER_SORT_DIR: 'asc' | 'desc' = 'asc';
+type ItemListLoadOutcome = 'loaded' | 'version-mismatch' | 'superseded' | 'error';
 const IMPORTED_PARAMETER_COLUMNS: MetadataColumn[] = [
   { id: 'infit', label: 'Infit', kind: 'number' },
   { id: 'discrimination', label: 'Trennschärfe', kind: 'number' },
@@ -826,23 +827,25 @@ export class ItemExplorerFacade implements OnDestroy {
 
         // Load metadata column settings
         this.metadataSettings = this.resolveMetadataSettings(fc);
-        this.loadSharedExplorerState();
+        void this.reloadSharedExplorerStateAndItems();
         this.syncPersonalItemDataSession();
         this.syncItemCollectionSession();
         this.startPlayerIfReady();
       });
-
-    this.reloadItems();
   }
 
   // --- Reload Items ---
-  reloadItems(onSettled?: () => void) {
+  reloadItems(
+    onSettled?: (outcome: ItemListLoadOutcome) => void,
+    expectedExplorerState?: ItemExplorerStateEnvelope,
+  ) {
     const loadToken = ++this.itemListLoadToken;
     let settled = false;
+    let outcome: ItemListLoadOutcome = 'error';
     const settle = () => {
       if (settled) return;
       settled = true;
-      onSettled?.();
+      onSettled?.(outcome);
     };
     this.itemListError = '';
     this.itemListLoading = true;
@@ -856,6 +859,16 @@ export class ItemExplorerFacade implements OnDestroy {
       .subscribe({
         next: (result) => {
           if (loadToken !== this.itemListLoadToken) {
+            outcome = 'superseded';
+            settle();
+            return;
+          }
+          if (!this.itemListMatchesCurrentExplorerState(result, expectedExplorerState)) {
+            outcome = 'version-mismatch';
+            this.itemListLoading = false;
+            if (!onSettled) {
+              void this.reloadSharedExplorerStateAndItems();
+            }
             settle();
             return;
           }
@@ -871,7 +884,11 @@ export class ItemExplorerFacade implements OnDestroy {
           this.itemSubIdLabel = String(result.subIdLabel || this.itemSubIdLabel).trim() || 'Sub-ID';
           this.hasPartialCredit = this.items.some((item) => !!item.subId);
           this.hydrateItemTagsFromItems();
-          this.applyExplorerStateToItems();
+          if (expectedExplorerState) {
+            this.applySharedExplorerEnvelope(expectedExplorerState);
+          } else {
+            this.applyExplorerStateToItems();
+          }
           this.hasEmpiricalDifficulty = this.items.some(
             (item: any) =>
               item.empiricalDifficulty !== undefined && item.empiricalDifficulty !== null,
@@ -885,10 +902,12 @@ export class ItemExplorerFacade implements OnDestroy {
             this.recalculateCollectionSummaries();
           }
           this.itemListLoading = false;
+          outcome = 'loaded';
           settle();
         },
         error: (error) => {
           if (loadToken !== this.itemListLoadToken) {
+            outcome = 'superseded';
             settle();
             return;
           }
@@ -3688,7 +3707,7 @@ export class ItemExplorerFacade implements OnDestroy {
   }
 
   private loadPersistedTags() {
-    // Explorer uses shared ACP state; tags are loaded through loadSharedExplorerState().
+    // Explorer uses shared ACP state; tags are loaded with the versioned item-list snapshot.
     this.applyFilter(false);
   }
 
@@ -3800,9 +3819,7 @@ export class ItemExplorerFacade implements OnDestroy {
     this.syncEffectiveExplorerPermissions();
     this.itemListError = '';
 
-    await new Promise<void>((resolve) => this.reloadItems(resolve));
-    if (this.destroyed) return;
-    await this.loadSharedExplorerState();
+    await this.reloadSharedExplorerStateAndItems();
     if (this.destroyed) return;
     this.perspectiveSwitchBusy = false;
   }
@@ -4111,32 +4128,62 @@ export class ItemExplorerFacade implements OnDestroy {
     resolver?.(result);
   }
 
-  private async loadSharedExplorerState(preserveDraftOperationError = false): Promise<boolean> {
-    if (this.destroyed) return false;
-    const draftOperationError = preserveDraftOperationError ? this.lastDraftOperationError : '';
+  private async fetchSharedExplorerState(): Promise<ItemExplorerStateEnvelope | null> {
+    if (this.destroyed) return null;
     try {
       const envelope = await firstValueFrom(this.api.getItemExplorerState(this.acpId));
-      if (this.destroyed) return false;
-      this.applySharedExplorerEnvelope(envelope);
-      if (preserveDraftOperationError) {
-        this.lastDraftOperationError = draftOperationError;
-        this.explorerUiStatus = 'ERROR';
-      }
-      return true;
+      return this.destroyed ? null : envelope;
     } catch (error) {
-      if (this.destroyed) return false;
+      if (this.destroyed) return null;
       console.error('Failed to load shared explorer state', error);
       this.explorerUiStatus = 'ERROR';
-      return false;
+      return null;
     }
   }
 
   private async reloadSharedExplorerStateAndItems(
     preserveDraftOperationError = false,
   ): Promise<void> {
-    const stateLoaded = await this.loadSharedExplorerState(preserveDraftOperationError);
-    if (!stateLoaded || this.destroyed) return;
-    await new Promise<void>((resolve) => this.reloadItems(resolve));
+    const draftOperationError = preserveDraftOperationError ? this.lastDraftOperationError : '';
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const envelope = await this.fetchSharedExplorerState();
+      if (!envelope || this.destroyed) return;
+      const outcome = await new Promise<ItemListLoadOutcome>((resolve) =>
+        this.reloadItems(resolve, envelope),
+      );
+      if (outcome === 'loaded' && preserveDraftOperationError) {
+        this.lastDraftOperationError = draftOperationError;
+        this.explorerUiStatus = 'ERROR';
+      }
+      if (outcome !== 'version-mismatch') return;
+    }
+
+    if (!this.destroyed) {
+      this.itemListError =
+        'Der Item-Explorer wurde während des Ladens mehrfach geändert. Bitte erneut laden.';
+      this.explorerUiStatus = 'ERROR';
+    }
+  }
+
+  private itemListMatchesCurrentExplorerState(
+    result: unknown,
+    expectedExplorerState: ItemExplorerStateEnvelope | undefined,
+  ): boolean {
+    if (!this.isRecord(result) || result['itemExplorerStateVersion'] === undefined) {
+      // Compatibility for older cached responses and focused unit tests. The
+      // current backend always supplies the version marker.
+      return true;
+    }
+    const explorerState = expectedExplorerState || this.latestExplorerState;
+    if (!explorerState) return false;
+
+    const responseVersion = Number(result['itemExplorerStateVersion']);
+    const expectedVersion =
+      explorerState.canEdit && this.viewPerspective === 'editor'
+        ? explorerState.version
+        : explorerState.publishedVersion;
+    return Number.isInteger(responseVersion) && responseVersion === expectedVersion;
   }
 
   private applySharedExplorerEnvelope(envelope: ItemExplorerStateEnvelope, markSaved = false) {

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.ts
@@ -801,36 +801,44 @@ export class ItemExplorerFacade implements OnDestroy {
     this.api
       .getAcpStartPage(this.acpId)
       .pipe(takeUntil(this.destroy$))
-      .subscribe((data) => {
-        const fc = data?.featureConfig || {};
-        this.enableTags = !!fc.enableItemListTags;
-        this.availableTags = fc.availableTags || [];
-        this.showAudioVideoCodingVariables = fc.showAudioVideoCodingVariables !== false;
-        this.itemExplorerConditionalVisibilityEnabled =
-          fc.enableItemExplorerConditionalVisibility === true;
-        this.playerFocusHighlightEnabled = fc.enablePlayerFocusHighlight === true;
-        this.itemExplorerPlayerTargetInfoEnabled = fc.showItemExplorerPlayerTargetInfo !== false;
-        this.showOnlyItemsWithEmpiricalDifficulty =
-          fc.showOnlyItemsWithEmpiricalDifficulty === true;
-        this.itemSubIdLabel = String(fc.itemSubIdLabel || 'Sub-ID').trim() || 'Sub-ID';
-        this.enablePersonalItemData = fc.enablePersonalItemData === true;
-        this.enableItemCollections = fc.enableItemCollections === true;
-        this.personalItemCategoryLabel =
-          String(fc.personalItemCategoryLabel || 'Kompetenzstufe').trim() || 'Kompetenzstufe';
-        this.personalItemCategoryValues = this.normalizeStringList(fc.personalItemCategoryValues);
-        this.personalItemTagLabel =
-          String(fc.personalItemTagLabel || 'Markierungen').trim() || 'Markierungen';
-        this.personalItemTags = this.normalizePersonalItemTagConfig(fc.personalItemTags);
-        // Explorer uses ACP-shared draft/published state instead of per-user preferences.
-        this.persistUserPreferences = false;
-        this.useServerPreferences = false;
+      .subscribe({
+        next: (data) => {
+          const fc = data?.featureConfig || {};
+          this.enableTags = !!fc.enableItemListTags;
+          this.availableTags = fc.availableTags || [];
+          this.showAudioVideoCodingVariables = fc.showAudioVideoCodingVariables !== false;
+          this.itemExplorerConditionalVisibilityEnabled =
+            fc.enableItemExplorerConditionalVisibility === true;
+          this.playerFocusHighlightEnabled = fc.enablePlayerFocusHighlight === true;
+          this.itemExplorerPlayerTargetInfoEnabled = fc.showItemExplorerPlayerTargetInfo !== false;
+          this.showOnlyItemsWithEmpiricalDifficulty =
+            fc.showOnlyItemsWithEmpiricalDifficulty === true;
+          this.itemSubIdLabel = String(fc.itemSubIdLabel || 'Sub-ID').trim() || 'Sub-ID';
+          this.enablePersonalItemData = fc.enablePersonalItemData === true;
+          this.enableItemCollections = fc.enableItemCollections === true;
+          this.personalItemCategoryLabel =
+            String(fc.personalItemCategoryLabel || 'Kompetenzstufe').trim() || 'Kompetenzstufe';
+          this.personalItemCategoryValues = this.normalizeStringList(fc.personalItemCategoryValues);
+          this.personalItemTagLabel =
+            String(fc.personalItemTagLabel || 'Markierungen').trim() || 'Markierungen';
+          this.personalItemTags = this.normalizePersonalItemTagConfig(fc.personalItemTags);
+          // Explorer uses ACP-shared draft/published state instead of per-user preferences.
+          this.persistUserPreferences = false;
+          this.useServerPreferences = false;
 
-        // Load metadata column settings
-        this.metadataSettings = this.resolveMetadataSettings(fc);
-        void this.reloadSharedExplorerStateAndItems();
-        this.syncPersonalItemDataSession();
-        this.syncItemCollectionSession();
-        this.startPlayerIfReady();
+          // Load metadata column settings
+          this.metadataSettings = this.resolveMetadataSettings(fc);
+          void this.reloadSharedExplorerStateAndItems();
+          this.syncPersonalItemDataSession();
+          this.syncItemCollectionSession();
+          this.startPlayerIfReady();
+        },
+        error: (error) => {
+          if (this.destroyed) return;
+          console.error('Failed to load Item Explorer feature configuration', error);
+          this.itemListError = 'Die Konfiguration des Item-Explorers konnte nicht geladen werden.';
+          this.explorerUiStatus = 'ERROR';
+        },
       });
   }
 

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.ts
@@ -1797,8 +1797,9 @@ export class ItemExplorerFacade implements OnDestroy {
           console.error(err);
           this.isUploading = false;
           if (err?.status === 409) {
-            this.errorMessage = 'Konflikt beim Speichern des Entwurfs. Bitte neu laden.';
-            this.loadSharedExplorerState();
+            this.errorMessage =
+              'Konflikt beim Speichern des Entwurfs. Der Explorer wurde neu geladen.';
+            void this.reloadSharedExplorerStateAndItems();
           } else {
             this.errorMessage =
               err.error?.message ||
@@ -1853,7 +1854,7 @@ export class ItemExplorerFacade implements OnDestroy {
             this.clearEmpiricalDifficultiesError =
               'Konflikt beim Speichern des Entwurfs. Der Explorer wurde neu geladen.';
             this.lastDraftOperationError = this.clearEmpiricalDifficultiesError;
-            void this.loadSharedExplorerState();
+            void this.reloadSharedExplorerStateAndItems();
             return;
           }
           this.clearEmpiricalDifficultiesError =
@@ -1908,7 +1909,7 @@ export class ItemExplorerFacade implements OnDestroy {
           this.renumberError =
             error?.error?.message || 'Die Nummerierung konnte nicht neu berechnet werden.';
           if (error?.status === 409) {
-            void this.loadSharedExplorerState();
+            void this.reloadSharedExplorerStateAndItems();
           }
         },
       });
@@ -4110,22 +4111,32 @@ export class ItemExplorerFacade implements OnDestroy {
     resolver?.(result);
   }
 
-  private async loadSharedExplorerState(preserveDraftOperationError = false): Promise<void> {
-    if (this.destroyed) return;
+  private async loadSharedExplorerState(preserveDraftOperationError = false): Promise<boolean> {
+    if (this.destroyed) return false;
     const draftOperationError = preserveDraftOperationError ? this.lastDraftOperationError : '';
     try {
       const envelope = await firstValueFrom(this.api.getItemExplorerState(this.acpId));
-      if (this.destroyed) return;
+      if (this.destroyed) return false;
       this.applySharedExplorerEnvelope(envelope);
       if (preserveDraftOperationError) {
         this.lastDraftOperationError = draftOperationError;
         this.explorerUiStatus = 'ERROR';
       }
+      return true;
     } catch (error) {
-      if (this.destroyed) return;
+      if (this.destroyed) return false;
       console.error('Failed to load shared explorer state', error);
       this.explorerUiStatus = 'ERROR';
+      return false;
     }
+  }
+
+  private async reloadSharedExplorerStateAndItems(
+    preserveDraftOperationError = false,
+  ): Promise<void> {
+    const stateLoaded = await this.loadSharedExplorerState(preserveDraftOperationError);
+    if (!stateLoaded || this.destroyed) return;
+    await new Promise<void>((resolve) => this.reloadItems(resolve));
   }
 
   private applySharedExplorerEnvelope(envelope: ItemExplorerStateEnvelope, markSaved = false) {
@@ -4436,7 +4447,7 @@ export class ItemExplorerFacade implements OnDestroy {
         'Fehler beim Speichern der Änderungen.',
       );
       if (error?.status === 409) {
-        await this.loadSharedExplorerState(true);
+        await this.reloadSharedExplorerStateAndItems(true);
       }
       return false;
     }
@@ -4482,7 +4493,7 @@ export class ItemExplorerFacade implements OnDestroy {
         'Fehler beim Verwerfen der Änderungen.',
       );
       if (error?.status === 409) {
-        await this.loadSharedExplorerState(true);
+        await this.reloadSharedExplorerStateAndItems(true);
       }
       return false;
     }
@@ -4940,7 +4951,7 @@ export class ItemExplorerFacade implements OnDestroy {
       if (error?.status === 409) {
         this.lastDraftOperationError =
           'Konflikt beim Aktualisieren des Entwurfs. Der Explorer wurde neu geladen.';
-        await this.loadSharedExplorerState(true);
+        await this.reloadSharedExplorerStateAndItems(true);
         return false;
       }
       this.lastDraftOperationError = this.extractDraftErrorMessage(

--- a/frontend/src/app/views/item-list/item-list-preferences.service.spec.ts
+++ b/frontend/src/app/views/item-list/item-list-preferences.service.spec.ts
@@ -1,0 +1,115 @@
+import { firstValueFrom, of, throwError } from 'rxjs';
+import { afterEach, beforeEach, vi } from 'vitest';
+import { ItemListPreferencesService } from './item-list-preferences.service';
+import { ItemListPreferences } from './item-list.models';
+
+describe('ItemListPreferencesService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it('falls back to normalized local preferences when the server load fails', async () => {
+    localStorage.setItem(
+      'cp:item-list:prefs:acp-1:user-1',
+      JSON.stringify({
+        filterText: 'alpha',
+        sortField: 'meanTaskDifficulty',
+        sortDir: 'desc',
+      }),
+    );
+    localStorage.setItem(
+      'cp:item-list:tags:acp-1:user-1',
+      JSON.stringify({ item1: [' review ', 'review', ''] }),
+    );
+    const service = new ItemListPreferencesService(
+      {
+        getViewItemPreferences: () => throwError(() => new Error('offline')),
+      } as never,
+      { isLoggedIn: true, currentUser: { id: 'user-1' } } as never,
+    );
+
+    await expect(
+      firstValueFrom(service.load({ acpId: 'acp-1', persist: true, enableTags: true })),
+    ).resolves.toEqual({
+      ui: {
+        filterText: 'alpha',
+        meanTaskDifficultyFilter: '',
+        sortField: 'meanTaskDifficulty',
+        sortDir: 'desc',
+      },
+      tags: { item1: ['review'] },
+    });
+    service.ngOnDestroy();
+  });
+
+  it('persists a complete normalized local snapshot under the existing keys', async () => {
+    const service = new ItemListPreferencesService(
+      {} as never,
+      { isLoggedIn: false, currentUser: null } as never,
+    );
+    await firstValueFrom(service.load({ acpId: 'acp-1', persist: true, enableTags: true }));
+
+    service.save({
+      ui: {
+        filterText: 'x',
+        meanTaskDifficultyFilter: '>=0',
+        sortField: 'meanTaskDifficulty',
+        sortDir: 'desc',
+      },
+      tags: { item1: [' one ', 'one', 'two'] },
+    });
+
+    expect(JSON.parse(localStorage.getItem('cp:item-list:prefs:acp-1:anonymous') || '{}')).toEqual({
+      filterText: 'x',
+      meanTaskDifficultyFilter: '>=0',
+      sortField: 'meanTaskDifficulty',
+      sortDir: 'desc',
+    });
+    expect(JSON.parse(localStorage.getItem('cp:item-list:tags:acp-1:anonymous') || '{}')).toEqual({
+      item1: ['one', 'two'],
+    });
+    service.ngOnDestroy();
+  });
+
+  it('debounces full server saves and continues after a failed request', async () => {
+    vi.useFakeTimers();
+    const saveViewItemPreferences = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => new Error('save failed')))
+      .mockReturnValue(of({}));
+    const service = new ItemListPreferencesService(
+      {
+        getViewItemPreferences: () => of({ ui: {}, tags: {} }),
+        saveViewItemPreferences,
+      } as never,
+      { isLoggedIn: true, currentUser: { id: 'user-1' } } as never,
+    );
+    await firstValueFrom(service.load({ acpId: 'acp-1', persist: true, enableTags: true }));
+    const first: ItemListPreferences = {
+      ui: {
+        filterText: 'first',
+        meanTaskDifficultyFilter: '',
+        sortField: 'itemId',
+        sortDir: 'asc',
+      },
+      tags: {},
+    };
+    const latest = { ...first, ui: { ...first.ui, filterText: 'latest' } };
+
+    service.save(first);
+    service.save(latest);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(saveViewItemPreferences).toHaveBeenCalledTimes(1);
+    expect(saveViewItemPreferences).toHaveBeenLastCalledWith('acp-1', latest, 'item-list');
+
+    service.save({ ...latest, tags: { item1: ['tag'] } });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(saveViewItemPreferences).toHaveBeenCalledTimes(2);
+    service.ngOnDestroy();
+  });
+});

--- a/frontend/src/app/views/item-list/item-list-preferences.service.spec.ts
+++ b/frontend/src/app/views/item-list/item-list-preferences.service.spec.ts
@@ -129,4 +129,35 @@ describe('ItemListPreferencesService', () => {
     expect(saveViewItemPreferences).toHaveBeenCalledTimes(2);
     service.ngOnDestroy();
   });
+
+  it('preserves server tags when the tag feature is disabled and UI preferences change', async () => {
+    vi.useFakeTimers();
+    const saveViewItemPreferences = vi.fn().mockReturnValue(of({}));
+    const service = new ItemListPreferencesService(
+      {
+        getViewItemPreferences: () =>
+          of({
+            ui: { filterText: 'before' },
+            tags: { item1: [' review ', 'review'] },
+          }),
+        saveViewItemPreferences,
+      } as never,
+      { isLoggedIn: true, currentUser: { id: 'user-1' } } as never,
+    );
+
+    const loaded = await firstValueFrom(
+      service.load({ acpId: 'acp-1', persist: true, enableTags: false }),
+    );
+    expect(loaded.tags).toEqual({ item1: ['review'] });
+
+    const changed = {
+      ...loaded,
+      ui: { ...loaded.ui, filterText: 'after' },
+    };
+    service.save(changed);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(saveViewItemPreferences).toHaveBeenCalledWith('acp-1', changed, 'item-list');
+    service.ngOnDestroy();
+  });
 });

--- a/frontend/src/app/views/item-list/item-list-preferences.service.spec.ts
+++ b/frontend/src/app/views/item-list/item-list-preferences.service.spec.ts
@@ -13,7 +13,7 @@ describe('ItemListPreferencesService', () => {
     localStorage.clear();
   });
 
-  it('falls back to normalized local preferences when the server load fails', async () => {
+  it('falls back to normalized local preferences for loading and subsequent saves', async () => {
     localStorage.setItem(
       'cp:item-list:prefs:acp-1:user-1',
       JSON.stringify({
@@ -26,16 +26,19 @@ describe('ItemListPreferencesService', () => {
       'cp:item-list:tags:acp-1:user-1',
       JSON.stringify({ item1: [' review ', 'review', ''] }),
     );
+    const saveViewItemPreferences = vi.fn();
     const service = new ItemListPreferencesService(
       {
         getViewItemPreferences: () => throwError(() => new Error('offline')),
+        saveViewItemPreferences,
       } as never,
       { isLoggedIn: true, currentUser: { id: 'user-1' } } as never,
     );
 
-    await expect(
-      firstValueFrom(service.load({ acpId: 'acp-1', persist: true, enableTags: true })),
-    ).resolves.toEqual({
+    const fallback = await firstValueFrom(
+      service.load({ acpId: 'acp-1', persist: true, enableTags: true }),
+    );
+    expect(fallback).toEqual({
       ui: {
         filterText: 'alpha',
         meanTaskDifficultyFilter: '',
@@ -43,6 +46,20 @@ describe('ItemListPreferencesService', () => {
         sortDir: 'desc',
       },
       tags: { item1: ['review'] },
+    });
+
+    service.save({
+      ...fallback,
+      ui: { ...fallback.ui, filterText: 'saved offline' },
+    });
+
+    expect(saveViewItemPreferences).not.toHaveBeenCalled();
+    expect(JSON.parse(localStorage.getItem('cp:item-list:prefs:acp-1:user-1') || '{}')).toEqual({
+      ...fallback.ui,
+      filterText: 'saved offline',
+    });
+    expect(JSON.parse(localStorage.getItem('cp:item-list:tags:acp-1:user-1') || '{}')).toEqual({
+      item1: ['review'],
     });
     service.ngOnDestroy();
   });

--- a/frontend/src/app/views/item-list/item-list-preferences.service.ts
+++ b/frontend/src/app/views/item-list/item-list-preferences.service.ts
@@ -1,0 +1,192 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import {
+  catchError,
+  debounceTime,
+  EMPTY,
+  map,
+  Observable,
+  of,
+  Subject,
+  switchMap,
+  takeUntil,
+} from 'rxjs';
+import { ApiService } from '../../core/services/api.service';
+import { AuthService } from '../../core/services/auth.service';
+import { ItemListPreferences, ItemListSortField, ItemListUiPreferences } from './item-list.models';
+
+export interface ItemListPreferenceContext {
+  acpId: string;
+  persist: boolean;
+  enableTags: boolean;
+}
+
+const DEFAULT_UI_PREFERENCES: ItemListUiPreferences = {
+  filterText: '',
+  meanTaskDifficultyFilter: '',
+  sortField: 'itemId',
+  sortDir: 'asc',
+};
+
+@Injectable()
+export class ItemListPreferencesService implements OnDestroy {
+  private readonly viewId = 'item-list';
+  private readonly destroy$ = new Subject<void>();
+  private readonly serverSaveRequests$ = new Subject<ItemListPreferences>();
+  private context: ItemListPreferenceContext = {
+    acpId: '',
+    persist: false,
+    enableTags: false,
+  };
+  private useServerPreferences = false;
+
+  constructor(
+    private readonly api: ApiService,
+    private readonly auth: AuthService,
+  ) {
+    this.serverSaveRequests$
+      .pipe(
+        debounceTime(250),
+        switchMap((preferences) =>
+          this.api.saveViewItemPreferences(this.context.acpId, preferences, this.viewId).pipe(
+            catchError((error) => {
+              console.error('Failed to persist item list preferences', error);
+              return EMPTY;
+            }),
+          ),
+        ),
+        takeUntil(this.destroy$),
+      )
+      .subscribe();
+  }
+
+  load(context: ItemListPreferenceContext): Observable<ItemListPreferences> {
+    this.context = context;
+    this.useServerPreferences = context.persist && this.auth.isLoggedIn;
+
+    if (!context.persist) {
+      return of(this.emptyPreferences());
+    }
+    if (!this.useServerPreferences) {
+      return of(this.loadLocalPreferences());
+    }
+
+    return this.api.getViewItemPreferences(context.acpId, this.viewId).pipe(
+      map((preferences) =>
+        this.normalizePreferences({
+          ui: preferences?.ui,
+          tags: context.enableTags ? preferences?.tags : {},
+        }),
+      ),
+      catchError(() => of(this.loadLocalPreferences())),
+    );
+  }
+
+  save(preferences: ItemListPreferences): ItemListPreferences {
+    const normalized = this.normalizePreferences(preferences);
+    if (!this.context.persist) {
+      return normalized;
+    }
+
+    if (this.useServerPreferences) {
+      this.serverSaveRequests$.next(normalized);
+    } else {
+      localStorage.setItem(this.uiPreferencesKey(), JSON.stringify(normalized.ui));
+      if (this.context.enableTags) {
+        localStorage.setItem(this.tagPreferencesKey(), JSON.stringify(normalized.tags));
+      }
+    }
+    return normalized;
+  }
+
+  normalizePreferences(raw: { ui?: unknown; tags?: unknown }): ItemListPreferences {
+    return {
+      ui: this.normalizeUiPreferences(raw.ui),
+      tags: this.context.enableTags ? this.normalizeTags(raw.tags) : {},
+    };
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private emptyPreferences(): ItemListPreferences {
+    return { ui: { ...DEFAULT_UI_PREFERENCES }, tags: {} };
+  }
+
+  private loadLocalPreferences(): ItemListPreferences {
+    return this.normalizePreferences({
+      ui: this.parseJsonObject(localStorage.getItem(this.uiPreferencesKey())),
+      tags: this.context.enableTags
+        ? this.parseJsonObject(localStorage.getItem(this.tagPreferencesKey()))
+        : {},
+    });
+  }
+
+  private normalizeUiPreferences(raw: unknown): ItemListUiPreferences {
+    const value = this.isObject(raw) ? raw : {};
+    const sortField = value['sortField'];
+    const allowedSortFields: ItemListSortField[] = [
+      'itemId',
+      'unitId',
+      'name',
+      'meanTaskDifficulty',
+    ];
+
+    return {
+      filterText: typeof value['filterText'] === 'string' ? value['filterText'] : '',
+      meanTaskDifficultyFilter:
+        typeof value['meanTaskDifficultyFilter'] === 'string'
+          ? value['meanTaskDifficultyFilter']
+          : '',
+      sortField:
+        typeof sortField === 'string' && allowedSortFields.includes(sortField as ItemListSortField)
+          ? (sortField as ItemListSortField)
+          : 'itemId',
+      sortDir: value['sortDir'] === 'desc' ? 'desc' : 'asc',
+    };
+  }
+
+  private normalizeTags(raw: unknown): Record<string, string[]> {
+    if (!this.isObject(raw)) return {};
+
+    const tags: Record<string, string[]> = {};
+    for (const [itemId, values] of Object.entries(raw)) {
+      const normalizedItemId = itemId.trim();
+      if (!normalizedItemId || !Array.isArray(values)) continue;
+      const normalizedValues = Array.from(
+        new Set(
+          values.map((value) => String(value || '').trim()).filter((value) => value.length > 0),
+        ),
+      );
+      if (normalizedValues.length) tags[normalizedItemId] = normalizedValues;
+    }
+    return tags;
+  }
+
+  private uiPreferencesKey(): string {
+    return `cp:item-list:prefs:${this.context.acpId}:${this.preferenceIdentity()}`;
+  }
+
+  private tagPreferencesKey(): string {
+    return `cp:item-list:tags:${this.context.acpId}:${this.preferenceIdentity()}`;
+  }
+
+  private preferenceIdentity(): string {
+    return this.auth.currentUser?.id || 'anonymous';
+  }
+
+  private parseJsonObject(raw: string | null): Record<string, unknown> {
+    if (!raw) return {};
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return this.isObject(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private isObject(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  }
+}

--- a/frontend/src/app/views/item-list/item-list-preferences.service.ts
+++ b/frontend/src/app/views/item-list/item-list-preferences.service.ts
@@ -74,7 +74,9 @@ export class ItemListPreferencesService implements OnDestroy {
       map((preferences) =>
         this.normalizePreferences({
           ui: preferences?.ui,
-          tags: context.enableTags ? preferences?.tags : {},
+          // Keep hidden server-side tags in the complete preference snapshot so
+          // toggling the feature off does not erase them on the next UI save.
+          tags: preferences?.tags,
         }),
       ),
       catchError(() => {
@@ -104,7 +106,7 @@ export class ItemListPreferencesService implements OnDestroy {
   normalizePreferences(raw: { ui?: unknown; tags?: unknown }): ItemListPreferences {
     return {
       ui: this.normalizeUiPreferences(raw.ui),
-      tags: this.context.enableTags ? this.normalizeTags(raw.tags) : {},
+      tags: this.normalizeTags(raw.tags),
     };
   }
 

--- a/frontend/src/app/views/item-list/item-list-preferences.service.ts
+++ b/frontend/src/app/views/item-list/item-list-preferences.service.ts
@@ -77,7 +77,10 @@ export class ItemListPreferencesService implements OnDestroy {
           tags: context.enableTags ? preferences?.tags : {},
         }),
       ),
-      catchError(() => of(this.loadLocalPreferences())),
+      catchError(() => {
+        this.useServerPreferences = false;
+        return of(this.loadLocalPreferences());
+      }),
     );
   }
 

--- a/frontend/src/app/views/item-list/item-list.component.html
+++ b/frontend/src/app/views/item-list/item-list.component.html
@@ -1,0 +1,118 @@
+<app-breadcrumb [items]="breadcrumbs" />
+
+<div class="page-header">
+  <h1>Item-Liste</h1>
+  <span class="item-count">{{ filteredItems.length }} von {{ items.length }} Items</span>
+</div>
+
+@if (enableFilter || enableSort) {
+  <div class="toolbar">
+    @if (enableFilter) {
+      <input
+        class="filter-input"
+        [(ngModel)]="filterText"
+        placeholder="🔍 Items filtern..."
+        (input)="applyFilter()"
+      />
+      @if (hasMeanTaskDifficulty) {
+        <input
+          class="filter-input difficulty-filter"
+          [(ngModel)]="meanTaskDifficultyFilter"
+          placeholder="Mittlere Schwierigkeit: Min..Max"
+          (input)="applyFilter()"
+        />
+      }
+    }
+    @if (enableSort) {
+      <select [(ngModel)]="sortField" (change)="applySort()" class="sort-select">
+        <option value="itemId">Item-ID</option>
+        <option value="unitId">Aufgabe</option>
+        <option value="name">Name</option>
+        @if (hasMeanTaskDifficulty) {
+          <option value="meanTaskDifficulty">Mittlere Aufgabenschwierigkeit</option>
+        }
+      </select>
+      <button class="btn btn-sm btn-outline" (click)="toggleSortDir()">
+        {{ sortDir === 'asc' ? '↑ A-Z' : '↓ Z-A' }}
+      </button>
+    }
+  </div>
+}
+
+<div class="card">
+  <table class="table">
+    <thead>
+      <tr>
+        <th (click)="sortBy('itemId')" class="sortable">
+          Item-ID {{ sortField === 'itemId' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
+        </th>
+        <th (click)="sortBy('unitId')" class="sortable">
+          Aufgabe {{ sortField === 'unitId' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
+        </th>
+        <th (click)="sortBy('name')" class="sortable">
+          Name {{ sortField === 'name' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
+        </th>
+        <th>Quellvariable</th>
+        @if (hasMeanTaskDifficulty) {
+          <th (click)="sortBy('meanTaskDifficulty')" class="sortable">
+            Mittlere Aufgabenschwierigkeit
+            {{ sortField === 'meanTaskDifficulty' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
+          </th>
+        }
+        @if (enableTags) {
+          <th>Tags</th>
+        }
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (item of filteredItems; track item.itemId) {
+        <tr [class.clickable]="enableClick" (click)="enableClick && navigateToItem(item)">
+          <td>
+            <code>{{ item.itemId }}</code>
+          </td>
+          <td>{{ item.unitName || item.unitId }}</td>
+          <td>{{ item.name || '–' }}</td>
+          <td>
+            <code>{{ item.sourceVariable || '–' }}</code>
+          </td>
+          @if (hasMeanTaskDifficulty) {
+            <td>{{ item.meanTaskDifficulty ?? '' }}</td>
+          }
+          @if (enableTags) {
+            <td class="tags-cell" (click)="$event.stopPropagation()">
+              @for (tag of itemTags[item.itemId] || []; track tag) {
+                <span class="badge badge-info tag-badge" (click)="removeItemTag(item.itemId, tag)"
+                  >{{ tag }} ✕</span
+                >
+              }
+              <select class="tag-select" (change)="addItemTag(item.itemId, $event)">
+                <option value="">+Tag</option>
+                @for (tag of availableTags; track tag) {
+                  <option [value]="tag">{{ tag }}</option>
+                }
+              </select>
+            </td>
+          }
+          <td>
+            @if (enableClick) {
+              <a
+                [routerLink]="['/view', acpId, 'item', item.itemId]"
+                class="btn btn-sm btn-outline"
+                (click)="$event.stopPropagation()"
+                >Ansehen</a
+              >
+            } @else {
+              <a
+                [routerLink]="['/view', acpId, 'unit', item.unitId]"
+                class="btn btn-sm btn-outline"
+                (click)="$event.stopPropagation()"
+                >Aufgabe</a
+              >
+            }
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</div>

--- a/frontend/src/app/views/item-list/item-list.component.scss
+++ b/frontend/src/app/views/item-list/item-list.component.scss
@@ -1,0 +1,62 @@
+.item-count {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.filter-input {
+  padding: 8px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+  min-width: 250px;
+  font-family: inherit;
+}
+
+.sort-select {
+  padding: 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  font-family: inherit;
+}
+
+.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.sortable:hover {
+  color: var(--color-primary-light);
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.clickable:hover td {
+  background: rgba(41, 128, 185, 0.04);
+}
+
+.tags-cell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.tag-badge {
+  cursor: pointer;
+  font-size: 0.7rem;
+}
+
+.tag-badge:hover {
+  opacity: 0.7;
+}
+
+.tag-select {
+  padding: 2px 4px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  background: white;
+}

--- a/frontend/src/app/views/item-list/item-list.component.spec.ts
+++ b/frontend/src/app/views/item-list/item-list.component.spec.ts
@@ -1,29 +1,46 @@
 import { of, Subject } from 'rxjs';
-import { afterEach, vi } from 'vitest';
+import { vi } from 'vitest';
+import { ItemListPreferencesService } from './item-list-preferences.service';
 import { ItemListComponent } from './item-list.component';
+import { ItemListPreferences } from './item-list.models';
+
+const emptyPreferences = (): ItemListPreferences => ({
+  ui: {
+    filterText: '',
+    meanTaskDifficultyFilter: '',
+    sortField: 'itemId',
+    sortDir: 'asc',
+  },
+  tags: {},
+});
 
 describe('ItemListComponent', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-    localStorage.clear();
-  });
-
-  const createComponent = () =>
-    new ItemListComponent(
-      { snapshot: { paramMap: { get: () => 'acp-1' } } } as any,
+  const createComponent = (options?: {
+    getAcpStartPage?: () => unknown;
+    getViewItems?: () => unknown;
+    loadPreferences?: () => unknown;
+  }) => {
+    const preferences = {
+      load: vi.fn(options?.loadPreferences || (() => of(emptyPreferences()))),
+      save: vi.fn((value: ItemListPreferences) => value),
+    };
+    const component = new ItemListComponent(
+      { snapshot: { paramMap: { get: () => 'acp-1' } } } as never,
       {
-        getAcpStartPage: () => of({ featureConfig: {} }),
-        getViewItems: () => of([]),
-      } as any,
-      { isLoggedIn: false, currentUser: null } as any,
+        getAcpStartPage: options?.getAcpStartPage || (() => of({ featureConfig: {} })),
+        getViewItems: options?.getViewItems || (() => of([])),
+      } as never,
+      preferences as unknown as ItemListPreferencesService,
     );
+    return { component, preferences };
+  };
 
   it('filters and sorts mean task difficulty numerically with missing values last', () => {
-    const component = createComponent();
+    const { component } = createComponent();
     component.items = [
-      { itemId: 'a', unitId: 'A', meanTaskDifficulty: -0.25 },
-      { itemId: 'b', unitId: 'B', meanTaskDifficulty: 1 },
-      { itemId: 'c', unitId: 'C' },
+      { itemId: 'a', unitId: 'A', unitName: 'A', meanTaskDifficulty: -0.25 },
+      { itemId: 'b', unitId: 'B', unitName: 'B', meanTaskDifficulty: 1 },
+      { itemId: 'c', unitId: 'C', unitName: 'C' },
     ];
     component.meanTaskDifficultyFilter = '-0.5..0';
 
@@ -40,10 +57,10 @@ describe('ItemListComponent', () => {
   });
 
   it('uses the same numeric filter grammar as the Item Explorer', () => {
-    const component = createComponent();
+    const { component } = createComponent();
     component.items = [
-      { itemId: 'negative', unitId: 'A', meanTaskDifficulty: -0.25 },
-      { itemId: 'positive', unitId: 'B', meanTaskDifficulty: 1 },
+      { itemId: 'negative', unitId: 'A', unitName: 'A', meanTaskDifficulty: -0.25 },
+      { itemId: 'positive', unitId: 'B', unitName: 'B', meanTaskDifficulty: 1 },
     ];
 
     component.meanTaskDifficultyFilter = '-0,5..0,5';
@@ -59,115 +76,87 @@ describe('ItemListComponent', () => {
     expect(component.filteredItems.map((item) => item.itemId)).toEqual(['negative']);
   });
 
-  it('removes a restored mean filter when preferences arrive after a list without values', () => {
-    vi.useFakeTimers();
-    const startPage$ = new Subject<any>();
-    const items$ = new Subject<any[]>();
-    const preferences$ = new Subject<any>();
-    const saveViewItemPreferences = vi.fn((_: string, preferences: any) => of(preferences));
-    const component = new ItemListComponent(
-      { snapshot: { paramMap: { get: () => 'acp-1' } } } as any,
-      {
-        getAcpStartPage: () => startPage$,
+  it.each(['preferences-first', 'items-first'])(
+    'builds one reconciled state after %s initialization',
+    (responseOrder) => {
+      const items$ = new Subject<Array<{ itemId: string; unitId: string; unitName: string }>>();
+      const preferences$ = new Subject<ItemListPreferences>();
+      const { component, preferences } = createComponent({
+        getAcpStartPage: () =>
+          of({ featureConfig: { persistUserPreferences: true, enableItemListTags: true } }),
         getViewItems: () => items$,
-        getViewItemPreferences: () => preferences$,
-        saveViewItemPreferences,
-      } as any,
-      { isLoggedIn: true, currentUser: { id: 'user-1' } } as any,
-    );
+        loadPreferences: () => preferences$,
+      });
+      const restored: ItemListPreferences = {
+        ui: {
+          filterText: '',
+          meanTaskDifficultyFilter: '-0.5..0',
+          sortField: 'meanTaskDifficulty',
+          sortDir: 'desc',
+        },
+        tags: { a: ['review'] },
+      };
+      const items = [{ itemId: 'a', unitId: 'A', unitName: 'A' }];
 
-    component.ngOnInit();
-    items$.next([{ itemId: 'a', unitId: 'A' }]);
-    startPage$.next({ featureConfig: { persistUserPreferences: true } });
-    preferences$.next({
-      ui: {
-        meanTaskDifficultyFilter: '-0.5..0',
-        sortField: 'meanTaskDifficulty',
-        sortDir: 'desc',
-      },
-    });
+      component.ngOnInit();
+      if (responseOrder === 'preferences-first') {
+        preferences$.next(restored);
+        preferences$.complete();
+        expect(component.items).toEqual([]);
+        items$.next(items);
+        items$.complete();
+      } else {
+        items$.next(items);
+        items$.complete();
+        expect(component.items).toEqual([]);
+        preferences$.next(restored);
+        preferences$.complete();
+      }
 
-    expect(component.meanTaskDifficultyFilter).toBe('');
-    expect(component.sortField).toBe('itemId');
-    expect(component.filteredItems.map((item) => item.itemId)).toEqual(['a']);
-
-    vi.advanceTimersByTime(250);
-    expect(saveViewItemPreferences).toHaveBeenCalledWith(
-      'acp-1',
-      {
-        ui: expect.objectContaining({
+      expect(component.items).toEqual(items);
+      expect(component.meanTaskDifficultyFilter).toBe('');
+      expect(component.sortField).toBe('itemId');
+      expect(component.sortDir).toBe('desc');
+      expect(component.filteredItems).toEqual(items);
+      expect(component.itemTags).toEqual({ a: ['review'] });
+      expect(preferences.save).toHaveBeenCalledWith({
+        ui: {
+          filterText: '',
           meanTaskDifficultyFilter: '',
           sortField: 'itemId',
-        }),
-        tags: {},
-      },
-      'item-list',
-    );
-    component.ngOnDestroy();
-  });
+          sortDir: 'desc',
+        },
+        tags: { a: ['review'] },
+      });
+      component.ngOnDestroy();
+    },
+  );
 
-  it('persists reconciled mean preferences in local storage', () => {
-    localStorage.setItem(
-      'cp:item-list:prefs:acp-1:anonymous',
-      JSON.stringify({
-        meanTaskDifficultyFilter: '-0.5..0',
-        sortField: 'meanTaskDifficulty',
-        sortDir: 'desc',
-      }),
-    );
-    const startPage$ = new Subject<any>();
-    const items$ = new Subject<any[]>();
-    const component = new ItemListComponent(
-      { snapshot: { paramMap: { get: () => 'acp-1' } } } as any,
-      {
-        getAcpStartPage: () => startPage$,
-        getViewItems: () => items$,
-      } as any,
-      { isLoggedIn: false, currentUser: null } as any,
-    );
-
-    component.ngOnInit();
-    items$.next([{ itemId: 'a', unitId: 'A' }]);
-    startPage$.next({ featureConfig: { persistUserPreferences: true } });
-
-    expect(JSON.parse(localStorage.getItem('cp:item-list:prefs:acp-1:anonymous') || '{}')).toEqual({
-      filterText: '',
-      meanTaskDifficultyFilter: '',
-      sortField: 'itemId',
-      sortDir: 'desc',
-    });
-  });
-
-  it('keeps a restored mean filter when preferences arrive before a list with values', () => {
-    const startPage$ = new Subject<any>();
-    const items$ = new Subject<any[]>();
-    const preferences$ = new Subject<any>();
-    const component = new ItemListComponent(
-      { snapshot: { paramMap: { get: () => 'acp-1' } } } as any,
-      {
-        getAcpStartPage: () => startPage$,
-        getViewItems: () => items$,
-        getViewItemPreferences: () => preferences$,
-      } as any,
-      { isLoggedIn: true, currentUser: { id: 'user-1' } } as any,
-    );
-
-    component.ngOnInit();
-    startPage$.next({ featureConfig: { persistUserPreferences: true } });
-    preferences$.next({
+  it('keeps valid mean preferences when the backend provides means', () => {
+    const restored: ItemListPreferences = {
       ui: {
+        filterText: '',
         meanTaskDifficultyFilter: '-0.5..0',
         sortField: 'meanTaskDifficulty',
         sortDir: 'asc',
       },
+      tags: {},
+    };
+    const { component, preferences } = createComponent({
+      getViewItems: () =>
+        of([
+          { itemId: 'a', unitId: 'A', unitName: 'A', meanTaskDifficulty: -0.25 },
+          { itemId: 'b', unitId: 'B', unitName: 'B', meanTaskDifficulty: 1 },
+        ]),
+      loadPreferences: () => of(restored),
     });
-    items$.next([
-      { itemId: 'a', unitId: 'A', meanTaskDifficulty: -0.25 },
-      { itemId: 'b', unitId: 'B', meanTaskDifficulty: 1 },
-    ]);
+
+    component.ngOnInit();
 
     expect(component.meanTaskDifficultyFilter).toBe('-0.5..0');
     expect(component.sortField).toBe('meanTaskDifficulty');
     expect(component.filteredItems.map((item) => item.itemId)).toEqual(['a']);
+    expect(preferences.save).not.toHaveBeenCalled();
+    component.ngOnDestroy();
   });
 });

--- a/frontend/src/app/views/item-list/item-list.component.ts
+++ b/frontend/src/app/views/item-list/item-list.component.ts
@@ -1,207 +1,33 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { forkJoin, Subject, switchMap, takeUntil } from 'rxjs';
 import { ApiService } from '../../core/services/api.service';
-import { AuthService } from '../../core/services/auth.service';
+import { SimpleItemListEntry } from '../../core/models/api.models';
 import { matchesNumericFilter } from '../../core/utils/numeric-filter.util';
 import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/breadcrumb.component';
+import { ItemListPreferencesService } from './item-list-preferences.service';
+import { ItemListPreferences, ItemListSortField, ItemListUiPreferences } from './item-list.models';
 
 @Component({
   selector: 'app-item-list',
   standalone: true,
   imports: [RouterLink, FormsModule, BreadcrumbComponent],
-  template: `
-    <app-breadcrumb [items]="breadcrumbs" />
-
-    <div class="page-header">
-      <h1>Item-Liste</h1>
-      <span class="item-count">{{ filteredItems.length }} von {{ items.length }} Items</span>
-    </div>
-
-    <!-- Filter & Sort toolbar -->
-    @if (enableFilter || enableSort) {
-      <div class="toolbar">
-        @if (enableFilter) {
-          <input
-            class="filter-input"
-            [(ngModel)]="filterText"
-            placeholder="🔍 Items filtern..."
-            (input)="applyFilter()"
-          />
-          @if (hasMeanTaskDifficulty) {
-            <input
-              class="filter-input difficulty-filter"
-              [(ngModel)]="meanTaskDifficultyFilter"
-              placeholder="Mittlere Schwierigkeit: Min..Max"
-              (input)="applyFilter()"
-            />
-          }
-        }
-        @if (enableSort) {
-          <select [(ngModel)]="sortField" (change)="applySort()" class="sort-select">
-            <option value="itemId">Item-ID</option>
-            <option value="unitId">Aufgabe</option>
-            <option value="name">Name</option>
-            @if (hasMeanTaskDifficulty) {
-              <option value="meanTaskDifficulty">Mittlere Aufgabenschwierigkeit</option>
-            }
-          </select>
-          <button class="btn btn-sm btn-outline" (click)="toggleSortDir()">
-            {{ sortDir === 'asc' ? '↑ A-Z' : '↓ Z-A' }}
-          </button>
-        }
-      </div>
-    }
-
-    <div class="card">
-      <table class="table">
-        <thead>
-          <tr>
-            <th (click)="sortBy('itemId')" class="sortable">
-              Item-ID {{ sortField === 'itemId' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
-            </th>
-            <th (click)="sortBy('unitId')" class="sortable">
-              Aufgabe {{ sortField === 'unitId' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
-            </th>
-            <th (click)="sortBy('name')" class="sortable">
-              Name {{ sortField === 'name' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
-            </th>
-            <th>Quellvariable</th>
-            @if (hasMeanTaskDifficulty) {
-              <th (click)="sortBy('meanTaskDifficulty')" class="sortable">
-                Mittlere Aufgabenschwierigkeit
-                {{ sortField === 'meanTaskDifficulty' ? (sortDir === 'asc' ? '↑' : '↓') : '' }}
-              </th>
-            }
-            @if (enableTags) {
-              <th>Tags</th>
-            }
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          @for (item of filteredItems; track item.rowKey || item.itemId) {
-            <tr [class.clickable]="enableClick" (click)="enableClick && navigateToItem(item)">
-              <td>
-                <code>{{ item.itemId }}</code>
-              </td>
-              <td>{{ item.unitName || item.unitId }}</td>
-              <td>{{ item.name || '–' }}</td>
-              <td>
-                <code>{{ item.sourceVariable || '–' }}</code>
-              </td>
-              @if (hasMeanTaskDifficulty) {
-                <td>{{ item.meanTaskDifficulty ?? '' }}</td>
-              }
-              @if (enableTags) {
-                <td class="tags-cell" (click)="$event.stopPropagation()">
-                  @for (tag of itemTags[item.itemId] || []; track tag) {
-                    <span
-                      class="badge badge-info tag-badge"
-                      (click)="removeItemTag(item.itemId, tag)"
-                      >{{ tag }} ✕</span
-                    >
-                  }
-                  <select class="tag-select" (change)="addItemTag(item.itemId, $event)">
-                    <option value="">+Tag</option>
-                    @for (tag of availableTags; track tag) {
-                      <option [value]="tag">{{ tag }}</option>
-                    }
-                  </select>
-                </td>
-              }
-              <td>
-                @if (enableClick) {
-                  <a
-                    [routerLink]="['/view', acpId, 'item', item.itemId]"
-                    class="btn btn-sm btn-outline"
-                    (click)="$event.stopPropagation()"
-                    >Ansehen</a
-                  >
-                } @else {
-                  <a
-                    [routerLink]="['/view', acpId, 'unit', item.unitId]"
-                    class="btn btn-sm btn-outline"
-                    (click)="$event.stopPropagation()"
-                    >Aufgabe</a
-                  >
-                }
-              </td>
-            </tr>
-          }
-        </tbody>
-      </table>
-    </div>
-  `,
-  styles: [
-    `
-      .item-count {
-        font-size: 0.85rem;
-        color: var(--color-text-secondary);
-      }
-      .filter-input {
-        padding: 8px 12px;
-        border: 1px solid var(--color-border);
-        border-radius: var(--radius);
-        font-size: 0.9rem;
-        min-width: 250px;
-        font-family: inherit;
-      }
-      .sort-select {
-        padding: 6px 10px;
-        border: 1px solid var(--color-border);
-        border-radius: var(--radius);
-        font-size: 0.85rem;
-        font-family: inherit;
-      }
-      .sortable {
-        cursor: pointer;
-        user-select: none;
-      }
-      .sortable:hover {
-        color: var(--color-primary-light);
-      }
-      .clickable {
-        cursor: pointer;
-      }
-      .clickable:hover td {
-        background: rgba(41, 128, 185, 0.04);
-      }
-      .tags-cell {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 4px;
-        align-items: center;
-      }
-      .tag-badge {
-        cursor: pointer;
-        font-size: 0.7rem;
-      }
-      .tag-badge:hover {
-        opacity: 0.7;
-      }
-      .tag-select {
-        padding: 2px 4px;
-        border: 1px solid var(--color-border);
-        border-radius: 4px;
-        font-size: 0.75rem;
-        background: white;
-      }
-    `,
-  ],
+  providers: [ItemListPreferencesService],
+  templateUrl: './item-list.component.html',
+  styleUrl: './item-list.component.scss',
 })
 export class ItemListComponent implements OnInit, OnDestroy {
   acpId = '';
-  items: any[] = [];
-  filteredItems: any[] = [];
+  items: SimpleItemListEntry[] = [];
+  filteredItems: SimpleItemListEntry[] = [];
   filterText = '';
-  sortField = 'itemId';
+  sortField: ItemListSortField = 'itemId';
   sortDir: 'asc' | 'desc' = 'asc';
   meanTaskDifficultyFilter = '';
   hasMeanTaskDifficulty = false;
   breadcrumbs: BreadcrumbItem[] = [];
 
-  // Feature flags
   enableFilter = true;
   enableSort = true;
   enableClick = true;
@@ -209,22 +35,16 @@ export class ItemListComponent implements OnInit, OnDestroy {
   availableTags: string[] = [];
   itemTags: Record<string, string[]> = {};
   persistUserPreferences = false;
-  useServerPreferences = false;
 
-  private readonly preferenceViewId = 'item-list';
-  private readonly serverPreferenceDebounceMs = 250;
-  private pendingServerUiPreferences: Record<string, unknown> = {};
-  private pendingServerTagPreferences: Record<string, string[]> = {};
-  private serverSaveTimeout: ReturnType<typeof setTimeout> | null = null;
-  private itemListLoaded = false;
+  private readonly destroy$ = new Subject<void>();
 
   constructor(
-    private route: ActivatedRoute,
-    private api: ApiService,
-    private auth: AuthService,
+    private readonly route: ActivatedRoute,
+    private readonly api: ApiService,
+    private readonly preferences: ItemListPreferencesService,
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.acpId = this.route.snapshot.paramMap.get('acpId') || '';
     this.breadcrumbs = [
       { label: 'Assessment Content Pool', route: ['/'] },
@@ -232,330 +52,167 @@ export class ItemListComponent implements OnInit, OnDestroy {
       { label: 'Item-Liste' },
     ];
 
-    // Load feature config
-    this.api.getAcpStartPage(this.acpId).subscribe((data) => {
-      const fc = data?.featureConfig || {};
-      this.enableFilter = fc.enableItemListFilter !== false;
-      this.enableSort = fc.enableItemListSort !== false;
-      this.enableClick = fc.enableItemClick !== false;
-      this.enableTags = !!fc.enableItemListTags;
-      this.availableTags = fc.availableTags || [];
-      this.persistUserPreferences = !!fc.persistUserPreferences;
-      this.useServerPreferences = this.persistUserPreferences && this.auth.isLoggedIn;
-      this.loadPreferences();
-    });
+    this.api
+      .getAcpStartPage(this.acpId)
+      .pipe(
+        switchMap((data) => {
+          const featureConfig = data?.featureConfig || {};
+          this.enableFilter = featureConfig.enableItemListFilter !== false;
+          this.enableSort = featureConfig.enableItemListSort !== false;
+          this.enableClick = featureConfig.enableItemClick !== false;
+          this.enableTags = featureConfig.enableItemListTags === true;
+          this.availableTags = Array.isArray(featureConfig.availableTags)
+            ? featureConfig.availableTags
+            : [];
+          this.persistUserPreferences = featureConfig.persistUserPreferences === true;
 
-    this.api.getViewItems(this.acpId).subscribe((items) => {
-      this.items = items;
-      this.itemListLoaded = true;
-      this.hasMeanTaskDifficulty = items.some(
-        (item) => item.meanTaskDifficulty !== undefined && item.meanTaskDifficulty !== null,
-      );
-      this.reconcileMeanTaskDifficultyPreferences();
-      this.filteredItems = [...items];
-      this.applyFilter(false);
-    });
+          return forkJoin({
+            items: this.api.getViewItems(this.acpId),
+            preferences: this.preferences.load({
+              acpId: this.acpId,
+              persist: this.persistUserPreferences,
+              enableTags: this.enableTags,
+            }),
+          });
+        }),
+        takeUntil(this.destroy$),
+      )
+      .subscribe(({ items, preferences }) => this.initializeViewState(items, preferences));
   }
 
-  ngOnDestroy() {
-    if (this.serverSaveTimeout) {
-      clearTimeout(this.serverSaveTimeout);
-      this.serverSaveTimeout = null;
-    }
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
-  applyFilter(shouldPersist = true) {
+  applyFilter(shouldPersist = true): void {
     const term = this.filterText.toLowerCase();
-    this.filteredItems = this.items.filter((i) => {
+    this.filteredItems = this.items.filter((item) => {
       const matchesText =
-        i.itemId.toLowerCase().includes(term) ||
-        (i.name || '').toLowerCase().includes(term) ||
-        (i.unitId || '').toLowerCase().includes(term) ||
-        (i.unitName || '').toLowerCase().includes(term);
+        item.itemId.toLowerCase().includes(term) ||
+        (item.name || '').toLowerCase().includes(term) ||
+        item.unitId.toLowerCase().includes(term) ||
+        item.unitName.toLowerCase().includes(term);
       if (!matchesText) return false;
       if (!this.meanTaskDifficultyFilter) return true;
       return (
-        typeof i.meanTaskDifficulty === 'number' &&
-        matchesNumericFilter(i.meanTaskDifficulty, this.meanTaskDifficultyFilter)
+        typeof item.meanTaskDifficulty === 'number' &&
+        matchesNumericFilter(item.meanTaskDifficulty, this.meanTaskDifficultyFilter)
       );
     });
     this.applySort(false);
-    if (shouldPersist) {
-      this.saveUiPreferences();
-    }
+    if (shouldPersist) this.savePreferences();
   }
 
-  sortBy(field: string) {
+  sortBy(field: ItemListSortField): void {
     if (this.sortField === field) {
       this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
     } else {
       this.sortField = field;
       this.sortDir = 'asc';
     }
-
     this.applySort(false);
-    this.saveUiPreferences();
+    this.savePreferences();
   }
 
-  toggleSortDir() {
+  toggleSortDir(): void {
     this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
     this.applySort(false);
-    this.saveUiPreferences();
+    this.savePreferences();
   }
 
-  applySort(shouldPersist = true) {
-    this.filteredItems.sort((a, b) => {
-      const aVal = a[this.sortField];
-      const bVal = b[this.sortField];
-      const aMissing = aVal === undefined || aVal === null || aVal === '';
-      const bMissing = bVal === undefined || bVal === null || bVal === '';
-      if (aMissing !== bMissing) return aMissing ? 1 : -1;
-      const cmp =
-        typeof aVal === 'number' && typeof bVal === 'number'
-          ? aVal - bVal
-          : String(aVal || '').localeCompare(String(bVal || ''), undefined, { numeric: true });
-      return this.sortDir === 'asc' ? cmp : -cmp;
+  applySort(shouldPersist = true): void {
+    this.filteredItems.sort((left, right) => {
+      const leftValue = left[this.sortField];
+      const rightValue = right[this.sortField];
+      const leftMissing = leftValue === undefined || leftValue === null || leftValue === '';
+      const rightMissing = rightValue === undefined || rightValue === null || rightValue === '';
+      if (leftMissing !== rightMissing) return leftMissing ? 1 : -1;
+      const comparison =
+        typeof leftValue === 'number' && typeof rightValue === 'number'
+          ? leftValue - rightValue
+          : String(leftValue || '').localeCompare(String(rightValue || ''), undefined, {
+              numeric: true,
+            });
+      return this.sortDir === 'asc' ? comparison : -comparison;
     });
-
-    if (shouldPersist) {
-      this.saveUiPreferences();
-    }
+    if (shouldPersist) this.savePreferences();
   }
 
-  navigateToItem(_item: any) {
-    // Navigation handled by routerLink in template
+  navigateToItem(_item: SimpleItemListEntry): void {
+    // Navigation is handled by the routerLink in the template.
   }
 
-  addItemTag(itemId: string, event: Event) {
-    const tag = (event.target as HTMLSelectElement).value;
+  addItemTag(itemId: string, event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    const tag = select.value;
     if (!tag) return;
 
-    if (!this.itemTags[itemId]) this.itemTags[itemId] = [];
-    if (!this.itemTags[itemId].includes(tag)) {
-      this.itemTags[itemId].push(tag);
-      this.saveTagPreferences();
+    const currentTags = this.itemTags[itemId] || [];
+    if (!currentTags.includes(tag)) {
+      this.itemTags = { ...this.itemTags, [itemId]: [...currentTags, tag] };
+      this.savePreferences();
       this.applyFilter(false);
     }
-
-    (event.target as HTMLSelectElement).value = '';
+    select.value = '';
   }
 
-  removeItemTag(itemId: string, tag: string) {
-    if (this.itemTags[itemId]) {
-      this.itemTags[itemId] = this.itemTags[itemId].filter((t) => t !== tag);
-      this.saveTagPreferences();
-      this.applyFilter(false);
-    }
-  }
-
-  private getUiPreferencesKey(): string {
-    const userId = this.auth.currentUser?.id || 'anonymous';
-    return `cp:item-list:prefs:${this.acpId}:${userId}`;
-  }
-
-  private loadUiPreferences() {
-    const raw = localStorage.getItem(this.getUiPreferencesKey());
-    if (!raw) return;
-
-    this.applyUiPreferences(this.parseJsonObject(raw));
-  }
-
-  private saveUiPreferences() {
-    if (!this.persistUserPreferences) {
-      return;
-    }
-
-    const ui = this.buildUiPreferences();
-    if (this.useServerPreferences) {
-      this.pendingServerUiPreferences = ui;
-      this.scheduleServerPreferenceSave();
-      return;
-    }
-
-    localStorage.setItem(this.getUiPreferencesKey(), JSON.stringify(ui));
-  }
-
-  private getTagPreferencesKey(): string {
-    const userId = this.auth.currentUser?.id || 'anonymous';
-    return `cp:item-list:tags:${this.acpId}:${userId}`;
-  }
-
-  private loadTagPreferences() {
-    const raw = localStorage.getItem(this.getTagPreferencesKey());
-    if (!raw) return;
-
-    this.itemTags = this.normalizeTags(this.parseJsonObject(raw));
-  }
-
-  private saveTagPreferences() {
-    const normalizedTags = this.normalizeTags(this.itemTags);
-    this.itemTags = normalizedTags;
-
-    if (!this.persistUserPreferences) {
-      return;
-    }
-
-    if (this.useServerPreferences) {
-      this.pendingServerTagPreferences = normalizedTags;
-      this.scheduleServerPreferenceSave();
-      return;
-    }
-
-    localStorage.setItem(this.getTagPreferencesKey(), JSON.stringify(normalizedTags));
-  }
-
-  private loadPreferences() {
-    if (!this.persistUserPreferences) {
-      this.itemTags = {};
-      this.applyFilter(false);
-      return;
-    }
-
-    if (this.useServerPreferences) {
-      this.api.getViewItemPreferences(this.acpId, this.preferenceViewId).subscribe({
-        next: (preferences) => {
-          this.applyUiPreferences(preferences?.ui);
-          this.itemTags = this.normalizeTags(preferences?.tags);
-          this.pendingServerUiPreferences = this.buildUiPreferences();
-          this.pendingServerTagPreferences = this.normalizeTags(this.itemTags);
-          this.applyFilter(false);
-        },
-        error: () => {
-          this.loadUiPreferences();
-          if (this.enableTags) {
-            this.loadTagPreferences();
-          }
-          this.applyFilter(false);
-        },
-      });
-      return;
-    }
-
-    this.loadUiPreferences();
-    if (this.enableTags) {
-      this.loadTagPreferences();
-    }
+  removeItemTag(itemId: string, tag: string): void {
+    if (!this.itemTags[itemId]) return;
+    this.itemTags = {
+      ...this.itemTags,
+      [itemId]: this.itemTags[itemId].filter((candidate) => candidate !== tag),
+    };
+    this.savePreferences();
     this.applyFilter(false);
   }
 
-  private scheduleServerPreferenceSave() {
-    if (this.serverSaveTimeout) {
-      clearTimeout(this.serverSaveTimeout);
-    }
+  private initializeViewState(
+    items: SimpleItemListEntry[],
+    preferences: ItemListPreferences,
+  ): void {
+    this.items = items;
+    this.hasMeanTaskDifficulty = items.some((item) => item.meanTaskDifficulty !== undefined);
 
-    this.serverSaveTimeout = setTimeout(() => {
-      this.serverSaveTimeout = null;
-      this.api
-        .saveViewItemPreferences(
-          this.acpId,
-          {
-            ui: this.pendingServerUiPreferences,
-            tags: this.pendingServerTagPreferences,
-          },
-          this.preferenceViewId,
-        )
-        .subscribe({
-          next: (savedPreferences) => {
-            this.pendingServerUiPreferences = this.isObject(savedPreferences?.ui)
-              ? savedPreferences.ui
-              : this.pendingServerUiPreferences;
-            this.pendingServerTagPreferences = this.normalizeTags(savedPreferences?.tags);
-            this.itemTags = this.pendingServerTagPreferences;
-          },
-          error: (err) => {
-            console.error('Failed to persist item list preferences', err);
-          },
-        });
-    }, this.serverPreferenceDebounceMs);
+    const reconciledUi = this.reconcileUiPreferences(preferences.ui);
+    this.applyUiPreferences(reconciledUi);
+    this.itemTags = preferences.tags;
+    this.filteredItems = [...items];
+    this.applyFilter(false);
+
+    if (reconciledUi !== preferences.ui) {
+      this.savePreferences();
+    }
   }
 
-  private buildUiPreferences(): Record<string, unknown> {
+  private reconcileUiPreferences(ui: ItemListUiPreferences): ItemListUiPreferences {
+    if (this.hasMeanTaskDifficulty) return ui;
+    if (!ui.meanTaskDifficultyFilter && ui.sortField !== 'meanTaskDifficulty') return ui;
+
     return {
-      filterText: this.filterText,
-      meanTaskDifficultyFilter: this.meanTaskDifficultyFilter,
-      sortField: this.sortField,
-      sortDir: this.sortDir,
+      ...ui,
+      meanTaskDifficultyFilter: '',
+      sortField: ui.sortField === 'meanTaskDifficulty' ? 'itemId' : ui.sortField,
     };
   }
 
-  private applyUiPreferences(rawUi: unknown) {
-    if (!this.isObject(rawUi)) return;
-
-    const filterText = rawUi['filterText'];
-    const sortField = rawUi['sortField'];
-    const sortDir = rawUi['sortDir'];
-    const meanTaskDifficultyFilter = rawUi['meanTaskDifficultyFilter'];
-
-    if (typeof filterText === 'string') {
-      this.filterText = filterText;
-    }
-
-    if (
-      typeof sortField === 'string' &&
-      ['itemId', 'unitId', 'name', 'meanTaskDifficulty'].includes(sortField)
-    ) {
-      this.sortField = sortField;
-    }
-
-    if (typeof meanTaskDifficultyFilter === 'string') {
-      this.meanTaskDifficultyFilter = meanTaskDifficultyFilter;
-    }
-
-    this.sortDir = sortDir === 'desc' ? 'desc' : 'asc';
-    this.reconcileMeanTaskDifficultyPreferences();
+  private applyUiPreferences(ui: ItemListUiPreferences): void {
+    this.filterText = ui.filterText;
+    this.meanTaskDifficultyFilter = ui.meanTaskDifficultyFilter;
+    this.sortField = ui.sortField;
+    this.sortDir = ui.sortDir;
   }
 
-  private reconcileMeanTaskDifficultyPreferences(): void {
-    if (!this.itemListLoaded || this.hasMeanTaskDifficulty) return;
-
-    let preferencesChanged = false;
-    if (this.meanTaskDifficultyFilter) {
-      this.meanTaskDifficultyFilter = '';
-      preferencesChanged = true;
-    }
-    if (this.sortField === 'meanTaskDifficulty') {
-      this.sortField = 'itemId';
-      preferencesChanged = true;
-    }
-    if (preferencesChanged) {
-      this.saveUiPreferences();
-    }
-  }
-
-  private parseJsonObject(raw: string): Record<string, unknown> {
-    try {
-      const parsed = JSON.parse(raw);
-      return this.isObject(parsed) ? parsed : {};
-    } catch {
-      return {};
-    }
-  }
-
-  private normalizeTags(rawTags: unknown): Record<string, string[]> {
-    if (!this.isObject(rawTags)) {
-      return {};
-    }
-
-    const tags: Record<string, string[]> = {};
-    for (const [itemId, values] of Object.entries(rawTags)) {
-      const normalizedItemId = String(itemId || '').trim();
-      if (!normalizedItemId || !Array.isArray(values)) continue;
-
-      const normalizedValues = Array.from(
-        new Set(
-          values.map((value) => String(value || '').trim()).filter((value) => value.length > 0),
-        ),
-      );
-
-      if (normalizedValues.length) {
-        tags[normalizedItemId] = normalizedValues;
-      }
-    }
-
-    return tags;
-  }
-
-  private isObject(value: unknown): value is Record<string, any> {
-    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  private savePreferences(): void {
+    const normalized = this.preferences.save({
+      ui: {
+        filterText: this.filterText,
+        meanTaskDifficultyFilter: this.meanTaskDifficultyFilter,
+        sortField: this.sortField,
+        sortDir: this.sortDir,
+      },
+      tags: this.itemTags,
+    });
+    this.itemTags = normalized.tags;
   }
 }

--- a/frontend/src/app/views/item-list/item-list.models.ts
+++ b/frontend/src/app/views/item-list/item-list.models.ts
@@ -1,0 +1,13 @@
+export type ItemListSortField = 'itemId' | 'unitId' | 'name' | 'meanTaskDifficulty';
+
+export interface ItemListUiPreferences extends Record<string, unknown> {
+  filterText: string;
+  meanTaskDifficultyFilter: string;
+  sortField: ItemListSortField;
+  sortDir: 'asc' | 'desc';
+}
+
+export interface ItemListPreferences {
+  ui: ItemListUiPreferences;
+  tags: Record<string, string[]>;
+}

--- a/scripts/run-browser-e2e.sh
+++ b/scripts/run-browser-e2e.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATABASE_CONTAINER="content-pool-browser-e2e-$$"
+DATABASE_PORT="${BROWSER_E2E_DATABASE_PORT:-55432}"
+USE_EXISTING_DATABASE="${BROWSER_E2E_USE_EXISTING_DATABASE:-false}"
+
+export NODE_ENV=test
+export DB_HOST=127.0.0.1
+export DB_PORT="$DATABASE_PORT"
+export DB_USERNAME=contentpool
+export DB_PASSWORD=contentpool_dev
+export DB_DATABASE=contentpool_e2e
+export DB_SYNCHRONIZE=true
+export DB_RUN_MIGRATIONS=false
+export JWT_SECRET=browser-e2e-secret-at-least-32-characters
+export PORT=3100
+export CORS_ORIGIN=http://127.0.0.1:4300
+export BROWSER_E2E_BACKEND_PORT=3100
+export BROWSER_E2E_FRONTEND_PORT=4300
+
+cleanup() {
+  if [[ "$USE_EXISTING_DATABASE" != "true" ]]; then
+    docker stop "$DATABASE_CONTAINER" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$USE_EXISTING_DATABASE" != "true" ]]; then
+  command -v docker >/dev/null 2>&1 || {
+    echo "Docker is required to start the isolated browser E2E database." >&2
+    exit 1
+  }
+  docker run --rm -d \
+    --name "$DATABASE_CONTAINER" \
+    -e POSTGRES_DB="$DB_DATABASE" \
+    -e POSTGRES_USER="$DB_USERNAME" \
+    -e POSTGRES_PASSWORD="$DB_PASSWORD" \
+    -p "$DATABASE_PORT:5432" \
+    postgres:16-alpine >/dev/null
+
+  database_ready=false
+  for _attempt in $(seq 1 30); do
+    if docker exec "$DATABASE_CONTAINER" \
+      pg_isready -U "$DB_USERNAME" -d "$DB_DATABASE" >/dev/null 2>&1; then
+      database_ready=true
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$database_ready" != "true" ]]; then
+    echo "The isolated browser E2E database did not become ready." >&2
+    exit 1
+  fi
+fi
+
+(cd "$REPOSITORY_ROOT/frontend" && npx playwright install chromium)
+(cd "$REPOSITORY_ROOT/backend" && npm run test:e2e:seed-browser)
+(cd "$REPOSITORY_ROOT/frontend" && npm run e2e:playwright)


### PR DESCRIPTION
## What changed

- adds a typed `SimpleItemListEntryDto` and a pure index-item projection
- reduces the simple item list lookup to one mean value per item
- consumes parser-provided `meanTaskDifficulty` directly in personal XLSX and CSV exports
- documents the typed list response in Swagger

## Why

The parser already owns mean task difficulty calculation. Recomputing it during export and carrying full parser rows into the simple list duplicated business logic and made UI/API/export divergence possible.

## Impact

The public route and export shapes remain compatible. Missing means stay optional in JSON and empty in exports; partial-credit rows still contribute individually while the simple list keeps one row per index item.

## Validation

- `npm test -- --runInBand items/mean-task-difficulty.spec.ts views/simple-item-list-projection.spec.ts item-explorer/item-export-projection.spec.ts views/views.service.spec.ts`
- `npm run build`
- `npx prettier --check "src/**/*.ts" "test/**/*.ts"`
