### PR TITLE
Automate item list browser acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,64 @@ jobs:
       - run: npm ci
       - run: npm run test -- --watch=false --browsers=ChromeHeadless || npx vitest run
 
+  browser-e2e:
+    name: Browser E2E
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: contentpool_e2e
+          POSTGRES_USER: contentpool
+          POSTGRES_PASSWORD: contentpool_dev
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U contentpool -d contentpool_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      NODE_ENV: test
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: contentpool
+      DB_PASSWORD: contentpool_dev
+      DB_DATABASE: contentpool_e2e
+      DB_SYNCHRONIZE: true
+      DB_RUN_MIGRATIONS: false
+      JWT_SECRET: ci-test-secret-at-least-32-characters
+      CORS_ORIGIN: http://127.0.0.1:4200
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: |
+            backend/package-lock.json
+            frontend/package-lock.json
+      - run: npm ci
+        working-directory: backend
+      - run: npm ci
+        working-directory: frontend
+      - run: npx playwright install --with-deps chromium
+        working-directory: frontend
+      - run: npm run test:e2e:seed-browser
+        working-directory: backend
+      - run: npm run e2e
+        working-directory: frontend
+      - name: Upload Playwright diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-diagnostics
+          path: |
+            frontend/playwright-report
+            frontend/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
   backend-build:
     name: Backend Build Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,6 @@ jobs:
       DB_SYNCHRONIZE: true
       DB_RUN_MIGRATIONS: false
       JWT_SECRET: ci-test-secret-at-least-32-characters
-      CORS_ORIGIN: http://127.0.0.1:4200
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -163,10 +162,11 @@ jobs:
         working-directory: frontend
       - run: npx playwright install --with-deps chromium
         working-directory: frontend
-      - run: npm run test:e2e:seed-browser
-        working-directory: backend
       - run: npm run e2e
         working-directory: frontend
+        env:
+          BROWSER_E2E_USE_EXISTING_DATABASE: true
+          BROWSER_E2E_DATABASE_PORT: 5432
       - name: Upload Playwright diagnostics
         if: failure()
         uses: actions/upload-artifact@v4

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e:seed-browser": "ts-node -r tsconfig-paths/register test/browser-e2e/seed.ts",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
     "typeorm:dist": "node ./node_modules/typeorm/cli.js",
     "migration:generate": "npm run typeorm -- migration:generate -d src/database/data-source.ts",

--- a/backend/test/browser-e2e/seed.ts
+++ b/backend/test/browser-e2e/seed.ts
@@ -1,0 +1,201 @@
+import { NestFactory } from "@nestjs/core";
+import { mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { DataSource } from "typeorm";
+import * as bcrypt from "bcryptjs";
+import { AppModule } from "../../src/app.module";
+import {
+  AccessModel,
+  Acp,
+  AcpAccessConfig,
+  AcpCredential,
+  AcpFile,
+  AcpItemExplorerState,
+  AcpRole,
+  AcpUserRole,
+  User,
+} from "../../src/database/entities";
+
+const ACP_ID = "10000000-0000-4000-8000-000000000001";
+const MANAGER_ID = "10000000-0000-4000-8000-000000000002";
+const MANAGER_USERNAME = "e2e-manager";
+const MANAGER_PASSWORD = "Manager-E2E-123!";
+const CREDENTIAL_USERNAME = "e2e-reviewer";
+const CREDENTIAL_PASSWORD = "Reviewer-E2E-123!";
+
+async function seed(): Promise<void> {
+  const database = process.env.DB_DATABASE || "";
+  if (
+    process.env.NODE_ENV !== "test" ||
+    !database.toLowerCase().includes("e2e")
+  ) {
+    throw new Error(
+      "Browser E2E fixtures require NODE_ENV=test and a DB_DATABASE containing 'e2e'.",
+    );
+  }
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: false,
+  });
+  try {
+    const dataSource = app.get(DataSource);
+    await dataSource.synchronize(true);
+
+    const itemProperties = {
+      "item-uuid-1": { empiricalDifficulty: -0.5 },
+      "item-uuid-2": { empiricalDifficulty: 0.5 },
+    };
+    const acp = await dataSource.getRepository(Acp).save(
+      dataSource.getRepository(Acp).create({
+        id: ACP_ID,
+        packageId: "browser-e2e-package",
+        name: "Browser E2E ACP",
+        description: "Isolated Playwright fixture",
+        acpIndex: {
+          version: "0.5.0",
+          packageId: "browser-e2e-package",
+          assessmentParts: [
+            {
+              id: "part-1",
+              name: "Teil 1",
+              units: [
+                {
+                  id: "u1",
+                  name: "Aufgabe 1",
+                  items: [
+                    { id: "i1", name: "Item 1", sourceVariable: "V1" },
+                    { id: "i2", name: "Item 2", sourceVariable: "V2" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        itemProperties,
+        settings: {},
+      }),
+    );
+
+    const manager = await dataSource.getRepository(User).save(
+      dataSource.getRepository(User).create({
+        id: MANAGER_ID,
+        username: MANAGER_USERNAME,
+        passwordHash: await bcrypt.hash(MANAGER_PASSWORD, 4),
+        displayName: "E2E Manager",
+        isAppAdmin: false,
+      }),
+    );
+    await dataSource.getRepository(AcpUserRole).save(
+      dataSource.getRepository(AcpUserRole).create({
+        userId: manager.id,
+        acpId: acp.id,
+        role: AcpRole.ACP_MANAGER,
+      }),
+    );
+
+    const accessConfig = await dataSource.getRepository(AcpAccessConfig).save(
+      dataSource.getRepository(AcpAccessConfig).create({
+        acpId: acp.id,
+        accessModel: AccessModel.CREDENTIALS_LIST,
+        allowRegistered: false,
+        featureConfig: {
+          enableItemList: true,
+          enableItemListFilter: true,
+          enableItemListSort: true,
+          enableItemClick: true,
+          persistUserPreferences: true,
+        },
+      }),
+    );
+    await dataSource.getRepository(AcpCredential).save(
+      dataSource.getRepository(AcpCredential).create({
+        accessConfigId: accessConfig.id,
+        username: CREDENTIAL_USERNAME,
+        passwordHash: await bcrypt.hash(CREDENTIAL_PASSWORD, 4),
+      }),
+    );
+
+    const sharedState = {
+      ui: {},
+      tags: {},
+      metadataColumns: { visible: [], order: [] },
+      itemOrder: [],
+      itemProperties,
+    };
+    await dataSource.getRepository(AcpItemExplorerState).save(
+      dataSource.getRepository(AcpItemExplorerState).create({
+        acpId: acp.id,
+        publishedState: sharedState,
+        draftState: sharedState,
+        status: "CLEAN",
+        version: 1,
+        publishedVersion: 1,
+      }),
+    );
+
+    const fixtureDirectory =
+      process.env.BROWSER_E2E_FIXTURE_DIR || "/tmp/content-pool-browser-e2e";
+    await mkdir(fixtureDirectory, { recursive: true });
+    const unitXml = `<?xml version="1.0" encoding="UTF-8"?>
+<Unit>
+  <Id>u1</Id>
+  <Label>Aufgabe 1</Label>
+  <Description>Browser E2E Unit</Description>
+  <DefinitionRef player="iqb-player-aspect@2.11">u1.voud</DefinitionRef>
+  <Reference>u1.vomd</Reference>
+</Unit>`;
+    const itemMetadata = JSON.stringify({
+      profiles: [],
+      items: [
+        {
+          id: "i1",
+          uuid: "item-uuid-1",
+          description: "Item 1",
+          variableId: "V1",
+          useUnitAliasAsPrefix: true,
+          profiles: [],
+        },
+        {
+          id: "i2",
+          uuid: "item-uuid-2",
+          description: "Item 2",
+          variableId: "V2",
+          useUnitAliasAsPrefix: true,
+          profiles: [],
+        },
+      ],
+    });
+    const files = [
+      { name: "u1.xml", content: unitXml, type: "UNIT_XML" },
+      { name: "u1.vomd", content: itemMetadata, type: "ITEM_METADATA" },
+    ];
+    for (const file of files) {
+      const filePath = join(fixtureDirectory, file.name);
+      await writeFile(filePath, file.content, "utf8");
+      await dataSource.getRepository(AcpFile).save(
+        dataSource.getRepository(AcpFile).create({
+          acpId: acp.id,
+          filePath,
+          originalName: file.name,
+          fileType: file.type,
+          fileSize: Buffer.byteLength(file.content),
+        }),
+      );
+    }
+
+    process.stdout.write(
+      JSON.stringify({
+        acpId: ACP_ID,
+        managerUsername: MANAGER_USERNAME,
+        credentialUsername: CREDENTIAL_USERNAME,
+      }) + "\n",
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+void seed().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -40,18 +40,17 @@ The frontend uses Vitest for tests and Angular ESLint tooling for lint checks.
 ### Full-stack browser tests
 
 The Playwright suite runs Chromium against the real Angular frontend, NestJS backend, and an
-isolated PostgreSQL database. Seed the dedicated E2E database from `backend/` and then run from
-`frontend/`:
+isolated PostgreSQL database. From the repository root, run:
 
 ```bash
-(cd backend && npm run test:e2e:seed-browser)
 (cd frontend && npm run e2e)
 ```
 
-The seed command refuses to run unless `NODE_ENV=test` and `DB_DATABASE` contains `e2e`. The
-Playwright configuration starts both application servers and retains trace, screenshot, and video
-diagnostics only for failed tests. CI performs the database setup and browser installation
-automatically.
+The wrapper starts a disposable PostgreSQL container, seeds it, and uses dedicated ports for both
+application servers. The seed and Playwright configuration refuse non-E2E database settings, and
+existing application servers are never reused. Trace, screenshot, and video diagnostics are kept
+only for failed tests. CI supplies its own isolated PostgreSQL service and performs browser
+installation automatically.
 
 ## What to Test for Common Change Types
 

--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -37,6 +37,22 @@ npm run lint
 
 The frontend uses Vitest for tests and Angular ESLint tooling for lint checks.
 
+### Full-stack browser tests
+
+The Playwright suite runs Chromium against the real Angular frontend, NestJS backend, and an
+isolated PostgreSQL database. Seed the dedicated E2E database from `backend/` and then run from
+`frontend/`:
+
+```bash
+(cd backend && npm run test:e2e:seed-browser)
+(cd frontend && npm run e2e)
+```
+
+The seed command refuses to run unless `NODE_ENV=test` and `DB_DATABASE` contains `e2e`. The
+Playwright configuration starts both application servers and retains trace, screenshot, and video
+diagnostics only for failed tests. CI performs the database setup and browser installation
+automatically.
+
 ## What to Test for Common Change Types
 
 ### Authentication or access changes

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,6 +34,8 @@ yarn-error.log
 .sass-cache/
 /connect.lock
 /coverage
+/playwright-report
+/test-results
 /libpeerconnection.log
 testem.log
 /typings

--- a/frontend/e2e/item-list-preferences.spec.ts
+++ b/frontend/e2e/item-list-preferences.spec.ts
@@ -1,0 +1,163 @@
+import { expect, Page, test } from '@playwright/test';
+
+const ACP_ID = '10000000-0000-4000-8000-000000000001';
+const MANAGER_USERNAME = 'e2e-manager';
+const MANAGER_PASSWORD = 'Manager-E2E-123!';
+const CREDENTIAL_USERNAME = 'e2e-reviewer';
+const CREDENTIAL_PASSWORD = 'Reviewer-E2E-123!';
+
+async function publishExplorerDraft(page: Page): Promise<void> {
+  const saveButton = page.getByRole('button', { name: /Speichern/ });
+  await expect(saveButton).toBeEnabled();
+  await saveButton.click();
+  await expect(
+    page.getByRole('heading', { name: 'Änderungsübersicht vor Speichern' }),
+  ).toBeVisible();
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/item-explorer/draft/save') &&
+        response.ok(),
+    ),
+    page.getByRole('button', { name: 'Veröffentlichen' }).click(),
+  ]);
+}
+
+async function loginWithCredential(page: Page): Promise<void> {
+  await page.goto(`/credential-login/${ACP_ID}`);
+  await page.getByLabel('Benutzername').fill(CREDENTIAL_USERNAME);
+  await page.getByLabel('Kennwort').fill(CREDENTIAL_PASSWORD);
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().endsWith('/api/auth/credential-login') &&
+        response.ok(),
+    ),
+    page.getByRole('button', { name: 'Zugang öffnen' }).click(),
+  ]);
+  await expect(page).toHaveURL(new RegExp(`/view/${ACP_ID}`));
+}
+
+test('reconciles mean filters across clear, reimport, reload and credential relogin', async ({
+  browser,
+  page,
+  request,
+}) => {
+  await loginWithCredential(page);
+  await page.goto(`/view/${ACP_ID}/items`);
+
+  const meanFilter = page.getByPlaceholder('Mittlere Schwierigkeit: Min..Max');
+  await expect(meanFilter).toBeVisible();
+  await expect(
+    page.getByRole('columnheader', { name: /Mittlere Aufgabenschwierigkeit/ }),
+  ).toBeVisible();
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        response.url().includes('/items/preferences') &&
+        response.ok(),
+    ),
+    meanFilter.fill('-0.1..0.1'),
+  ]);
+  await expect(page.locator('tbody tr')).toHaveCount(2);
+  await page.reload();
+  await expect(meanFilter).toHaveValue('-0.1..0.1');
+
+  const managerLogin = await request.post('/api/auth/login', {
+    data: { username: MANAGER_USERNAME, password: MANAGER_PASSWORD },
+  });
+  expect(managerLogin.ok()).toBeTruthy();
+  const managerToken = (await managerLogin.json()).accessToken as string;
+  const managerContext = await browser.newContext();
+  await managerContext.addInitScript((token) => {
+    localStorage.setItem('cp_token', token);
+    localStorage.setItem('cp_auth_type', 'local');
+  }, managerToken);
+  const managerPage = await managerContext.newPage();
+
+  await managerPage.goto(`/view/${ACP_ID}/item-explorer`);
+  await expect(managerPage.getByRole('heading', { name: 'Item-Explorer' })).toBeVisible();
+  await managerPage.getByRole('button', { name: /Werte bereinigen/ }).click();
+  await Promise.all([
+    managerPage.waitForResponse(
+      (response) =>
+        response.request().method() === 'DELETE' &&
+        response.url().includes('/empirical-difficulty') &&
+        response.ok(),
+    ),
+    managerPage.getByRole('button', { name: 'Alle Werte entfernen' }).click(),
+  ]);
+  await publishExplorerDraft(managerPage);
+
+  const preferenceCleanup = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PUT' &&
+      response.url().includes('/items/preferences') &&
+      response.ok(),
+  );
+  await page.reload();
+  await preferenceCleanup;
+  await expect(page.getByPlaceholder('Mittlere Schwierigkeit: Min..Max')).toBeHidden();
+  await expect(
+    page.getByRole('columnheader', { name: /Mittlere Aufgabenschwierigkeit/ }),
+  ).toBeHidden();
+
+  const credentialToken = await page.evaluate(() => localStorage.getItem('cp_token'));
+  expect(credentialToken).toBeTruthy();
+  const cleanedPreferences = await request.get(
+    `/api/view/acp/${ACP_ID}/items/preferences?viewId=item-list`,
+    { headers: { Authorization: `Bearer ${credentialToken}` } },
+  );
+  expect(cleanedPreferences.ok()).toBeTruthy();
+  expect((await cleanedPreferences.json()).ui).toMatchObject({
+    meanTaskDifficultyFilter: '',
+    sortField: 'itemId',
+  });
+
+  const uploadInput = managerPage.locator('input[type="file"][accept=".csv"]');
+  await Promise.all([
+    managerPage.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/upload-item-parameters') &&
+        response.ok(),
+    ),
+    uploadInput.setInputFiles({
+      name: 'difficulty.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from('item;est\ni1;0.2\ni2;0.8'),
+    }),
+  ]);
+  await expect(managerPage.getByRole('heading', { name: 'Upload Bericht' })).toBeVisible();
+  await managerPage.getByRole('button', { name: /Schließen/ }).click();
+  await publishExplorerDraft(managerPage);
+
+  await page.reload();
+  const restoredMeanFilter = page.getByPlaceholder('Mittlere Schwierigkeit: Min..Max');
+  await expect(restoredMeanFilter).toBeVisible();
+  await expect(restoredMeanFilter).toHaveValue('');
+  await expect(page.getByText('0.5', { exact: true })).toHaveCount(2);
+
+  await page.getByRole('button', { name: 'Abmelden' }).click();
+  await expect(page).toHaveURL(/\/login/);
+  await loginWithCredential(page);
+  await page.goto(`/view/${ACP_ID}/items`);
+  await expect(page.getByPlaceholder('Mittlere Schwierigkeit: Min..Max')).toHaveValue('');
+  await expect(page.getByText('0.5', { exact: true })).toHaveCount(2);
+
+  const reloginToken = await page.evaluate(() => localStorage.getItem('cp_token'));
+  const persistedPreferences = await request.get(
+    `/api/view/acp/${ACP_ID}/items/preferences?viewId=item-list`,
+    { headers: { Authorization: `Bearer ${reloginToken}` } },
+  );
+  expect(persistedPreferences.ok()).toBeTruthy();
+  expect((await persistedPreferences.json()).ui).toMatchObject({
+    meanTaskDifficultyFilter: '',
+    sortField: 'itemId',
+  });
+
+  await managerContext.close();
+});

--- a/frontend/e2e/proxy.conf.json
+++ b/frontend/e2e/proxy.conf.json
@@ -1,10 +1,10 @@
 {
   "/api": {
-    "target": "http://127.0.0.1:3000",
+    "target": "http://127.0.0.1:3100",
     "secure": false
   },
   "/assets/GeoGebra": {
-    "target": "http://127.0.0.1:3000",
+    "target": "http://127.0.0.1:3100",
     "secure": false
   }
 }

--- a/frontend/e2e/proxy.conf.json
+++ b/frontend/e2e/proxy.conf.json
@@ -1,0 +1,10 @@
+{
+  "/api": {
+    "target": "http://127.0.0.1:3000",
+    "secure": false
+  },
+  "/assets/GeoGebra": {
+    "target": "http://127.0.0.1:3000",
+    "secure": false
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "@angular/cli": "^21.2.7",
         "@angular/compiler-cli": "^21.2.7",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.61.1",
         "@vitest/coverage-v8": "^4.1.2",
         "angular-eslint": "21.3.1",
         "eslint": "^10.0.3",
@@ -3517,6 +3518,22 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.4",
@@ -8795,6 +8812,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "vitest",
+    "e2e": "playwright test",
     "lint": "ng lint"
   },
   "private": true,
@@ -33,6 +34,7 @@
     "@angular/cli": "^21.2.7",
     "@angular/compiler-cli": "^21.2.7",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.61.1",
     "@vitest/coverage-v8": "^4.1.2",
     "angular-eslint": "21.3.1",
     "eslint": "^10.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "vitest",
-    "e2e": "playwright test",
+    "e2e": "../scripts/run-browser-e2e.sh",
+    "e2e:playwright": "playwright test",
     "lint": "ng lint"
   },
   "private": true,

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,20 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const backendPort = 3100;
+const frontendPort = 4300;
+const databaseName = process.env['DB_DATABASE'] || '';
+
+if (process.env['NODE_ENV'] !== 'test' || !databaseName.toLowerCase().includes('e2e')) {
+  throw new Error('Run browser tests through `npm run e2e` to use the isolated E2E environment.');
+}
+if (
+  process.env['PORT'] !== String(backendPort) ||
+  process.env['BROWSER_E2E_BACKEND_PORT'] !== String(backendPort) ||
+  process.env['BROWSER_E2E_FRONTEND_PORT'] !== String(frontendPort)
+) {
+  throw new Error('Browser E2E tests require the dedicated backend and frontend ports.');
+}
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -8,7 +23,7 @@ export default defineConfig({
   expect: { timeout: 10_000 },
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
-    baseURL: 'http://127.0.0.1:4200',
+    baseURL: `http://127.0.0.1:${frontendPort}`,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -23,15 +38,15 @@ export default defineConfig({
     {
       command: 'npm run start',
       cwd: '../backend',
-      url: 'http://127.0.0.1:3000/api/health/live',
-      reuseExistingServer: !process.env.CI,
+      url: `http://127.0.0.1:${backendPort}/api/health/live`,
+      reuseExistingServer: false,
       timeout: 120_000,
     },
     {
-      command: 'npm start -- --host 127.0.0.1 --port 4200 --proxy-config e2e/proxy.conf.json',
+      command: `npm start -- --host 127.0.0.1 --port ${frontendPort} --proxy-config e2e/proxy.conf.json`,
       cwd: '.',
-      url: 'http://127.0.0.1:4200',
-      reuseExistingServer: !process.env.CI,
+      url: `http://127.0.0.1:${frontendPort}`,
+      reuseExistingServer: false,
       timeout: 120_000,
     },
   ],

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:4200',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command: 'npm run start',
+      cwd: '../backend',
+      url: 'http://127.0.0.1:3000/api/health/live',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+    {
+      command: 'npm start -- --host 127.0.0.1 --port 4200 --proxy-config e2e/proxy.conf.json',
+      cwd: '.',
+      url: 'http://127.0.0.1:4200',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/scripts/run-browser-e2e.sh
+++ b/scripts/run-browser-e2e.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATABASE_CONTAINER="content-pool-browser-e2e-$$"
+DATABASE_PORT="${BROWSER_E2E_DATABASE_PORT:-55432}"
+USE_EXISTING_DATABASE="${BROWSER_E2E_USE_EXISTING_DATABASE:-false}"
+
+export NODE_ENV=test
+export DB_HOST=127.0.0.1
+export DB_PORT="$DATABASE_PORT"
+export DB_USERNAME=contentpool
+export DB_PASSWORD=contentpool_dev
+export DB_DATABASE=contentpool_e2e
+export DB_SYNCHRONIZE=true
+export DB_RUN_MIGRATIONS=false
+export JWT_SECRET=browser-e2e-secret-at-least-32-characters
+export PORT=3100
+export CORS_ORIGIN=http://127.0.0.1:4300
+export BROWSER_E2E_BACKEND_PORT=3100
+export BROWSER_E2E_FRONTEND_PORT=4300
+
+cleanup() {
+  if [[ "$USE_EXISTING_DATABASE" != "true" ]]; then
+    docker stop "$DATABASE_CONTAINER" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$USE_EXISTING_DATABASE" != "true" ]]; then
+  command -v docker >/dev/null 2>&1 || {
+    echo "Docker is required to start the isolated browser E2E database." >&2
+    exit 1
+  }
+  docker run --rm -d \
+    --name "$DATABASE_CONTAINER" \
+    -e POSTGRES_DB="$DB_DATABASE" \
+    -e POSTGRES_USER="$DB_USERNAME" \
+    -e POSTGRES_PASSWORD="$DB_PASSWORD" \
+    -p "$DATABASE_PORT:5432" \
+    postgres:16-alpine >/dev/null
+
+  database_ready=false
+  for _attempt in $(seq 1 30); do
+    if docker exec "$DATABASE_CONTAINER" \
+      pg_isready -U "$DB_USERNAME" -d "$DB_DATABASE" >/dev/null 2>&1; then
+      database_ready=true
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$database_ready" != "true" ]]; then
+    echo "The isolated browser E2E database did not become ready." >&2
+    exit 1
+  fi
+fi
+
+(cd "$REPOSITORY_ROOT/frontend" && npx playwright install chromium)
+(cd "$REPOSITORY_ROOT/backend" && npm run test:e2e:seed-browser)
+(cd "$REPOSITORY_ROOT/frontend" && npm run e2e:playwright)


### PR DESCRIPTION
## What changed

- adds Playwright Chromium infrastructure for full-stack browser acceptance tests
- adds a guarded fixture CLI for an isolated PostgreSQL E2E database
- automates credential login, mean filtering, clear/publish, reload, CSV reimport/publish, logout/relogin, and server preference verification
- adds a GitHub Actions browser job with failure-only trace, screenshot, video, and report artifacts
- documents the local full-stack test workflow

## Why

The response-order and persistence regressions were found through manual browser acceptance. Component tests cannot fully cover real authentication, draft publication, parser data, browser storage, and server preference persistence together.

## Impact

No production endpoint or schema is added. The fixture reset refuses to run unless `NODE_ENV=test` and the database name contains `e2e`. Chromium runs with one worker against the real Angular, NestJS, and PostgreSQL stack.

## Validation

- real local PostgreSQL + fixture seed + `npm run e2e`: 1 passed
- backend: 598 tests, build, ESLint, Prettier
- frontend: 437 tests, build, lint, Prettier
- `npx playwright test --list`

## Stack

Depends on #75, which depends on #74.
