### PR TITLE
Validate UUID routes and harden ACP file mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Application admins can create, inspect and revoke integration tokens in the UI u
 
 ### Core Endpoints
 
+- `GET /api/server/capabilities`: Inspect the authenticated token's scopes and ACP restriction without addressing an ACP
 - `GET /api/server/acp`: List transferable ACPs
 - `GET /api/server/acp/:acpId`: Full transfer payload (index + files metadata)
 - `GET /api/server/acp/:acpId/export`: Alias for full transfer payload
@@ -304,6 +305,12 @@ Tokens can be scoped per integration client. Supported scopes:
 - `files.read`
 - `files.write`
 - `audit.read`
+
+`GET /api/server/capabilities` requires a valid integration token but no
+particular scope. It returns the token's granted `scopes`, a capability map for
+all supported scopes, and its `allowedAcpIds` restriction. Integrations should
+use this endpoint for connection and permission checks instead of probing an
+ACP route with a synthetic ID.
 
 ## OIDC / Keycloak Integration
 

--- a/backend/src/acp/acp.controller.ts
+++ b/backend/src/acp/acp.controller.ts
@@ -14,6 +14,7 @@ import {
   Header,
   Logger,
   ForbiddenException,
+  UsePipes,
 } from "@nestjs/common";
 import {
   ArrayNotEmpty,
@@ -50,6 +51,7 @@ import { Roles } from "../auth/roles.decorator";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
 import { AdminService } from "../admin/admin.service";
 import { ALL_SERVER_API_SCOPES } from "../api/server-api-scopes";
+import { UuidRouteParamsPipe } from "../common/uuid-param";
 
 class CreateAcpApplicationTokenDto {
   @ApiProperty({ description: "Human-readable application name" })
@@ -78,6 +80,7 @@ class CreateAcpApplicationTokenDto {
 @ApiTags("ACP Management")
 @Controller("acp")
 @UseGuards(JwtAuthGuard)
+@UsePipes(new UuidRouteParamsPipe())
 @ApiBearerAuth()
 export class AcpController {
   private readonly logger = new Logger(AcpController.name);

--- a/backend/src/acp/acp.controller.ts
+++ b/backend/src/acp/acp.controller.ts
@@ -6,7 +6,6 @@ import {
   Patch,
   Delete,
   Body,
-  Param,
   Query,
   UseGuards,
   Request,
@@ -14,7 +13,6 @@ import {
   Header,
   Logger,
   ForbiddenException,
-  UsePipes,
 } from "@nestjs/common";
 import {
   ArrayNotEmpty,
@@ -51,7 +49,7 @@ import { Roles } from "../auth/roles.decorator";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
 import { AdminService } from "../admin/admin.service";
 import { ALL_SERVER_API_SCOPES } from "../api/server-api-scopes";
-import { UuidRouteParamsPipe } from "../common/uuid-param";
+import { UuidParam } from "../common/uuid-param";
 
 class CreateAcpApplicationTokenDto {
   @ApiProperty({ description: "Human-readable application name" })
@@ -80,7 +78,6 @@ class CreateAcpApplicationTokenDto {
 @ApiTags("ACP Management")
 @Controller("acp")
 @UseGuards(JwtAuthGuard)
-@UsePipes(new UuidRouteParamsPipe())
 @ApiBearerAuth()
 export class AcpController {
   private readonly logger = new Logger(AcpController.name);
@@ -104,7 +101,7 @@ export class AcpController {
   @UseGuards(RolesGuard)
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Get ACP by ID" })
-  async findOne(@Param("id") id: string) {
+  async findOne(@UuidParam("id") id: string) {
     return this.acpService.findById(id);
   }
 
@@ -122,7 +119,7 @@ export class AcpController {
   @ApiOperation({
     summary: "Update ACP name/description (ACP Manager or Admin only)",
   })
-  async update(@Param("id") id: string, @Body() dto: UpdateAcpDto) {
+  async update(@UuidParam("id") id: string, @Body() dto: UpdateAcpDto) {
     return this.acpService.update(id, dto);
   }
 
@@ -130,7 +127,7 @@ export class AcpController {
   @UseGuards(RolesGuard)
   @Roles("APP_ADMIN")
   @ApiOperation({ summary: "Delete ACP (Admin only)" })
-  async delete(@Param("id") id: string) {
+  async delete(@UuidParam("id") id: string) {
     return this.acpService.delete(id);
   }
 
@@ -139,7 +136,7 @@ export class AcpController {
   @UseGuards(RolesGuard)
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Get ACP-Index" })
-  async getIndex(@Param("id") id: string) {
+  async getIndex(@UuidParam("id") id: string) {
     return this.acpService.getIndex(id);
   }
 
@@ -148,7 +145,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Update ACP-Index" })
   async updateIndex(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() index: Record<string, unknown>,
   ) {
     return this.acpService.updateIndex(id, index);
@@ -159,7 +156,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Import ACP-Index from JSON (replaces existing)" })
   async importIndex(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() index: Record<string, unknown>,
   ) {
     return this.acpService.importIndex(id, index);
@@ -169,7 +166,7 @@ export class AcpController {
   @UseGuards(RolesGuard)
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Reset ACP-Index to defaults" })
-  async deleteIndex(@Param("id") id: string) {
+  async deleteIndex(@UuidParam("id") id: string) {
     return this.acpService.deleteIndex(id);
   }
 
@@ -178,7 +175,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @Header("Content-Type", "application/json")
   @ApiOperation({ summary: "Export ACP-Index as JSON file download" })
-  async exportIndex(@Param("id") id: string, @Res() res: Response) {
+  async exportIndex(@UuidParam("id") id: string, @Res() res: Response) {
     const index = await this.acpService.getIndex(id);
     res.setHeader(
       "Content-Disposition",
@@ -193,7 +190,7 @@ export class AcpController {
   @ApiOperation({
     summary: "List users that can be assigned read access by ACP managers",
   })
-  async getAssignableUsers(@Param("id") id: string) {
+  async getAssignableUsers(@UuidParam("id") id: string) {
     return this.acpService.getAssignableUsers(id);
   }
 
@@ -202,7 +199,7 @@ export class AcpController {
   @UseGuards(RolesGuard)
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "List role assignments for ACP" })
-  async getRoles(@Param("id") id: string) {
+  async getRoles(@UuidParam("id") id: string) {
     return this.acpService.getRoles(id);
   }
 
@@ -213,7 +210,7 @@ export class AcpController {
     summary: "Assign user role for ACP (ACP Manager can assign READ_ONLY only)",
   })
   async assignRole(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() dto: AssignRoleDto,
     @Request() req: any,
   ) {
@@ -233,8 +230,8 @@ export class AcpController {
     summary: "Remove user role for ACP (ACP Manager can remove READ_ONLY only)",
   })
   async removeRole(
-    @Param("id") id: string,
-    @Param("userId") userId: string,
+    @UuidParam("id") id: string,
+    @UuidParam("userId") userId: string,
     @Request() req: any,
   ) {
     // If user is not App Admin, check if they're removing an ACP_MANAGER role (which is forbidden)
@@ -255,7 +252,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "List application tokens limited to this ACP" })
   async listApplicationTokens(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Query("limit") limit?: string,
     @Query("offset") offset?: string,
   ) {
@@ -271,7 +268,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Create an application token limited to this ACP" })
   async createApplicationToken(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() dto: CreateAcpApplicationTokenDto,
     @Request() req: any,
   ) {
@@ -296,8 +293,8 @@ export class AcpController {
     summary: "Revoke an application token exclusively limited to this ACP",
   })
   async revokeApplicationToken(
-    @Param("id") id: string,
-    @Param("tokenId") tokenId: string,
+    @UuidParam("id") id: string,
+    @UuidParam("tokenId") tokenId: string,
     @Request() req: any,
   ) {
     return this.adminService.revokeApplicationToken(tokenId, req?.user?.sub, {
@@ -313,7 +310,7 @@ export class AcpController {
   @UseGuards(RolesGuard)
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Get access configuration for ACP" })
-  async getAccessConfig(@Param("id") id: string) {
+  async getAccessConfig(@UuidParam("id") id: string) {
     return this.acpService.getAccessConfig(id);
   }
 
@@ -322,7 +319,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Update access configuration for ACP" })
   async updateAccessConfig(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() dto: UpdateAccessConfigDto,
   ) {
     return this.acpService.updateAccessConfig(id, dto);
@@ -333,7 +330,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Upload credentials list for ACP" })
   async uploadCredentials(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Query("mode") mode: "replace" | "append" | "upsert" = "replace",
     @Body() dto: UploadCredentialsDto,
   ) {
@@ -352,7 +349,7 @@ export class AcpController {
   @UseGuards(RolesGuard)
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Get credentials list for ACP" })
-  async getCredentials(@Param("id") id: string) {
+  async getCredentials(@UuidParam("id") id: string) {
     return this.acpService.getCredentials(id);
   }
 
@@ -361,8 +358,8 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Delete a credential from ACP" })
   async deleteCredential(
-    @Param("id") id: string,
-    @Param("credentialId") credentialId: string,
+    @UuidParam("id") id: string,
+    @UuidParam("credentialId") credentialId: string,
   ) {
     await this.acpService.deleteCredential(id, credentialId);
     return { message: "Credential deleted successfully" };
@@ -373,7 +370,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Create a single credential for ACP" })
   async createCredential(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() dto: CreateCredentialDto,
   ) {
     return this.acpService.createCredential(id, dto);
@@ -384,8 +381,8 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Update a credential" })
   async updateCredential(
-    @Param("id") id: string,
-    @Param("credentialId") credentialId: string,
+    @UuidParam("id") id: string,
+    @UuidParam("credentialId") credentialId: string,
     @Body() dto: UpdateCredentialDto,
   ) {
     return this.acpService.updateCredential(id, credentialId, dto);
@@ -398,7 +395,7 @@ export class AcpController {
     summary: "Update metadata column visibility and order (ACP Manager only)",
   })
   async updateMetadataColumns(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() dto: UpdateMetadataColumnsDto,
     @Request() req: any,
   ) {
@@ -431,7 +428,7 @@ export class AcpController {
     summary: "Patch Item Explorer draft state (ACP Manager or Admin)",
   })
   async patchItemExplorerDraft(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() dto: PatchItemExplorerDraftDto,
     @Request() req: any,
   ) {
@@ -452,7 +449,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Publish Item Explorer draft state" })
   async saveItemExplorerDraft(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() dto: VersionedItemExplorerActionDto,
     @Request() req: any,
   ) {
@@ -470,7 +467,7 @@ export class AcpController {
     summary: "Discard Item Explorer draft state and reset to published",
   })
   async discardItemExplorerDraft(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body() dto: VersionedItemExplorerActionDto,
     @Request() req: any,
   ) {
@@ -486,7 +483,7 @@ export class AcpController {
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "List Item Explorer change log entries" })
   async getItemExplorerChanges(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Query("limit") limit?: string,
   ) {
     const parsedLimit = parseInt(limit || "", 10);

--- a/backend/src/acp/dto/acp.dto.ts
+++ b/backend/src/acp/dto/acp.dto.ts
@@ -10,6 +10,7 @@ import {
   Matches,
   IsInt,
   Min,
+  IsUUID,
 } from "class-validator";
 import { Type } from "class-transformer";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
@@ -50,8 +51,7 @@ export class UpdateAcpDto {
 
 export class AssignRoleDto {
   @ApiProperty()
-  @IsString()
-  @IsNotEmpty()
+  @IsUUID("all")
   userId!: string;
 
   @ApiProperty({ enum: ["ACP_MANAGER", "READ_ONLY"] })

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -3,9 +3,7 @@ import {
   Controller,
   Delete,
   Get,
-  Param,
   Patch,
-  ParseUUIDPipe,
   Post,
   Put,
   Query,
@@ -38,6 +36,7 @@ import { OidcAuthGuard } from "../auth/guards/oidc-auth.guard";
 import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { ALL_SERVER_API_SCOPES } from "../api/server-api-scopes";
+import { UuidParam } from "../common/uuid-param";
 
 class CreateApplicationTokenDto {
   @ApiProperty({ description: "Human-readable application name" })
@@ -69,7 +68,7 @@ class CreateApplicationTokenDto {
   })
   @IsOptional()
   @IsArray()
-  @IsUUID("4", { each: true })
+  @IsUUID("all", { each: true })
   allowedAcpIds?: string[] | null;
 }
 
@@ -118,10 +117,7 @@ export class AdminController {
 
   @Patch("application-tokens/:id/revoke")
   @ApiOperation({ summary: "Revoke an application token" })
-  async revokeApplicationToken(
-    @Param("id", new ParseUUIDPipe({ version: "4" })) id: string,
-    @Req() req: any,
-  ) {
+  async revokeApplicationToken(@UuidParam("id") id: string, @Req() req: any) {
     return this.adminService.revokeApplicationToken(id, req?.user?.sub);
   }
 

--- a/backend/src/api/dto/server-api-capabilities.dto.ts
+++ b/backend/src/api/dto/server-api-capabilities.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { ALL_SERVER_API_SCOPES, ServerApiScope } from "../server-api-scopes";
+import { ServerApiCapabilities } from "../server-api.types";
+
+export class ServerApiCapabilitiesDto implements ServerApiCapabilities {
+  @ApiProperty({ example: "coding-box" })
+  clientId!: string;
+
+  @ApiProperty({ enum: ALL_SERVER_API_SCOPES, isArray: true })
+  scopes!: string[];
+
+  @ApiProperty({
+    type: "object",
+    additionalProperties: { type: "boolean" },
+  })
+  capabilities!: Record<ServerApiScope, boolean>;
+
+  @ApiProperty({
+    type: "array",
+    items: { type: "string", format: "uuid" },
+    nullable: true,
+  })
+  allowedAcpIds!: string[] | null;
+}

--- a/backend/src/api/server-api-audit.interceptor.spec.ts
+++ b/backend/src/api/server-api-audit.interceptor.spec.ts
@@ -3,13 +3,19 @@ import { Reflector } from "@nestjs/core";
 import { lastValueFrom, of, throwError } from "rxjs";
 import { SERVER_API_AUDIT_KEY } from "./server-api-audit.decorator";
 import { ServerApiAuditInterceptor } from "./server-api-audit.interceptor";
+import { ServerApiRequest } from "./server-api.types";
+import { Response } from "express";
+import { createServerApiRequest } from "../testing/test-fixtures";
 
 describe("ServerApiAuditInterceptor", () => {
   let interceptor: ServerApiAuditInterceptor;
   let reflector: { getAllAndOverride: jest.Mock };
   let auditService: { log: jest.Mock };
 
-  const createContext = (req: any, res: any): ExecutionContext =>
+  const createContext = (
+    req: Partial<ServerApiRequest>,
+    res: Partial<Response>,
+  ): ExecutionContext =>
     ({
       switchToHttp: () => ({
         getRequest: () => req,
@@ -56,13 +62,12 @@ describe("ServerApiAuditInterceptor", () => {
       resourceType: "file",
     });
 
-    const req = {
-      serverApiClient: { id: "client-1" },
+    const req = Object.assign(createServerApiRequest({ id: "client-1" }), {
       method: "GET",
       originalUrl: "/server/acp/acp-1/files/file-1",
       params: { acpId: "acp-1", fileId: "file-1" },
       query: { verbose: "1" },
-    };
+    });
     const res = { statusCode: 200 };
 
     const next: CallHandler = {
@@ -91,13 +96,12 @@ describe("ServerApiAuditInterceptor", () => {
       resourceType: "file",
     });
 
-    const req = {
-      serverApiClient: { id: "client-2" },
+    const req = Object.assign(createServerApiRequest({ id: "client-2" }), {
       method: "POST",
       url: "/server/acp/acp-1/files/upload",
       params: { acpId: "acp-1" },
       query: {},
-    };
+    });
     const res = { statusCode: 500 };
 
     const err = new Error("boom");

--- a/backend/src/api/server-api-audit.interceptor.ts
+++ b/backend/src/api/server-api-audit.interceptor.ts
@@ -11,6 +11,8 @@ import {
   ServerApiAuditMetadata,
 } from "./server-api-audit.decorator";
 import { ServerApiAuditService } from "./server-api-audit.service";
+import { ServerApiRequest } from "./server-api.types";
+import { Response } from "express";
 
 @Injectable()
 export class ServerApiAuditInterceptor implements NestInterceptor {
@@ -29,16 +31,18 @@ export class ServerApiAuditInterceptor implements NestInterceptor {
       return next.handle();
     }
 
-    const req = context.switchToHttp().getRequest();
-    const res = context.switchToHttp().getResponse();
+    const req = context.switchToHttp().getRequest<ServerApiRequest>();
+    const res = context.switchToHttp().getResponse<Response>();
+    const acpId = this.firstParam(req.params?.acpId);
+    const fileId = this.firstParam(req.params?.fileId);
 
     const baseEntry = {
       clientId: req?.serverApiClient?.id || "unknown",
       action: auditMeta.action,
       method: req?.method || "UNKNOWN",
       path: req?.originalUrl || req?.url || "",
-      acpId: req?.params?.acpId,
-      resourceId: req?.params?.fileId || req?.params?.acpId,
+      acpId,
+      resourceId: fileId || acpId,
       details: {
         resourceType: auditMeta.resourceType,
         query: req?.query || {},
@@ -67,5 +71,9 @@ export class ServerApiAuditInterceptor implements NestInterceptor {
         return throwError(() => error);
       }),
     );
+  }
+
+  private firstParam(value: string | string[] | undefined): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
   }
 }

--- a/backend/src/api/server-api-auth.guard.spec.ts
+++ b/backend/src/api/server-api-auth.guard.spec.ts
@@ -6,13 +6,14 @@ import {
 import { Reflector } from "@nestjs/core";
 import { ServerApiAuthGuard } from "./server-api-auth.guard";
 import { SERVER_API_SCOPES_KEY } from "./server-api-scopes.decorator";
+import { ServerApiRequest } from "./server-api.types";
 
 describe("ServerApiAuthGuard", () => {
   let guard: ServerApiAuthGuard;
   let reflector: { getAllAndOverride: jest.Mock };
   let authService: { validateToken: jest.Mock; hasScopes: jest.Mock };
 
-  const createContext = (req: any): ExecutionContext =>
+  const createContext = (req: Partial<ServerApiRequest>): ExecutionContext =>
     ({
       switchToHttp: () => ({ getRequest: () => req }),
       getHandler: () => function handler() {},
@@ -72,7 +73,7 @@ describe("ServerApiAuthGuard", () => {
   });
 
   it("accepts x-server-token and enriches request with client identity", async () => {
-    const req: any = {
+    const req: Partial<ServerApiRequest> = {
       headers: { "x-server-token": "  token-a  " },
     };
 
@@ -97,7 +98,7 @@ describe("ServerApiAuthGuard", () => {
     authService.validateToken.mockResolvedValue({ id: "client-b", scopes: [] });
     authService.hasScopes.mockReturnValue(true);
 
-    const req: any = {
+    const req: Partial<ServerApiRequest> = {
       headers: { "x-integration-token": "integration-token" },
     };
     await expect(guard.canActivate(createContext(req))).resolves.toBe(true);

--- a/backend/src/api/server-api-auth.guard.ts
+++ b/backend/src/api/server-api-auth.guard.ts
@@ -8,6 +8,8 @@ import {
 import { Reflector } from "@nestjs/core";
 import { ServerApiAuthService } from "./server-api-auth.service";
 import { SERVER_API_SCOPES_KEY } from "./server-api-scopes.decorator";
+import { Request } from "express";
+import { ServerApiRequest } from "./server-api.types";
 
 @Injectable()
 export class ServerApiAuthGuard implements CanActivate {
@@ -17,7 +19,7 @@ export class ServerApiAuthGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const req = context.switchToHttp().getRequest();
+    const req = context.switchToHttp().getRequest<ServerApiRequest>();
     const token = this.extractToken(req);
     if (!token) {
       throw new UnauthorizedException("Missing server API token");
@@ -49,7 +51,7 @@ export class ServerApiAuthGuard implements CanActivate {
     return true;
   }
 
-  private extractToken(req: any): string | null {
+  private extractToken(req: Request): string | null {
     const xServerToken =
       (req.headers?.["x-server-token"] as string | undefined) ||
       (req.headers?.["x-integration-token"] as string | undefined);

--- a/backend/src/api/server-api.controller.spec.ts
+++ b/backend/src/api/server-api.controller.spec.ts
@@ -1,4 +1,5 @@
 import { ServerApiController } from "./server-api.controller";
+import { SERVER_API_SCOPES_KEY } from "./server-api-scopes.decorator";
 
 describe("ServerApiController", () => {
   let controller: ServerApiController;
@@ -76,6 +77,35 @@ describe("ServerApiController", () => {
       "acp-1",
       undefined,
     );
+  });
+
+  it("reports authenticated token scopes without requiring an ACP", () => {
+    expect(
+      Reflect.getMetadata(SERVER_API_SCOPES_KEY, controller.getCapabilities),
+    ).toEqual([]);
+    expect(
+      controller.getCapabilities({
+        serverApiClient: {
+          id: "coding-box",
+          scopes: ["acp.read", "files.read"],
+          allowedAcpIds: ["11111111-1111-4111-8111-111111111111"],
+        },
+      }),
+    ).toEqual({
+      clientId: "coding-box",
+      scopes: ["acp.read", "files.read"],
+      capabilities: {
+        "acp.read": true,
+        "transfer.read": false,
+        "transfer.write": false,
+        "index.read": false,
+        "index.write": false,
+        "files.read": true,
+        "files.write": false,
+        "audit.read": false,
+      },
+      allowedAcpIds: ["11111111-1111-4111-8111-111111111111"],
+    });
   });
 
   it("updates ACP index using strategy and optimistic timestamp", async () => {

--- a/backend/src/api/server-api.controller.spec.ts
+++ b/backend/src/api/server-api.controller.spec.ts
@@ -1,5 +1,6 @@
 import { ServerApiController } from "./server-api.controller";
 import { SERVER_API_SCOPES_KEY } from "./server-api-scopes.decorator";
+import { createServerApiRequest, TEST_UUIDS } from "../testing/test-fixtures";
 
 describe("ServerApiController", () => {
   let controller: ServerApiController;
@@ -84,13 +85,13 @@ describe("ServerApiController", () => {
       Reflect.getMetadata(SERVER_API_SCOPES_KEY, controller.getCapabilities),
     ).toEqual([]);
     expect(
-      controller.getCapabilities({
-        serverApiClient: {
+      controller.getCapabilities(
+        createServerApiRequest({
           id: "coding-box",
           scopes: ["acp.read", "files.read"],
-          allowedAcpIds: ["11111111-1111-4111-8111-111111111111"],
-        },
-      }),
+          allowedAcpIds: [TEST_UUIDS.acp],
+        }),
+      ),
     ).toEqual({
       clientId: "coding-box",
       scopes: ["acp.read", "files.read"],
@@ -104,7 +105,7 @@ describe("ServerApiController", () => {
         "files.write": false,
         "audit.read": false,
       },
-      allowedAcpIds: ["11111111-1111-4111-8111-111111111111"],
+      allowedAcpIds: [TEST_UUIDS.acp],
     });
   });
 
@@ -190,7 +191,7 @@ describe("ServerApiController", () => {
         changelog: "new scheme",
         expectedUpdatedAt: "2026-01-01T00:00:00.000Z",
       } as any,
-      { serverApiClient: { id: "sync-client" } },
+      createServerApiRequest({ id: "sync-client" }),
     );
 
     expect(result).toEqual({ replacedFiles: [] });
@@ -202,7 +203,7 @@ describe("ServerApiController", () => {
         expectedUpdatedAt: "2026-01-01T00:00:00.000Z",
         sourceClientId: "sync-client",
       },
-      undefined,
+      null,
     );
   });
 
@@ -234,9 +235,12 @@ describe("ServerApiController", () => {
 
   it("uses parsed audit limit and defaults to 100 for invalid values", async () => {
     await expect(
-      controller.getAuditLogs("50", "acp.read", "client-1", {
-        serverApiClient: { allowedAcpIds: ["acp-1"] },
-      }),
+      controller.getAuditLogs(
+        "50",
+        "acp.read",
+        "client-1",
+        createServerApiRequest({ allowedAcpIds: [TEST_UUIDS.acp] }),
+      ),
     ).resolves.toEqual([{ id: "log-1" }]);
     await expect(
       controller.getAuditLogs("NaN", undefined, undefined),
@@ -247,7 +251,7 @@ describe("ServerApiController", () => {
       50,
       "acp.read",
       "client-1",
-      ["acp-1"],
+      [TEST_UUIDS.acp],
     );
     expect(serverApiAuditService.list).toHaveBeenNthCalledWith(
       2,

--- a/backend/src/api/server-api.controller.ts
+++ b/backend/src/api/server-api.controller.ts
@@ -2,7 +2,6 @@ import {
   Body,
   Controller,
   Get,
-  Param,
   Post,
   Put,
   Query,
@@ -31,6 +30,8 @@ import { ServerApiAuthGuard } from "./server-api-auth.guard";
 import { ServerApiScopes } from "./server-api-scopes.decorator";
 import { ServerApiAudit } from "./server-api-audit.decorator";
 import { ServerApiAuditInterceptor } from "./server-api-audit.interceptor";
+import { ALL_SERVER_API_SCOPES, ServerApiScope } from "./server-api-scopes";
+import { UuidParam } from "../common/uuid-param";
 
 class ServerImportAcpDto {
   @ApiProperty()
@@ -108,6 +109,32 @@ export class ServerApiController {
     private readonly serverApiAuditService: ServerApiAuditService,
   ) {}
 
+  @Get("capabilities")
+  @ServerApiScopes()
+  @ServerApiAudit("server.capabilities.read", "server-api-client")
+  @ApiOperation({
+    summary: "Inspect the authenticated integration token capabilities",
+  })
+  getCapabilities(@Req() req: any): {
+    clientId: string;
+    scopes: string[];
+    capabilities: Record<ServerApiScope, boolean>;
+    allowedAcpIds: string[] | null;
+  } {
+    const client = req.serverApiClient;
+    const grantedScopes = new Set<string>(client.scopes);
+    const capabilities = Object.fromEntries(
+      ALL_SERVER_API_SCOPES.map((scope) => [scope, grantedScopes.has(scope)]),
+    ) as Record<ServerApiScope, boolean>;
+
+    return {
+      clientId: client.id,
+      scopes: [...client.scopes],
+      capabilities,
+      allowedAcpIds: client.allowedAcpIds,
+    };
+  }
+
   @Get("acp")
   @ServerApiScopes("acp.read")
   @ServerApiAudit("acp.list", "acp")
@@ -120,7 +147,7 @@ export class ServerApiController {
   @ServerApiScopes("transfer.read")
   @ServerApiAudit("acp.transfer.read", "acp")
   @ApiOperation({ summary: "Get full ACP transfer payload (index + files)" })
-  async getAcp(@Param("acpId") acpId: string, @Req() req?: any) {
+  async getAcp(@UuidParam("acpId") acpId: string, @Req() req?: any) {
     return this.serverApiService.getAcpTransferData(
       acpId,
       req?.serverApiClient?.allowedAcpIds,
@@ -131,7 +158,7 @@ export class ServerApiController {
   @ServerApiScopes("transfer.read")
   @ServerApiAudit("acp.transfer.export", "acp")
   @ApiOperation({ summary: "Export full ACP transfer payload (index + files)" })
-  async exportAcp(@Param("acpId") acpId: string, @Req() req?: any) {
+  async exportAcp(@UuidParam("acpId") acpId: string, @Req() req?: any) {
     return this.serverApiService.getAcpTransferData(
       acpId,
       req?.serverApiClient?.allowedAcpIds,
@@ -142,7 +169,7 @@ export class ServerApiController {
   @ServerApiScopes("index.read")
   @ServerApiAudit("acp.index.read", "acp-index")
   @ApiOperation({ summary: "Get only ACP index payload" })
-  async getAcpIndex(@Param("acpId") acpId: string, @Req() req?: any) {
+  async getAcpIndex(@UuidParam("acpId") acpId: string, @Req() req?: any) {
     return this.serverApiService.getAcpIndex(
       acpId,
       req?.serverApiClient?.allowedAcpIds,
@@ -159,7 +186,7 @@ export class ServerApiController {
     description: "overwrite | merge",
   })
   async updateAcpIndex(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() body: UpdateIndexDto,
     @Query("strategy") strategy?: string,
     @Req() req?: any,
@@ -177,7 +204,7 @@ export class ServerApiController {
   @ServerApiScopes("files.read")
   @ServerApiAudit("acp.files.list", "file")
   @ApiOperation({ summary: "List transfer-relevant file metadata for an ACP" })
-  async listFiles(@Param("acpId") acpId: string, @Req() req?: any) {
+  async listFiles(@UuidParam("acpId") acpId: string, @Req() req?: any) {
     return this.serverApiService.listFiles(
       acpId,
       req?.serverApiClient?.allowedAcpIds,
@@ -189,8 +216,8 @@ export class ServerApiController {
   @ServerApiAudit("acp.files.read", "file")
   @ApiOperation({ summary: "Get transfer metadata of one file" })
   async getFile(
-    @Param("acpId") acpId: string,
-    @Param("fileId") fileId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("fileId") fileId: string,
     @Req() req?: any,
   ) {
     return this.serverApiService.getFile(
@@ -205,8 +232,8 @@ export class ServerApiController {
   @ServerApiAudit("acp.files.download", "file")
   @ApiOperation({ summary: "Download one ACP file for transfer" })
   async downloadFile(
-    @Param("acpId") acpId: string,
-    @Param("fileId") fileId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("fileId") fileId: string,
     @Res() res: Response,
     @Req() req?: any,
   ) {
@@ -247,7 +274,7 @@ export class ServerApiController {
   })
   @UseInterceptors(FilesInterceptor("files", 100))
   async uploadFiles(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @UploadedFiles() files: Express.Multer.File[],
     @Query("conflictStrategy") conflictStrategy?: string,
     @Req() req?: any,
@@ -292,7 +319,7 @@ export class ServerApiController {
   })
   @UseInterceptors(FilesInterceptor("files", 100))
   async replaceCodingSchemes(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @UploadedFiles() files: Express.Multer.File[],
     @Body() body: ReplaceCodingSchemeDto,
     @Req() req: any,

--- a/backend/src/api/server-api.controller.ts
+++ b/backend/src/api/server-api.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiBody,
   ApiConsumes,
   ApiOperation,
+  ApiOkResponse,
   ApiProperty,
   ApiPropertyOptional,
   ApiQuery,
@@ -32,6 +33,11 @@ import { ServerApiAudit } from "./server-api-audit.decorator";
 import { ServerApiAuditInterceptor } from "./server-api-audit.interceptor";
 import { ALL_SERVER_API_SCOPES, ServerApiScope } from "./server-api-scopes";
 import { UuidParam } from "../common/uuid-param";
+import {
+  AuthenticatedServerApiRequest,
+  ServerApiCapabilities,
+} from "./server-api.types";
+import { ServerApiCapabilitiesDto } from "./dto/server-api-capabilities.dto";
 
 class ServerImportAcpDto {
   @ApiProperty()
@@ -115,12 +121,10 @@ export class ServerApiController {
   @ApiOperation({
     summary: "Inspect the authenticated integration token capabilities",
   })
-  getCapabilities(@Req() req: any): {
-    clientId: string;
-    scopes: string[];
-    capabilities: Record<ServerApiScope, boolean>;
-    allowedAcpIds: string[] | null;
-  } {
+  @ApiOkResponse({ type: ServerApiCapabilitiesDto })
+  getCapabilities(
+    @Req() req: AuthenticatedServerApiRequest,
+  ): ServerApiCapabilities {
     const client = req.serverApiClient;
     const grantedScopes = new Set<string>(client.scopes);
     const capabilities = Object.fromEntries(
@@ -139,7 +143,7 @@ export class ServerApiController {
   @ServerApiScopes("acp.read")
   @ServerApiAudit("acp.list", "acp")
   @ApiOperation({ summary: "List all ACPs for server transfer" })
-  async listAcps(@Req() req?: any) {
+  async listAcps(@Req() req?: AuthenticatedServerApiRequest) {
     return this.serverApiService.listAcps(req?.serverApiClient?.allowedAcpIds);
   }
 
@@ -147,7 +151,10 @@ export class ServerApiController {
   @ServerApiScopes("transfer.read")
   @ServerApiAudit("acp.transfer.read", "acp")
   @ApiOperation({ summary: "Get full ACP transfer payload (index + files)" })
-  async getAcp(@UuidParam("acpId") acpId: string, @Req() req?: any) {
+  async getAcp(
+    @UuidParam("acpId") acpId: string,
+    @Req() req?: AuthenticatedServerApiRequest,
+  ) {
     return this.serverApiService.getAcpTransferData(
       acpId,
       req?.serverApiClient?.allowedAcpIds,
@@ -158,7 +165,10 @@ export class ServerApiController {
   @ServerApiScopes("transfer.read")
   @ServerApiAudit("acp.transfer.export", "acp")
   @ApiOperation({ summary: "Export full ACP transfer payload (index + files)" })
-  async exportAcp(@UuidParam("acpId") acpId: string, @Req() req?: any) {
+  async exportAcp(
+    @UuidParam("acpId") acpId: string,
+    @Req() req?: AuthenticatedServerApiRequest,
+  ) {
     return this.serverApiService.getAcpTransferData(
       acpId,
       req?.serverApiClient?.allowedAcpIds,
@@ -169,7 +179,10 @@ export class ServerApiController {
   @ServerApiScopes("index.read")
   @ServerApiAudit("acp.index.read", "acp-index")
   @ApiOperation({ summary: "Get only ACP index payload" })
-  async getAcpIndex(@UuidParam("acpId") acpId: string, @Req() req?: any) {
+  async getAcpIndex(
+    @UuidParam("acpId") acpId: string,
+    @Req() req?: AuthenticatedServerApiRequest,
+  ) {
     return this.serverApiService.getAcpIndex(
       acpId,
       req?.serverApiClient?.allowedAcpIds,
@@ -189,7 +202,7 @@ export class ServerApiController {
     @UuidParam("acpId") acpId: string,
     @Body() body: UpdateIndexDto,
     @Query("strategy") strategy?: string,
-    @Req() req?: any,
+    @Req() req?: AuthenticatedServerApiRequest,
   ) {
     return this.serverApiService.updateAcpIndex(
       acpId,
@@ -204,7 +217,10 @@ export class ServerApiController {
   @ServerApiScopes("files.read")
   @ServerApiAudit("acp.files.list", "file")
   @ApiOperation({ summary: "List transfer-relevant file metadata for an ACP" })
-  async listFiles(@UuidParam("acpId") acpId: string, @Req() req?: any) {
+  async listFiles(
+    @UuidParam("acpId") acpId: string,
+    @Req() req?: AuthenticatedServerApiRequest,
+  ) {
     return this.serverApiService.listFiles(
       acpId,
       req?.serverApiClient?.allowedAcpIds,
@@ -218,7 +234,7 @@ export class ServerApiController {
   async getFile(
     @UuidParam("acpId") acpId: string,
     @UuidParam("fileId") fileId: string,
-    @Req() req?: any,
+    @Req() req?: AuthenticatedServerApiRequest,
   ) {
     return this.serverApiService.getFile(
       acpId,
@@ -235,7 +251,7 @@ export class ServerApiController {
     @UuidParam("acpId") acpId: string,
     @UuidParam("fileId") fileId: string,
     @Res() res: Response,
-    @Req() req?: any,
+    @Req() req?: AuthenticatedServerApiRequest,
   ) {
     const { buffer, file } = await this.serverApiService.downloadFile(
       acpId,
@@ -277,7 +293,7 @@ export class ServerApiController {
     @UuidParam("acpId") acpId: string,
     @UploadedFiles() files: Express.Multer.File[],
     @Query("conflictStrategy") conflictStrategy?: string,
-    @Req() req?: any,
+    @Req() req?: AuthenticatedServerApiRequest,
   ) {
     return this.serverApiService.uploadFiles(
       acpId,
@@ -322,7 +338,7 @@ export class ServerApiController {
     @UuidParam("acpId") acpId: string,
     @UploadedFiles() files: Express.Multer.File[],
     @Body() body: ReplaceCodingSchemeDto,
-    @Req() req: any,
+    @Req() req: AuthenticatedServerApiRequest,
   ) {
     return this.serverApiService.replaceCodingSchemeFiles(
       acpId,
@@ -350,7 +366,7 @@ export class ServerApiController {
   async importAcp(
     @Body() body: ServerImportAcpDto,
     @Query("conflictStrategy") conflictStrategy?: string,
-    @Req() req?: any,
+    @Req() req?: AuthenticatedServerApiRequest,
   ) {
     return this.serverApiService.receiveAcp(
       body,
@@ -373,7 +389,7 @@ export class ServerApiController {
   async receiveAcp(
     @Body() body: ServerImportAcpDto,
     @Query("conflictStrategy") conflictStrategy?: string,
-    @Req() req?: any,
+    @Req() req?: AuthenticatedServerApiRequest,
   ) {
     return this.serverApiService.receiveAcp(
       body,
@@ -390,7 +406,7 @@ export class ServerApiController {
     @Query("limit") limit?: string,
     @Query("action") action?: string,
     @Query("clientId") clientId?: string,
-    @Req() req?: any,
+    @Req() req?: AuthenticatedServerApiRequest,
   ) {
     const parsedLimit = Number.parseInt(limit || "100", 10);
     return this.serverApiAuditService.list(

--- a/backend/src/api/server-api.service.spec.ts
+++ b/backend/src/api/server-api.service.spec.ts
@@ -10,6 +10,7 @@ import { ServerApiService } from "./server-api.service";
 import { Acp, AcpFile } from "../database/entities";
 import { FilesService } from "../files/files.service";
 import { SnapshotsService } from "../snapshots/snapshots.service";
+import { TEST_UUIDS } from "../testing/test-fixtures";
 
 describe("ServerApiService", () => {
   let service: ServerApiService;
@@ -82,7 +83,7 @@ describe("ServerApiService", () => {
 
   it("rejects import when package exists and conflictStrategy=reject", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -102,7 +103,7 @@ describe("ServerApiService", () => {
 
   it("merges existing ACP index when conflictStrategy=merge", async () => {
     const existing = {
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       name: "Old",
       description: "Old Desc",
@@ -150,7 +151,7 @@ describe("ServerApiService", () => {
 
   it("throws conflict on index update when expectedUpdatedAt mismatches", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -158,7 +159,7 @@ describe("ServerApiService", () => {
 
     await expect(
       service.updateAcpIndex(
-        "11111111-1111-4111-8111-111111111111",
+        TEST_UUIDS.acp,
         { version: "0.5.0" },
         "overwrite",
         "2026-01-02T00:00:00.000Z",
@@ -168,7 +169,7 @@ describe("ServerApiService", () => {
 
   it("rejects file upload when duplicate filename exists and conflictStrategy=reject", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -177,7 +178,7 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([
       {
         id: "33333333-3333-4333-8333-333333333333",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "unit.xml",
       },
     ]);
@@ -187,7 +188,7 @@ describe("ServerApiService", () => {
 
     await expect(
       service.uploadFiles(
-        "11111111-1111-4111-8111-111111111111",
+        TEST_UUIDS.acp,
         [
           {
             originalname: "unit.xml",
@@ -203,7 +204,7 @@ describe("ServerApiService", () => {
 
   it("replaces multiple coding schemes in one batch and creates a snapshot with changelog", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -212,12 +213,12 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([
       {
         id: "33333333-3333-4333-8333-333333333333",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "UNIT-1.VOCS",
       },
       {
         id: "55555555-5555-4555-8555-555555555555",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "UNIT-2.VOCS",
       },
     ]);
@@ -225,7 +226,7 @@ describe("ServerApiService", () => {
     filesService.uploadMultiple.mockResolvedValue([
       {
         id: "44444444-4444-4444-8444-444444444444",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "UNIT-1.VOCS",
         fileType: "application/json",
         fileSize: 10,
@@ -234,7 +235,7 @@ describe("ServerApiService", () => {
       },
       {
         id: "66666666-6666-4666-8666-666666666666",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "UNIT-2.VOCS",
         fileType: "application/json",
         fileSize: 12,
@@ -251,7 +252,7 @@ describe("ServerApiService", () => {
     });
 
     const result = await service.replaceCodingSchemeFiles(
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       [
         {
           originalname: "unit-1.vocs",
@@ -275,22 +276,24 @@ describe("ServerApiService", () => {
     expect(filesService.deleteForAcp).not.toHaveBeenCalled();
     expect(filesService.uploadMultiple).toHaveBeenCalledTimes(1);
     expect(filesService.uploadMultiple).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       [
         expect.objectContaining({ originalname: "UNIT-1.VOCS" }),
         expect.objectContaining({ originalname: "UNIT-2.VOCS" }),
       ],
-      "overwrite",
-      { expandArchives: false },
+      {
+        conflictStrategy: "overwrite",
+        expandArchives: false,
+      },
     );
     expect(filesService.upload).not.toHaveBeenCalled();
     expect(
       filesService.cleanupReferencesAfterFileMutation,
-    ).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111", {
+    ).toHaveBeenCalledWith(TEST_UUIDS.acp, {
       skipValidation: true,
     });
     expect(snapshotsService.create).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       "Kodierschema aktualisiert",
     );
     expect(result.snapshot.versionNumber).toBe(7);
@@ -299,7 +302,7 @@ describe("ServerApiService", () => {
 
   it("does not delete coding schemes before a failed replacement batch", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -307,19 +310,19 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([
       {
         id: "33333333-3333-4333-8333-333333333333",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "UNIT-1.VOCS",
       },
       {
         id: "55555555-5555-4555-8555-555555555555",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "UNIT-2.VOCS",
       },
     ]);
     filesService.uploadMultiple.mockRejectedValue(new Error("upload failed"));
 
     await expect(
-      service.replaceCodingSchemeFiles("11111111-1111-4111-8111-111111111111", [
+      service.replaceCodingSchemeFiles(TEST_UUIDS.acp, [
         { originalname: "unit-1.vocs" } as Express.Multer.File,
         { originalname: "unit-2.vocs" } as Express.Multer.File,
       ]),
@@ -334,7 +337,7 @@ describe("ServerApiService", () => {
 
   it("fails replacement if coding scheme does not exist in ACP", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -342,7 +345,7 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([]);
 
     await expect(
-      service.replaceCodingSchemeFiles("11111111-1111-4111-8111-111111111111", [
+      service.replaceCodingSchemeFiles(TEST_UUIDS.acp, [
         {
           originalname: "unit-1.vocs",
           buffer: Buffer.from("{}"),
@@ -355,7 +358,7 @@ describe("ServerApiService", () => {
 
   it("fails replacement when a non-vocs file is provided", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -363,7 +366,7 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([]);
 
     await expect(
-      service.replaceCodingSchemeFiles("11111111-1111-4111-8111-111111111111", [
+      service.replaceCodingSchemeFiles(TEST_UUIDS.acp, [
         {
           originalname: "unit-1.xml",
           buffer: Buffer.from("<xml/>"),
@@ -384,7 +387,7 @@ describe("ServerApiService", () => {
         updatedAt: new Date("2026-01-03T00:00:00.000Z"),
       },
       {
-        id: "11111111-1111-4111-8111-111111111111",
+        id: TEST_UUIDS.acp,
         packageId: "pkg-1",
         name: "First",
         acpIndex: { version: "1.2.3" },
@@ -401,7 +404,7 @@ describe("ServerApiService", () => {
         updatedAt: "2026-01-03T00:00:00.000Z",
       },
       {
-        id: "11111111-1111-4111-8111-111111111111",
+        id: TEST_UUIDS.acp,
         packageId: "pkg-1",
         name: "First",
         version: "1.2.3",
@@ -413,7 +416,7 @@ describe("ServerApiService", () => {
   it("filters and enforces ACP restrictions for limited application tokens", async () => {
     acpRepository.find.mockResolvedValue([
       {
-        id: "11111111-1111-4111-8111-111111111111",
+        id: TEST_UUIDS.acp,
         packageId: "pkg-1",
         name: "First",
         acpIndex: {},
@@ -421,11 +424,9 @@ describe("ServerApiService", () => {
       },
     ]);
 
-    await expect(
-      service.listAcps(["11111111-1111-4111-8111-111111111111"]),
-    ).resolves.toEqual([
+    await expect(service.listAcps([TEST_UUIDS.acp])).resolves.toEqual([
       {
-        id: "11111111-1111-4111-8111-111111111111",
+        id: TEST_UUIDS.acp,
         packageId: "pkg-1",
         name: "First",
         version: "0.0.0",
@@ -440,14 +441,14 @@ describe("ServerApiService", () => {
 
     await expect(
       service.getAcpIndex("22222222-2222-4222-8222-222222222222", [
-        "11111111-1111-4111-8111-111111111111",
+        TEST_UUIDS.acp,
       ]),
     ).rejects.toThrow(ForbiddenException);
   });
 
   it("returns transfer payload and index payload for existing ACPs", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       name: "Demo",
       description: "desc",
@@ -457,7 +458,7 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([
       {
         id: "33333333-3333-4333-8333-333333333333",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "unit.xml",
         fileType: "text/xml",
         fileSize: 21,
@@ -466,11 +467,9 @@ describe("ServerApiService", () => {
       },
     ]);
 
-    const transfer = await service.getAcpTransferData(
-      "11111111-1111-4111-8111-111111111111",
-    );
+    const transfer = await service.getAcpTransferData(TEST_UUIDS.acp);
     expect(transfer).toEqual({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       name: "Demo",
       description: "desc",
@@ -490,11 +489,9 @@ describe("ServerApiService", () => {
       ],
     });
 
-    const index = await service.getAcpIndex(
-      "11111111-1111-4111-8111-111111111111",
-    );
+    const index = await service.getAcpIndex(TEST_UUIDS.acp);
     expect(index).toEqual({
-      acpId: "11111111-1111-4111-8111-111111111111",
+      acpId: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: "2026-01-01T00:00:00.000Z",
       acpIndex: { version: "0.5.0" },
@@ -503,16 +500,14 @@ describe("ServerApiService", () => {
 
   it("returns empty index object if ACP index is missing", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: undefined,
     });
 
-    await expect(
-      service.getAcpIndex("11111111-1111-4111-8111-111111111111"),
-    ).resolves.toEqual({
-      acpId: "11111111-1111-4111-8111-111111111111",
+    await expect(service.getAcpIndex(TEST_UUIDS.acp)).resolves.toEqual({
+      acpId: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: "2026-01-01T00:00:00.000Z",
       acpIndex: {},
@@ -521,15 +516,11 @@ describe("ServerApiService", () => {
 
   it("rejects invalid index update payload and invalid strategy values", async () => {
     await expect(
-      service.updateAcpIndex(
-        "11111111-1111-4111-8111-111111111111",
-        [] as any,
-        "overwrite",
-      ),
+      service.updateAcpIndex(TEST_UUIDS.acp, [] as any, "overwrite"),
     ).rejects.toThrow(BadRequestException);
 
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -537,7 +528,7 @@ describe("ServerApiService", () => {
 
     await expect(
       service.updateAcpIndex(
-        "11111111-1111-4111-8111-111111111111",
+        TEST_UUIDS.acp,
         { version: "0.5.0" },
         "invalid-strategy",
       ),
@@ -545,7 +536,7 @@ describe("ServerApiService", () => {
 
     await expect(
       service.updateAcpIndex(
-        "11111111-1111-4111-8111-111111111111",
+        TEST_UUIDS.acp,
         { version: "0.5.0" },
         "overwrite",
         "not-a-date",
@@ -555,7 +546,7 @@ describe("ServerApiService", () => {
 
   it("lists and reads transfer files and throws when file is missing", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -563,7 +554,7 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([
       {
         id: "33333333-3333-4333-8333-333333333333",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "unit.xml",
         fileType: "text/xml",
         fileSize: 12,
@@ -574,7 +565,7 @@ describe("ServerApiService", () => {
     fileRepository.findOne
       .mockResolvedValueOnce({
         id: "33333333-3333-4333-8333-333333333333",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "unit.xml",
         fileType: "text/xml",
         fileSize: 12,
@@ -583,14 +574,9 @@ describe("ServerApiService", () => {
       })
       .mockResolvedValueOnce(null);
 
+    await expect(service.listFiles(TEST_UUIDS.acp)).resolves.toHaveLength(1);
     await expect(
-      service.listFiles("11111111-1111-4111-8111-111111111111"),
-    ).resolves.toHaveLength(1);
-    await expect(
-      service.getFile(
-        "11111111-1111-4111-8111-111111111111",
-        "33333333-3333-4333-8333-333333333333",
-      ),
+      service.getFile(TEST_UUIDS.acp, "33333333-3333-4333-8333-333333333333"),
     ).resolves.toEqual(
       expect.objectContaining({
         id: "33333333-3333-4333-8333-333333333333",
@@ -599,22 +585,19 @@ describe("ServerApiService", () => {
       }),
     );
     await expect(
-      service.getFile(
-        "11111111-1111-4111-8111-111111111111",
-        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-      ),
+      service.getFile(TEST_UUIDS.acp, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
     ).rejects.toThrow(NotFoundException);
   });
 
   it("throws when file operations are requested for a missing ACP", async () => {
     acpRepository.findOne.mockResolvedValue(null);
 
-    await expect(
-      service.listFiles("99999999-9999-4999-8999-999999999999"),
-    ).rejects.toThrow(NotFoundException);
+    await expect(service.listFiles(TEST_UUIDS.unknownAcp)).rejects.toThrow(
+      NotFoundException,
+    );
     await expect(
       service.downloadFile(
-        "99999999-9999-4999-8999-999999999999",
+        TEST_UUIDS.unknownAcp,
         "33333333-3333-4333-8333-333333333333",
       ),
     ).rejects.toThrow(NotFoundException);
@@ -625,9 +608,7 @@ describe("ServerApiService", () => {
       service.listFiles("__coding-box-connection-test__"),
     ).rejects.toThrow(BadRequestException);
     await expect(
-      service.listFiles("__coding-box-connection-test__", [
-        "11111111-1111-4111-8111-111111111111",
-      ]),
+      service.listFiles("__coding-box-connection-test__", [TEST_UUIDS.acp]),
     ).rejects.toThrow(BadRequestException);
 
     expect(acpRepository.findOne).not.toHaveBeenCalled();
@@ -636,10 +617,7 @@ describe("ServerApiService", () => {
 
   it("returns bad request for invalid file ids before querying Postgres", async () => {
     await expect(
-      service.getFile(
-        "11111111-1111-4111-8111-111111111111",
-        "not-a-file-uuid",
-      ),
+      service.getFile(TEST_UUIDS.acp, "not-a-file-uuid"),
     ).rejects.toThrow(BadRequestException);
 
     expect(fileRepository.findOne).not.toHaveBeenCalled();
@@ -647,7 +625,7 @@ describe("ServerApiService", () => {
 
   it("downloads files through FilesService when ACP exists", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -659,7 +637,7 @@ describe("ServerApiService", () => {
 
     await expect(
       service.downloadFile(
-        "11111111-1111-4111-8111-111111111111",
+        TEST_UUIDS.acp,
         "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       ),
     ).resolves.toEqual({
@@ -667,25 +645,25 @@ describe("ServerApiService", () => {
       file: { id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" },
     });
     expect(filesService.downloadForAcp).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
     );
   });
 
   it("rejects upload requests without files or with invalid conflictStrategy", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
     });
 
-    await expect(
-      service.uploadFiles("11111111-1111-4111-8111-111111111111", []),
-    ).rejects.toThrow(BadRequestException);
+    await expect(service.uploadFiles(TEST_UUIDS.acp, [])).rejects.toThrow(
+      BadRequestException,
+    );
     await expect(
       service.uploadFiles(
-        "11111111-1111-4111-8111-111111111111",
+        TEST_UUIDS.acp,
         [{ originalname: "f.xml" } as any],
         "invalid",
       ),
@@ -694,7 +672,7 @@ describe("ServerApiService", () => {
 
   it("supports keep-both and overwrite upload conflict strategies", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -702,7 +680,7 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([
       {
         id: "55555555-5555-4555-8555-555555555555",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "unit.xml",
       },
     ]);
@@ -710,7 +688,7 @@ describe("ServerApiService", () => {
       .mockResolvedValueOnce([
         {
           id: "66666666-6666-4666-8666-666666666666",
-          acpId: "11111111-1111-4111-8111-111111111111",
+          acpId: TEST_UUIDS.acp,
           originalName: "unit.xml",
           fileType: "text/xml",
           fileSize: 10,
@@ -721,7 +699,7 @@ describe("ServerApiService", () => {
       .mockResolvedValueOnce([
         {
           id: "77777777-7777-4777-8777-777777777777",
-          acpId: "11111111-1111-4111-8111-111111111111",
+          acpId: TEST_UUIDS.acp,
           originalName: "unit.xml",
           fileType: "text/xml",
           fileSize: 11,
@@ -731,7 +709,7 @@ describe("ServerApiService", () => {
       ] as AcpFile[]);
 
     const keepBoth = await service.uploadFiles(
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       [{ originalname: "bundle.zip" } as any],
       "keep-both",
     );
@@ -743,16 +721,16 @@ describe("ServerApiService", () => {
     );
     expect(filesService.uploadMultiple).toHaveBeenNthCalledWith(
       1,
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       [{ originalname: "bundle.zip" }],
-      "keep-both",
+      { conflictStrategy: "keep-both" },
     );
     expect(
       filesService.cleanupReferencesAfterFileMutation,
     ).not.toHaveBeenCalled();
 
     const overwrite = await service.uploadFiles(
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       [{ originalname: "bundle.zip" } as any],
       "overwrite",
     );
@@ -761,27 +739,24 @@ describe("ServerApiService", () => {
     );
     expect(filesService.uploadMultiple).toHaveBeenNthCalledWith(
       2,
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       [{ originalname: "bundle.zip" }],
-      "overwrite",
+      { conflictStrategy: "overwrite" },
     );
     expect(
       filesService.cleanupReferencesAfterFileMutation,
-    ).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111", {
+    ).toHaveBeenCalledWith(TEST_UUIDS.acp, {
       skipValidation: true,
     });
   });
 
   it("validates replacement file list details before processing", async () => {
     await expect(
-      service.replaceCodingSchemeFiles(
-        "11111111-1111-4111-8111-111111111111",
-        [],
-      ),
+      service.replaceCodingSchemeFiles(TEST_UUIDS.acp, []),
     ).rejects.toThrow(BadRequestException);
 
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -789,19 +764,19 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([
       {
         id: "33333333-3333-4333-8333-333333333333",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "UNIT-1.VOCS",
       },
     ]);
 
     await expect(
-      service.replaceCodingSchemeFiles("11111111-1111-4111-8111-111111111111", [
+      service.replaceCodingSchemeFiles(TEST_UUIDS.acp, [
         { originalname: "   " } as any,
       ]),
     ).rejects.toThrow(BadRequestException);
 
     await expect(
-      service.replaceCodingSchemeFiles("11111111-1111-4111-8111-111111111111", [
+      service.replaceCodingSchemeFiles(TEST_UUIDS.acp, [
         { originalname: "unit-1.vocs" } as any,
         { originalname: "UNIT-1.VOCS" } as any,
       ]),
@@ -810,7 +785,7 @@ describe("ServerApiService", () => {
 
   it("generates default coding scheme changelog with source client suffix", async () => {
     acpRepository.findOne.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       acpIndex: {},
@@ -818,14 +793,14 @@ describe("ServerApiService", () => {
     fileRepository.find.mockResolvedValue([
       {
         id: "33333333-3333-4333-8333-333333333333",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "UNIT-1.VOCS",
       },
     ]);
     filesService.uploadMultiple.mockResolvedValue([
       {
         id: "44444444-4444-4444-8444-444444444444",
-        acpId: "11111111-1111-4111-8111-111111111111",
+        acpId: TEST_UUIDS.acp,
         originalName: "UNIT-1.VOCS",
         fileType: "application/json",
         fileSize: 10,
@@ -841,18 +816,18 @@ describe("ServerApiService", () => {
     });
 
     await service.replaceCodingSchemeFiles(
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       [{ originalname: "unit-1.vocs" } as any],
       { sourceClientId: "sync-agent" },
     );
 
     expect(snapshotsService.create).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
+      TEST_UUIDS.acp,
       "Kodierschema ersetzt via sync-agent: UNIT-1.VOCS",
     );
     expect(
       filesService.cleanupReferencesAfterFileMutation,
-    ).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111", {
+    ).toHaveBeenCalledWith(TEST_UUIDS.acp, {
       skipValidation: true,
     });
   });
@@ -913,7 +888,7 @@ describe("ServerApiService", () => {
 
   it("overwrites existing ACP index when conflictStrategy=overwrite", async () => {
     const existing = {
-      id: "11111111-1111-4111-8111-111111111111",
+      id: TEST_UUIDS.acp,
       packageId: "pkg-1",
       name: "Old",
       description: "Old",

--- a/backend/src/api/server-api.service.spec.ts
+++ b/backend/src/api/server-api.service.spec.ts
@@ -201,7 +201,7 @@ describe("ServerApiService", () => {
     ).rejects.toThrow(ConflictException);
   });
 
-  it("replaces existing coding schemes and creates a snapshot with changelog", async () => {
+  it("replaces multiple coding schemes in one batch and creates a snapshot with changelog", async () => {
     acpRepository.findOne.mockResolvedValue({
       id: "11111111-1111-4111-8111-111111111111",
       packageId: "pkg-1",
@@ -215,17 +215,33 @@ describe("ServerApiService", () => {
         acpId: "11111111-1111-4111-8111-111111111111",
         originalName: "UNIT-1.VOCS",
       },
+      {
+        id: "55555555-5555-4555-8555-555555555555",
+        acpId: "11111111-1111-4111-8111-111111111111",
+        originalName: "UNIT-2.VOCS",
+      },
     ]);
 
-    filesService.upload.mockResolvedValue({
-      id: "44444444-4444-4444-8444-444444444444",
-      acpId: "11111111-1111-4111-8111-111111111111",
-      originalName: "UNIT-1.VOCS",
-      fileType: "application/json",
-      fileSize: 10,
-      checksum: "abc",
-      uploadedAt: new Date("2026-01-02T00:00:00.000Z"),
-    });
+    filesService.uploadMultiple.mockResolvedValue([
+      {
+        id: "44444444-4444-4444-8444-444444444444",
+        acpId: "11111111-1111-4111-8111-111111111111",
+        originalName: "UNIT-1.VOCS",
+        fileType: "application/json",
+        fileSize: 10,
+        checksum: "abc",
+        uploadedAt: new Date("2026-01-02T00:00:00.000Z"),
+      },
+      {
+        id: "66666666-6666-4666-8666-666666666666",
+        acpId: "11111111-1111-4111-8111-111111111111",
+        originalName: "UNIT-2.VOCS",
+        fileType: "application/json",
+        fileSize: 12,
+        checksum: "def",
+        uploadedAt: new Date("2026-01-02T00:00:00.000Z"),
+      },
+    ]);
 
     snapshotsService.create.mockResolvedValue({
       id: "88888888-8888-4888-8888-888888888888",
@@ -243,6 +259,12 @@ describe("ServerApiService", () => {
           size: 2,
           mimetype: "application/json",
         } as Express.Multer.File,
+        {
+          originalname: "unit-2.vocs",
+          buffer: Buffer.from('{"two":true}'),
+          size: 12,
+          mimetype: "application/json",
+        } as Express.Multer.File,
       ],
       {
         changelog: "Kodierschema aktualisiert",
@@ -250,14 +272,18 @@ describe("ServerApiService", () => {
       },
     );
 
-    expect(filesService.deleteForAcp).toHaveBeenCalledWith(
+    expect(filesService.deleteForAcp).not.toHaveBeenCalled();
+    expect(filesService.uploadMultiple).toHaveBeenCalledTimes(1);
+    expect(filesService.uploadMultiple).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      "33333333-3333-4333-8333-333333333333",
+      [
+        expect.objectContaining({ originalname: "UNIT-1.VOCS" }),
+        expect.objectContaining({ originalname: "UNIT-2.VOCS" }),
+      ],
+      "overwrite",
+      { expandArchives: false },
     );
-    expect(filesService.upload).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      expect.objectContaining({ originalname: "UNIT-1.VOCS" }),
-    );
+    expect(filesService.upload).not.toHaveBeenCalled();
     expect(
       filesService.cleanupReferencesAfterFileMutation,
     ).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111", {
@@ -268,7 +294,42 @@ describe("ServerApiService", () => {
       "Kodierschema aktualisiert",
     );
     expect(result.snapshot.versionNumber).toBe(7);
-    expect(result.replacedFiles).toHaveLength(1);
+    expect(result.replacedFiles).toHaveLength(2);
+  });
+
+  it("does not delete coding schemes before a failed replacement batch", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      packageId: "pkg-1",
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      acpIndex: {},
+    });
+    fileRepository.find.mockResolvedValue([
+      {
+        id: "33333333-3333-4333-8333-333333333333",
+        acpId: "11111111-1111-4111-8111-111111111111",
+        originalName: "UNIT-1.VOCS",
+      },
+      {
+        id: "55555555-5555-4555-8555-555555555555",
+        acpId: "11111111-1111-4111-8111-111111111111",
+        originalName: "UNIT-2.VOCS",
+      },
+    ]);
+    filesService.uploadMultiple.mockRejectedValue(new Error("upload failed"));
+
+    await expect(
+      service.replaceCodingSchemeFiles("11111111-1111-4111-8111-111111111111", [
+        { originalname: "unit-1.vocs" } as Express.Multer.File,
+        { originalname: "unit-2.vocs" } as Express.Multer.File,
+      ]),
+    ).rejects.toThrow("upload failed");
+
+    expect(filesService.deleteForAcp).not.toHaveBeenCalled();
+    expect(
+      filesService.cleanupReferencesAfterFileMutation,
+    ).not.toHaveBeenCalled();
+    expect(snapshotsService.create).not.toHaveBeenCalled();
   });
 
   it("fails replacement if coding scheme does not exist in ACP", async () => {
@@ -559,13 +620,29 @@ describe("ServerApiService", () => {
     ).rejects.toThrow(NotFoundException);
   });
 
-  it("returns not found for invalid ACP ids before querying Postgres", async () => {
+  it("returns bad request for invalid ACP ids before querying Postgres", async () => {
     await expect(
       service.listFiles("__coding-box-connection-test__"),
-    ).rejects.toThrow(NotFoundException);
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      service.listFiles("__coding-box-connection-test__", [
+        "11111111-1111-4111-8111-111111111111",
+      ]),
+    ).rejects.toThrow(BadRequestException);
 
     expect(acpRepository.findOne).not.toHaveBeenCalled();
     expect(fileRepository.find).not.toHaveBeenCalled();
+  });
+
+  it("returns bad request for invalid file ids before querying Postgres", async () => {
+    await expect(
+      service.getFile(
+        "11111111-1111-4111-8111-111111111111",
+        "not-a-file-uuid",
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(fileRepository.findOne).not.toHaveBeenCalled();
   });
 
   it("downloads files through FilesService when ACP exists", async () => {
@@ -745,15 +822,17 @@ describe("ServerApiService", () => {
         originalName: "UNIT-1.VOCS",
       },
     ]);
-    filesService.upload.mockResolvedValue({
-      id: "44444444-4444-4444-8444-444444444444",
-      acpId: "11111111-1111-4111-8111-111111111111",
-      originalName: "UNIT-1.VOCS",
-      fileType: "application/json",
-      fileSize: 10,
-      checksum: "abc",
-      uploadedAt: new Date("2026-01-02T00:00:00.000Z"),
-    });
+    filesService.uploadMultiple.mockResolvedValue([
+      {
+        id: "44444444-4444-4444-8444-444444444444",
+        acpId: "11111111-1111-4111-8111-111111111111",
+        originalName: "UNIT-1.VOCS",
+        fileType: "application/json",
+        fileSize: 10,
+        checksum: "abc",
+        uploadedAt: new Date("2026-01-02T00:00:00.000Z"),
+      },
+    ]);
     snapshotsService.create.mockResolvedValue({
       id: "88888888-8888-4888-8888-888888888888",
       versionNumber: 7,

--- a/backend/src/api/server-api.service.ts
+++ b/backend/src/api/server-api.service.ts
@@ -7,10 +7,10 @@ import {
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { In, Repository } from "typeorm";
-import { validate as isUuid } from "uuid";
 import { Acp, AcpFile } from "../database/entities";
 import { FilesService } from "../files/files.service";
 import { SnapshotsService } from "../snapshots/snapshots.service";
+import { assertUuidParam } from "../common/uuid-param";
 
 export type ConflictStrategy = "reject" | "overwrite" | "merge";
 export type IndexUpdateStrategy = "overwrite" | "merge";
@@ -181,9 +181,7 @@ export class ServerApiService {
   }> {
     this.assertAcpAllowed(acpId, allowedAcpIds);
     this.assertValidAcpId(acpId);
-    if (!isUuid(fileId)) {
-      throw new NotFoundException("File not found");
-    }
+    assertUuidParam(fileId, "File ID");
 
     const file = await this.fileRepository.findOne({
       where: { id: fileId, acpId },
@@ -201,9 +199,7 @@ export class ServerApiService {
   ): Promise<{ buffer: Buffer; file: AcpFile }> {
     this.assertAcpAllowed(acpId, allowedAcpIds);
     await this.getAcpOrFail(acpId);
-    if (!isUuid(fileId)) {
-      throw new NotFoundException("File not found");
-    }
+    assertUuidParam(fileId, "File ID");
     return this.filesService.downloadForAcp(acpId, fileId);
   }
 
@@ -302,7 +298,6 @@ export class ServerApiService {
     const seenIncoming = new Set<string>();
     const replacementPlan: Array<{
       incoming: Express.Multer.File;
-      matches: AcpFile[];
       canonicalName: string;
     }> = [];
 
@@ -334,32 +329,27 @@ export class ServerApiService {
 
       replacementPlan.push({
         incoming,
-        matches,
         canonicalName: matches[0].originalName,
       });
     }
 
-    const replacedFiles: AcpFile[] = [];
-    let deletedAny = false;
-    for (const plan of replacementPlan) {
-      for (const existing of plan.matches) {
-        await this.filesService.deleteForAcp(acpId, existing.id);
-        deletedAny = true;
-      }
+    const uploadPayloads = replacementPlan.map(
+      (plan) =>
+        ({
+          ...plan.incoming,
+          originalname: plan.canonicalName,
+        }) as Express.Multer.File,
+    );
+    const replacedFiles = await this.filesService.uploadMultiple(
+      acpId,
+      uploadPayloads,
+      "overwrite",
+      { expandArchives: false },
+    );
 
-      const uploadPayload = {
-        ...plan.incoming,
-        originalname: plan.canonicalName,
-      } as Express.Multer.File;
-      const saved = await this.filesService.upload(acpId, uploadPayload);
-      replacedFiles.push(saved);
-    }
-
-    if (deletedAny) {
-      await this.filesService.cleanupReferencesAfterFileMutation(acpId, {
-        skipValidation: true,
-      });
-    }
+    await this.filesService.cleanupReferencesAfterFileMutation(acpId, {
+      skipValidation: true,
+    });
 
     const resolvedChangelog = this.resolveCodingSchemeChangelog(
       options.changelog,
@@ -475,6 +465,7 @@ export class ServerApiService {
   }
 
   private assertAcpAllowed(acpId: string, allowedAcpIds?: AllowedAcpIds): void {
+    this.assertValidAcpId(acpId);
     if (!this.isAcpRestricted(allowedAcpIds)) {
       return;
     }
@@ -500,9 +491,7 @@ export class ServerApiService {
   }
 
   private assertValidAcpId(acpId: string): void {
-    if (!isUuid(acpId)) {
-      throw new NotFoundException(`ACP with ID ${acpId} not found`);
-    }
+    assertUuidParam(acpId, "ACP ID");
   }
 
   private toTransferFileMeta(file: AcpFile): {

--- a/backend/src/api/server-api.service.ts
+++ b/backend/src/api/server-api.service.ts
@@ -233,11 +233,9 @@ export class ServerApiService {
     const existingNames = new Set(
       existingFiles.map((file) => this.normalizeFileName(file.originalName)),
     );
-    const uploaded = await this.filesService.uploadMultiple(
-      acpId,
-      files,
+    const uploaded = await this.filesService.uploadMultiple(acpId, files, {
       conflictStrategy,
-    );
+    });
     const deletedAny =
       conflictStrategy === "overwrite" &&
       uploaded.some((file) =>
@@ -343,8 +341,10 @@ export class ServerApiService {
     const replacedFiles = await this.filesService.uploadMultiple(
       acpId,
       uploadPayloads,
-      "overwrite",
-      { expandArchives: false },
+      {
+        conflictStrategy: "overwrite",
+        expandArchives: false,
+      },
     );
 
     await this.filesService.cleanupReferencesAfterFileMutation(acpId, {

--- a/backend/src/api/server-api.types.ts
+++ b/backend/src/api/server-api.types.ts
@@ -1,0 +1,23 @@
+import { Request } from "express";
+import { ServerApiScope } from "./server-api-scopes";
+
+export interface AuthenticatedServerApiClient {
+  id: string;
+  scopes: string[];
+  allowedAcpIds: string[] | null;
+}
+
+export interface ServerApiRequest extends Request {
+  serverApiClient?: AuthenticatedServerApiClient;
+}
+
+export interface AuthenticatedServerApiRequest extends Request {
+  serverApiClient: AuthenticatedServerApiClient;
+}
+
+export interface ServerApiCapabilities {
+  clientId: string;
+  scopes: string[];
+  capabilities: Record<ServerApiScope, boolean>;
+  allowedAcpIds: string[] | null;
+}

--- a/backend/src/api/server-api.uuid-lifecycle.spec.ts
+++ b/backend/src/api/server-api.uuid-lifecycle.spec.ts
@@ -1,0 +1,104 @@
+import { INestApplication, NotFoundException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import * as request from "supertest";
+import { ServerApiController } from "./server-api.controller";
+import { ServerApiService } from "./server-api.service";
+import { ServerApiAuthGuard } from "./server-api-auth.guard";
+import { ServerApiAuthService } from "./server-api-auth.service";
+import { ServerApiAuditInterceptor } from "./server-api-audit.interceptor";
+import { ServerApiAuditService } from "./server-api-audit.service";
+
+describe("Server API UUID request lifecycle", () => {
+  let app: INestApplication;
+  let serverApiService: { listFiles: jest.Mock };
+  let authService: {
+    validateToken: jest.Mock;
+    hasScopes: jest.Mock;
+  };
+
+  const version5Uuid = "21f7f8de-8051-5b89-8680-0195ef798b6a";
+
+  beforeAll(async () => {
+    serverApiService = {
+      listFiles: jest
+        .fn()
+        .mockRejectedValue(
+          new NotFoundException(`ACP with ID ${version5Uuid} not found`),
+        ),
+    };
+    authService = {
+      validateToken: jest.fn().mockResolvedValue({
+        id: "test-client",
+        scopes: ["files.read"],
+        allowedAcpIds: null,
+      }),
+      hasScopes: jest
+        .fn()
+        .mockImplementation((scopes: string[], required: string[]) =>
+          required.every((scope) => scopes.includes(scope)),
+        ),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [ServerApiController],
+      providers: [
+        ServerApiAuthGuard,
+        ServerApiAuditInterceptor,
+        {
+          provide: ServerApiService,
+          useValue: serverApiService,
+        },
+        {
+          provide: ServerApiAuthService,
+          useValue: authService,
+        },
+        {
+          provide: ServerApiAuditService,
+          useValue: { log: jest.fn().mockResolvedValue(undefined) },
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix("api");
+    await app.init();
+  });
+
+  beforeEach(() => {
+    serverApiService.listFiles.mockClear();
+    authService.validateToken.mockClear();
+    authService.hasScopes.mockClear();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("returns 401 before UUID parsing when authentication is missing", async () => {
+    await request(app.getHttpServer())
+      .get("/api/server/acp/not-a-uuid/files")
+      .expect(401);
+
+    expect(authService.validateToken).not.toHaveBeenCalled();
+    expect(serverApiService.listFiles).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed UUID after successful authentication", async () => {
+    await request(app.getHttpServer())
+      .get("/api/server/acp/not-a-uuid/files")
+      .set("x-server-token", "valid-token")
+      .expect(400);
+
+    expect(authService.validateToken).toHaveBeenCalledWith("valid-token");
+    expect(serverApiService.listFiles).not.toHaveBeenCalled();
+  });
+
+  it("accepts a non-v4 UUID and lets the service return 404", async () => {
+    await request(app.getHttpServer())
+      .get(`/api/server/acp/${version5Uuid}/files`)
+      .set("x-server-token", "valid-token")
+      .expect(404);
+
+    expect(serverApiService.listFiles).toHaveBeenCalledWith(version5Uuid, null);
+  });
+});

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty } from "class-validator";
+import { IsString, IsNotEmpty, IsUUID } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
 
 export class LoginDto {
@@ -15,8 +15,7 @@ export class LoginDto {
 
 export class CredentialLoginDto {
   @ApiProperty({ description: "ACP ID to access" })
-  @IsString()
-  @IsNotEmpty()
+  @IsUUID("all")
   acpId!: string;
 
   @ApiProperty({ example: "reviewer1" })

--- a/backend/src/auth/guards/acp-access.guard.spec.ts
+++ b/backend/src/auth/guards/acp-access.guard.spec.ts
@@ -7,6 +7,7 @@ import { AcpAccessConfig, AcpRole, AcpUserRole } from "../../database/entities";
 import { User } from "../../database/entities/user.entity";
 
 describe("AcpAccessGuard", () => {
+  const acpId = "11111111-1111-4111-8111-111111111111";
   let guard: AcpAccessGuard;
   let acpUserRoleRepository: { findOne: jest.Mock };
   let accessConfigRepository: { findOne: jest.Mock };
@@ -62,7 +63,7 @@ describe("AcpAccessGuard", () => {
     });
 
     const request: any = {
-      params: { acpId: "acp-www" },
+      params: { acpId },
       user: {
         sub: "julian-user-id",
         username: "julian",
@@ -73,7 +74,7 @@ describe("AcpAccessGuard", () => {
 
     await expect(guard.canActivate(createContext(request))).resolves.toBe(true);
     expect(acpUserRoleRepository.findOne).toHaveBeenCalledWith({
-      where: { userId: "julian-user-id", acpId: "acp-www" },
+      where: { userId: "julian-user-id", acpId },
     });
     expect(request.acpAccessLevel).toBe("MANAGER");
   });
@@ -84,12 +85,12 @@ describe("AcpAccessGuard", () => {
     });
     accessConfigRepository.findOne.mockResolvedValue({
       id: "public-config",
-      acpId: "acp-www",
+      acpId,
       accessModel: "PUBLIC",
     });
 
     const request: any = {
-      params: { acpId: "acp-www" },
+      params: { acpId },
       user: {
         sub: "julian-user-id",
         username: "julian",
@@ -106,12 +107,12 @@ describe("AcpAccessGuard", () => {
   it("allows anonymous access when ACP is PUBLIC", async () => {
     accessConfigRepository.findOne.mockResolvedValue({
       id: "public-config",
-      acpId: "acp-public",
+      acpId,
       accessModel: "PUBLIC",
     });
 
     const request: any = {
-      params: { acpId: "acp-public" },
+      params: { acpId },
       user: null,
       headers: {},
       query: {},
@@ -125,7 +126,7 @@ describe("AcpAccessGuard", () => {
     accessConfigRepository.findOne.mockResolvedValue(null);
 
     const request: any = {
-      params: { acpId: "acp-private" },
+      params: { acpId },
       user: null,
       headers: {},
       query: {},
@@ -134,5 +135,21 @@ describe("AcpAccessGuard", () => {
     await expect(guard.canActivate(createContext(request))).rejects.toThrow(
       "Authentication required",
     );
+  });
+
+  it("rejects malformed ACP ids before querying repositories", async () => {
+    const request: any = {
+      params: { acpId: "__coding-box-connection-test__" },
+      user: null,
+      headers: {},
+      query: {},
+    };
+
+    await expect(guard.canActivate(createContext(request))).rejects.toThrow(
+      "ACP ID must be a valid UUID",
+    );
+    expect(acpUserRoleRepository.findOne).not.toHaveBeenCalled();
+    expect(accessConfigRepository.findOne).not.toHaveBeenCalled();
+    expect(userRepository.findOne).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/auth/guards/acp-access.guard.ts
+++ b/backend/src/auth/guards/acp-access.guard.ts
@@ -15,6 +15,7 @@ import {
   AccessModel,
 } from "../../database/entities";
 import { User } from "../../database/entities/user.entity";
+import { assertUuidParam } from "../../common/uuid-param";
 
 /**
  * Guard that checks if the current user has access to the ACP specified by :acpId param.
@@ -43,6 +44,7 @@ export class AcpAccessGuard implements CanActivate {
     if (!acpId) {
       throw new NotFoundException("ACP ID not found in request");
     }
+    assertUuidParam(acpId, "ACP ID");
 
     // Try to resolve user from JWT even if no JwtAuthGuard is attached.
     // This keeps ACP routes compatible with optional-auth scenarios.

--- a/backend/src/auth/guards/roles.guard.spec.ts
+++ b/backend/src/auth/guards/roles.guard.spec.ts
@@ -3,6 +3,8 @@ import { Reflector } from "@nestjs/core";
 import { RolesGuard, ROLES_KEY } from "./roles.guard";
 
 describe("RolesGuard", () => {
+  const acpId = "11111111-1111-4111-8111-111111111111";
+  const otherAcpId = "22222222-2222-4222-8222-222222222222";
   let guard: RolesGuard;
   let reflector: { getAllAndOverride: jest.Mock };
 
@@ -43,7 +45,7 @@ describe("RolesGuard", () => {
 
     const request = {
       user: { isAppAdmin: true },
-      params: { id: "acp-1" },
+      params: { id: acpId },
     };
 
     expect(guard.canActivate(createContext(request))).toBe(true);
@@ -55,9 +57,9 @@ describe("RolesGuard", () => {
     const request = {
       user: {
         isAppAdmin: false,
-        acpRoles: [{ acpId: "acp-1", role: "ACP_MANAGER" }],
+        acpRoles: [{ acpId, role: "ACP_MANAGER" }],
       },
-      params: { id: "acp-1" },
+      params: { id: acpId },
     };
 
     expect(guard.canActivate(createContext(request))).toBe(true);
@@ -69,9 +71,9 @@ describe("RolesGuard", () => {
     const request = {
       user: {
         isAppAdmin: false,
-        acpRoles: [{ acpId: "acp-1", role: "ACP_MANAGER" }],
+        acpRoles: [{ acpId, role: "ACP_MANAGER" }],
       },
-      params: { acpId: "acp-1" },
+      params: { acpId },
     };
 
     expect(guard.canActivate(createContext(request))).toBe(true);
@@ -83,13 +85,26 @@ describe("RolesGuard", () => {
     const request = {
       user: {
         isAppAdmin: false,
-        acpRoles: [{ acpId: "acp-2", role: "READ_ONLY" }],
+        acpRoles: [{ acpId: otherAcpId, role: "READ_ONLY" }],
       },
-      params: { id: "acp-1" },
+      params: { id: acpId },
     };
 
     expect(() => guard.canActivate(createContext(request))).toThrow(
       ForbiddenException,
     );
+  });
+
+  it("rejects malformed resource ids after authentication", () => {
+    reflector.getAllAndOverride.mockReturnValue(["ACP_MANAGER"]);
+
+    expect(() =>
+      guard.canActivate(
+        createContext({
+          user: { isAppAdmin: true },
+          params: { id: "not-a-uuid" },
+        }),
+      ),
+    ).toThrow("Resource ID must be a valid UUID");
   });
 });

--- a/backend/src/auth/guards/roles.guard.ts
+++ b/backend/src/auth/guards/roles.guard.ts
@@ -6,6 +6,7 @@ import {
   Logger,
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
+import { assertUuidParam } from "../../common/uuid-param";
 
 export const ROLES_KEY = "roles";
 
@@ -34,6 +35,11 @@ export class RolesGuard implements CanActivate {
 
     if (!user) {
       throw new ForbiddenException("Not authenticated");
+    }
+
+    const routeUuid = params.acpId || params.id;
+    if (routeUuid) {
+      assertUuidParam(routeUuid, params.acpId ? "ACP ID" : "Resource ID");
     }
 
     // Check if user is App Admin - App Admins have access to everything

--- a/backend/src/comments/comments.controller.ts
+++ b/backend/src/comments/comments.controller.ts
@@ -9,6 +9,7 @@ import {
   Request,
   Res,
   ForbiddenException,
+  UsePipes,
 } from "@nestjs/common";
 import { Response } from "express";
 import { ApiBearerAuth, ApiTags, ApiOperation } from "@nestjs/swagger";
@@ -18,6 +19,7 @@ import { AcpAccessGuard } from "../auth/guards/acp-access.guard";
 import { CommentTargetType } from "../database/entities";
 import { IsString, IsNotEmpty, IsEnum } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
+import { UuidRouteParamsPipe } from "../common/uuid-param";
 
 export class CreateCommentDto {
   @ApiProperty({ enum: CommentTargetType })
@@ -37,6 +39,7 @@ export class CreateCommentDto {
 
 @ApiTags("Comments")
 @Controller("acp/:acpId/comments")
+@UsePipes(new UuidRouteParamsPipe())
 export class CommentsController {
   constructor(private readonly commentsService: CommentsService) {}
 

--- a/backend/src/comments/comments.controller.ts
+++ b/backend/src/comments/comments.controller.ts
@@ -3,13 +3,11 @@ import {
   Get,
   Post,
   Delete,
-  Param,
   Body,
   UseGuards,
   Request,
   Res,
   ForbiddenException,
-  UsePipes,
 } from "@nestjs/common";
 import { Response } from "express";
 import { ApiBearerAuth, ApiTags, ApiOperation } from "@nestjs/swagger";
@@ -19,7 +17,7 @@ import { AcpAccessGuard } from "../auth/guards/acp-access.guard";
 import { CommentTargetType } from "../database/entities";
 import { IsString, IsNotEmpty, IsEnum } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
-import { UuidRouteParamsPipe } from "../common/uuid-param";
+import { UuidParam } from "../common/uuid-param";
 
 export class CreateCommentDto {
   @ApiProperty({ enum: CommentTargetType })
@@ -39,7 +37,6 @@ export class CreateCommentDto {
 
 @ApiTags("Comments")
 @Controller("acp/:acpId/comments")
-@UsePipes(new UuidRouteParamsPipe())
 export class CommentsController {
   constructor(private readonly commentsService: CommentsService) {}
 
@@ -47,7 +44,7 @@ export class CommentsController {
   @UseGuards(JwtAuthGuard, AcpAccessGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: "List all comments for an ACP (Manager only)" })
-  async findAll(@Param("acpId") acpId: string, @Request() req: any) {
+  async findAll(@UuidParam("acpId") acpId: string, @Request() req: any) {
     this.assertManagerAccess(req);
     return this.commentsService.findByAcp(acpId);
   }
@@ -56,7 +53,7 @@ export class CommentsController {
   @UseGuards(JwtAuthGuard, AcpAccessGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: "List my comments for an ACP" })
-  async findMine(@Param("acpId") acpId: string, @Request() req: any) {
+  async findMine(@UuidParam("acpId") acpId: string, @Request() req: any) {
     if (req.user.type === "credential") {
       return this.commentsService.findByCredential(acpId, req.user.username);
     }
@@ -68,7 +65,7 @@ export class CommentsController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Create a comment" })
   async create(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() dto: CreateCommentDto,
     @Request() req: any,
   ) {
@@ -100,7 +97,7 @@ export class CommentsController {
   @UseGuards(JwtAuthGuard, AcpAccessGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: "Delete all comments for an ACP (Manager only)" })
-  async deleteAll(@Param("acpId") acpId: string, @Request() req: any) {
+  async deleteAll(@UuidParam("acpId") acpId: string, @Request() req: any) {
     this.assertManagerAccess(req);
     const count = await this.commentsService.deleteByAcp(acpId);
     return { message: `${count} comments deleted` };
@@ -110,7 +107,7 @@ export class CommentsController {
   @UseGuards(JwtAuthGuard, AcpAccessGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: "Export comments as JSON" })
-  async exportComments(@Param("acpId") acpId: string, @Request() req: any) {
+  async exportComments(@UuidParam("acpId") acpId: string, @Request() req: any) {
     if (req.user.isAppAdmin || req.acpAccessLevel === "MANAGER") {
       return this.commentsService.exportComments(acpId);
     }
@@ -128,7 +125,7 @@ export class CommentsController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Export comments as XLSX" })
   async exportCommentsXlsx(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Request() req: any,
     @Res() res: Response,
   ) {

--- a/backend/src/common/uuid-param.spec.ts
+++ b/backend/src/common/uuid-param.spec.ts
@@ -1,0 +1,39 @@
+import { ArgumentMetadata, BadRequestException } from "@nestjs/common";
+import { UuidRouteParamsPipe, assertUuidParam } from "./uuid-param";
+
+describe("UUID route parameter validation", () => {
+  const validUuid = "11111111-1111-4111-8111-111111111111";
+
+  it("accepts syntactically valid UUID values independent of version", () => {
+    expect(() => assertUuidParam(validUuid, "ACP ID")).not.toThrow();
+    expect(() =>
+      assertUuidParam("21f7f8de-8051-5b89-8680-0195ef798b6a", "ACP ID"),
+    ).not.toThrow();
+  });
+
+  it("rejects malformed UUID values with bad request", () => {
+    expect(() =>
+      assertUuidParam("__coding-box-connection-test__", "ACP ID"),
+    ).toThrow(BadRequestException);
+  });
+
+  it("validates UUID route parameters but preserves semantic identifiers", () => {
+    const pipe = new UuidRouteParamsPipe();
+    const acpMetadata: ArgumentMetadata = {
+      type: "param",
+      metatype: String,
+      data: "acpId",
+    };
+    const itemMetadata: ArgumentMetadata = {
+      type: "param",
+      metatype: String,
+      data: "itemId",
+    };
+
+    expect(pipe.transform(validUuid, acpMetadata)).toBe(validUuid);
+    expect(() =>
+      pipe.transform("__coding-box-connection-test__", acpMetadata),
+    ).toThrow(BadRequestException);
+    expect(pipe.transform("DE_ITEM_01", itemMetadata)).toBe("DE_ITEM_01");
+  });
+});

--- a/backend/src/common/uuid-param.spec.ts
+++ b/backend/src/common/uuid-param.spec.ts
@@ -1,8 +1,40 @@
-import { ArgumentMetadata, BadRequestException } from "@nestjs/common";
-import { UuidRouteParamsPipe, assertUuidParam } from "./uuid-param";
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  INestApplication,
+  Param,
+} from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import * as request from "supertest";
+import { assertUuidParam, UuidParam } from "./uuid-param";
+
+@Controller("uuid-test/:acpId")
+class ExplicitUuidTestController {
+  @Get("items/:itemId")
+  read(
+    @UuidParam("acpId") acpId: string,
+    @Param("itemId") itemId: string,
+  ): { acpId: string; itemId: string } {
+    return { acpId, itemId };
+  }
+}
 
 describe("UUID route parameter validation", () => {
   const validUuid = "11111111-1111-4111-8111-111111111111";
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [ExplicitUuidTestController],
+    }).compile();
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
 
   it("accepts syntactically valid UUID values independent of version", () => {
     expect(() => assertUuidParam(validUuid, "ACP ID")).not.toThrow();
@@ -17,23 +49,14 @@ describe("UUID route parameter validation", () => {
     ).toThrow(BadRequestException);
   });
 
-  it("validates UUID route parameters but preserves semantic identifiers", () => {
-    const pipe = new UuidRouteParamsPipe();
-    const acpMetadata: ArgumentMetadata = {
-      type: "param",
-      metatype: String,
-      data: "acpId",
-    };
-    const itemMetadata: ArgumentMetadata = {
-      type: "param",
-      metatype: String,
-      data: "itemId",
-    };
+  it("validates only explicitly decorated UUID parameters", async () => {
+    await request(app.getHttpServer())
+      .get(`/uuid-test/${validUuid}/items/DE_ITEM_01`)
+      .expect(200)
+      .expect({ acpId: validUuid, itemId: "DE_ITEM_01" });
 
-    expect(pipe.transform(validUuid, acpMetadata)).toBe(validUuid);
-    expect(() =>
-      pipe.transform("__coding-box-connection-test__", acpMetadata),
-    ).toThrow(BadRequestException);
-    expect(pipe.transform("DE_ITEM_01", itemMetadata)).toBe("DE_ITEM_01");
+    await request(app.getHttpServer())
+      .get("/uuid-test/not-a-uuid/items/DE_ITEM_01")
+      .expect(400);
   });
 });

--- a/backend/src/common/uuid-param.ts
+++ b/backend/src/common/uuid-param.ts
@@ -1,0 +1,46 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  Param,
+  ParseUUIDPipe,
+  PipeTransform,
+} from "@nestjs/common";
+import { isUUID } from "class-validator";
+const UUID_ROUTE_PARAM_NAMES = new Set([
+  "id",
+  "acpId",
+  "fileId",
+  "snapshotId",
+  "credentialId",
+  "userId",
+  "jobId",
+  "tokenId",
+  "collectionId",
+]);
+
+export const UuidParam = (name: string): ParameterDecorator =>
+  Param(name, new ParseUUIDPipe());
+
+export function assertUuidParam(
+  value: unknown,
+  name: string,
+): asserts value is string {
+  if (typeof value !== "string" || !isUUID(value)) {
+    throw new BadRequestException(`${name} must be a valid UUID`);
+  }
+}
+
+@Injectable()
+export class UuidRouteParamsPipe implements PipeTransform {
+  transform(value: unknown, metadata: ArgumentMetadata): unknown {
+    if (
+      metadata.type === "param" &&
+      metadata.data &&
+      UUID_ROUTE_PARAM_NAMES.has(metadata.data)
+    ) {
+      assertUuidParam(value, metadata.data);
+    }
+    return value;
+  }
+}

--- a/backend/src/common/uuid-param.ts
+++ b/backend/src/common/uuid-param.ts
@@ -1,23 +1,5 @@
-import {
-  ArgumentMetadata,
-  BadRequestException,
-  Injectable,
-  Param,
-  ParseUUIDPipe,
-  PipeTransform,
-} from "@nestjs/common";
+import { BadRequestException, Param, ParseUUIDPipe } from "@nestjs/common";
 import { isUUID } from "class-validator";
-const UUID_ROUTE_PARAM_NAMES = new Set([
-  "id",
-  "acpId",
-  "fileId",
-  "snapshotId",
-  "credentialId",
-  "userId",
-  "jobId",
-  "tokenId",
-  "collectionId",
-]);
 
 export const UuidParam = (name: string): ParameterDecorator =>
   Param(name, new ParseUUIDPipe());
@@ -28,19 +10,5 @@ export function assertUuidParam(
 ): asserts value is string {
   if (typeof value !== "string" || !isUUID(value)) {
     throw new BadRequestException(`${name} must be a valid UUID`);
-  }
-}
-
-@Injectable()
-export class UuidRouteParamsPipe implements PipeTransform {
-  transform(value: unknown, metadata: ArgumentMetadata): unknown {
-    if (
-      metadata.type === "param" &&
-      metadata.data &&
-      UUID_ROUTE_PARAM_NAMES.has(metadata.data)
-    ) {
-      assertUuidParam(value, metadata.data);
-    }
-    return value;
   }
 }

--- a/backend/src/files/archive-expansion.service.ts
+++ b/backend/src/files/archive-expansion.service.ts
@@ -1,0 +1,194 @@
+import { BadRequestException, Injectable } from "@nestjs/common";
+import * as path from "path";
+
+@Injectable()
+export class ArchiveExpansionService {
+  async expand(files: Express.Multer.File[]): Promise<Express.Multer.File[]> {
+    const expandedFiles: Express.Multer.File[] = [];
+
+    for (const file of files) {
+      const incomingName = String(file?.originalname || "").trim();
+      if (!incomingName) {
+        throw new BadRequestException("All files must include a filename");
+      }
+
+      if (!this.isZipUpload(file)) {
+        expandedFiles.push(file);
+        continue;
+      }
+
+      const extractedFiles = await this.extractZipEntries(file);
+      if (!extractedFiles.length) {
+        throw new BadRequestException(
+          `ZIP archive "${incomingName}" does not contain any uploadable files`,
+        );
+      }
+
+      expandedFiles.push(...extractedFiles);
+    }
+
+    return expandedFiles;
+  }
+
+  private isZipUpload(file: Express.Multer.File): boolean {
+    const fileName = String(file?.originalname || "")
+      .trim()
+      .toLowerCase();
+    const mimeType = String(file?.mimetype || "")
+      .split(";")[0]
+      .trim()
+      .toLowerCase();
+    return (
+      fileName.endsWith(".zip") ||
+      mimeType === "application/zip" ||
+      mimeType === "application/x-zip-compressed"
+    );
+  }
+
+  private async extractZipEntries(
+    uploadedZip: Express.Multer.File,
+  ): Promise<Express.Multer.File[]> {
+    const JSZip = require("jszip");
+
+    let archive: any;
+    try {
+      archive = await JSZip.loadAsync(uploadedZip.buffer);
+    } catch {
+      throw new BadRequestException(
+        `ZIP archive "${uploadedZip.originalname}" could not be extracted`,
+      );
+    }
+
+    const extractedFiles: Express.Multer.File[] = [];
+    const archiveEntries = Object.values(archive.files || {});
+
+    for (const entry of archiveEntries as Array<{
+      dir?: boolean;
+      name?: string;
+    }>) {
+      if (entry?.dir) {
+        continue;
+      }
+
+      const originalEntryName = String(entry?.name || "");
+      const extractedName = this.getArchiveEntryFileName(originalEntryName);
+      if (
+        !extractedName ||
+        this.shouldSkipArchiveEntry(originalEntryName, extractedName)
+      ) {
+        continue;
+      }
+
+      const zipEntry = archive.file(originalEntryName);
+      if (!zipEntry) {
+        continue;
+      }
+
+      const buffer = Buffer.from(await zipEntry.async("nodebuffer"));
+      extractedFiles.push({
+        ...uploadedZip,
+        originalname: extractedName,
+        mimetype: this.inferMimeTypeFromFileName(extractedName),
+        size: buffer.length,
+        buffer,
+      });
+    }
+
+    return extractedFiles;
+  }
+
+  private getArchiveEntryFileName(entryName: string): string {
+    const normalizedPath = String(entryName || "")
+      .replace(/\\/g, "/")
+      .trim();
+    return path.posix.basename(normalizedPath).trim();
+  }
+
+  private shouldSkipArchiveEntry(
+    entryName: string,
+    extractedName: string,
+  ): boolean {
+    const normalizedPath = String(entryName || "")
+      .replace(/\\/g, "/")
+      .trim();
+    if (!normalizedPath) {
+      return true;
+    }
+
+    if (normalizedPath.startsWith("__MACOSX/")) {
+      return true;
+    }
+
+    return extractedName === ".DS_Store";
+  }
+
+  private inferMimeTypeFromFileName(fileName: string): string {
+    const extension = path
+      .extname(String(fileName || ""))
+      .slice(1)
+      .toLowerCase();
+
+    switch (extension) {
+      case "xml":
+        return "application/xml";
+      case "json":
+      case "voud":
+      case "vomd":
+      case "vocs":
+        return "application/json";
+      case "html":
+      case "htm":
+        return "text/html";
+      case "csv":
+        return "text/csv";
+      case "tsv":
+        return "text/tab-separated-values";
+      case "txt":
+      case "md":
+      case "log":
+      case "yml":
+      case "yaml":
+      case "ini":
+      case "properties":
+        return "text/plain";
+      case "pdf":
+        return "application/pdf";
+      case "png":
+        return "image/png";
+      case "jpg":
+      case "jpeg":
+        return "image/jpeg";
+      case "gif":
+        return "image/gif";
+      case "webp":
+        return "image/webp";
+      case "svg":
+      case "svgz":
+        return "image/svg+xml";
+      case "bmp":
+        return "image/bmp";
+      case "mp3":
+        return "audio/mpeg";
+      case "wav":
+        return "audio/wav";
+      case "ogg":
+        return "audio/ogg";
+      case "m4a":
+        return "audio/mp4";
+      case "aac":
+        return "audio/aac";
+      case "mp4":
+        return "video/mp4";
+      case "webm":
+        return "video/webm";
+      case "mov":
+        return "video/quicktime";
+      case "m4v":
+        return "video/x-m4v";
+      case "ogv":
+        return "video/ogg";
+      default:
+        return "application/octet-stream";
+    }
+  }
+}

--- a/backend/src/files/file-mutation.service.ts
+++ b/backend/src/files/file-mutation.service.ts
@@ -1,0 +1,251 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { DataSource, Repository } from "typeorm";
+import { assertUuidParam } from "../common/uuid-param";
+import { Acp, AcpFile } from "../database/entities";
+import { ArchiveExpansionService } from "./archive-expansion.service";
+import { FileStorageService } from "./file-storage.service";
+
+export type UploadConflictStrategy = "reject" | "overwrite" | "keep-both";
+
+export interface UploadMultipleOptions {
+  conflictStrategy?: string;
+  expandArchives?: boolean;
+}
+
+@Injectable()
+export class FileMutationService {
+  constructor(
+    @InjectRepository(AcpFile)
+    private readonly fileRepository: Repository<AcpFile>,
+    @InjectRepository(Acp)
+    private readonly acpRepository: Repository<Acp>,
+    private readonly dataSource: DataSource,
+    private readonly archiveExpansionService: ArchiveExpansionService,
+    private readonly fileStorageService: FileStorageService,
+  ) {}
+
+  async upload(
+    acpId: string,
+    uploadedFile: Express.Multer.File,
+  ): Promise<AcpFile> {
+    await this.getAcpOrFail(acpId);
+    const stagedFile = await this.fileStorageService.stageUpload(
+      acpId,
+      uploadedFile,
+    );
+
+    try {
+      return await this.fileRepository.save(stagedFile);
+    } catch (error) {
+      await this.fileStorageService.removePhysicalFile(stagedFile);
+      throw error;
+    }
+  }
+
+  async uploadMultiple(
+    acpId: string,
+    files: Express.Multer.File[],
+    options: UploadMultipleOptions = {},
+  ): Promise<AcpFile[]> {
+    const conflictStrategy = this.resolveConflictStrategy(
+      options.conflictStrategy,
+    );
+    if (!files?.length) {
+      throw new BadRequestException("At least one file is required");
+    }
+
+    await this.getAcpOrFail(acpId);
+    const normalizedFiles =
+      options.expandArchives === false
+        ? files
+        : await this.archiveExpansionService.expand(files);
+    const filesToPersist = this.resolveIncomingFiles(
+      normalizedFiles,
+      conflictStrategy,
+    );
+    if (conflictStrategy === "reject") {
+      const existingFiles = await this.fileRepository.find({
+        where: { acpId },
+        order: { originalName: "ASC" },
+      });
+      this.assertNoRejectedConflicts(
+        filesToPersist,
+        this.groupByNormalizedName(existingFiles),
+        conflictStrategy,
+      );
+    }
+
+    const stagedFiles: AcpFile[] = [];
+    try {
+      for (const file of filesToPersist) {
+        stagedFiles.push(
+          await this.fileStorageService.stageUpload(acpId, file),
+        );
+      }
+    } catch (error) {
+      await this.fileStorageService.removePhysicalFiles(stagedFiles);
+      throw error;
+    }
+
+    try {
+      const result = await this.dataSource.transaction(async (manager) => {
+        const acpRepository = manager.getRepository(Acp);
+        const lockedAcp = await acpRepository.findOne({
+          where: { id: acpId },
+          lock: { mode: "pessimistic_write" },
+        });
+        if (!lockedAcp) {
+          throw new NotFoundException(`ACP with ID ${acpId} not found`);
+        }
+
+        const repository = manager.getRepository(AcpFile);
+        const existingFiles = await repository.find({
+          where: { acpId },
+          order: { originalName: "ASC" },
+        });
+        const existingByName = this.groupByNormalizedName(existingFiles);
+        this.assertNoRejectedConflicts(
+          filesToPersist,
+          existingByName,
+          conflictStrategy,
+        );
+
+        const replacedFiles =
+          conflictStrategy === "overwrite"
+            ? this.collectOverwriteMatches(filesToPersist, existingByName)
+            : [];
+        const savedFiles = await repository.save(stagedFiles);
+        if (replacedFiles.length) {
+          await repository.remove(replacedFiles);
+        }
+        return { savedFiles, replacedFiles };
+      });
+
+      await this.fileStorageService.removePhysicalFiles(result.replacedFiles);
+      return result.savedFiles;
+    } catch (error) {
+      await this.fileStorageService.removePhysicalFiles(stagedFiles);
+      throw error;
+    }
+  }
+
+  private resolveIncomingFiles(
+    files: Express.Multer.File[],
+    conflictStrategy: UploadConflictStrategy,
+  ): Express.Multer.File[] {
+    const byName = new Map<string, Express.Multer.File>();
+    const duplicates = new Set<string>();
+
+    for (const file of files) {
+      const name = String(file?.originalname || "").trim();
+      const key = this.normalizeFileName(name);
+      if (!key) {
+        throw new BadRequestException("All files must include a filename");
+      }
+      if (byName.has(key)) {
+        duplicates.add(name);
+      }
+      byName.set(key, file);
+    }
+
+    if (conflictStrategy === "reject" && duplicates.size) {
+      this.throwConflict(duplicates);
+    }
+    if (conflictStrategy === "overwrite") {
+      return Array.from(byName.values());
+    }
+    return files;
+  }
+
+  private assertNoRejectedConflicts(
+    files: Express.Multer.File[],
+    existingByName: Map<string, AcpFile[]>,
+    conflictStrategy: UploadConflictStrategy,
+  ): void {
+    if (conflictStrategy !== "reject") {
+      return;
+    }
+
+    const conflicts = new Set<string>();
+    for (const file of files) {
+      if (existingByName.has(this.normalizeFileName(file.originalname))) {
+        conflicts.add(file.originalname);
+      }
+    }
+    if (conflicts.size) {
+      this.throwConflict(conflicts);
+    }
+  }
+
+  private throwConflict(conflicts: Set<string>): never {
+    throw new ConflictException({
+      message:
+        "File conflicts detected. Resolve duplicates by skipping or uploading with conflictStrategy=overwrite.",
+      conflicts: Array.from(conflicts).sort((a, b) => a.localeCompare(b)),
+    });
+  }
+
+  private collectOverwriteMatches(
+    files: Express.Multer.File[],
+    existingByName: Map<string, AcpFile[]>,
+  ): AcpFile[] {
+    const matches = new Map<string, AcpFile>();
+    for (const file of files) {
+      for (const match of existingByName.get(
+        this.normalizeFileName(file.originalname),
+      ) || []) {
+        matches.set(match.id, match);
+      }
+    }
+    return Array.from(matches.values());
+  }
+
+  private groupByNormalizedName(files: AcpFile[]): Map<string, AcpFile[]> {
+    const grouped = new Map<string, AcpFile[]>();
+    for (const file of files) {
+      const key = this.normalizeFileName(file.originalName);
+      if (!key) {
+        continue;
+      }
+      const bucket = grouped.get(key) || [];
+      bucket.push(file);
+      grouped.set(key, bucket);
+    }
+    return grouped;
+  }
+
+  private resolveConflictStrategy(input?: string): UploadConflictStrategy {
+    const strategy = (input || "reject").trim().toLowerCase();
+    if (
+      strategy === "reject" ||
+      strategy === "overwrite" ||
+      strategy === "keep-both"
+    ) {
+      return strategy;
+    }
+    throw new BadRequestException(
+      "Invalid conflictStrategy. Expected one of: reject, overwrite, keep-both",
+    );
+  }
+
+  private normalizeFileName(fileName: string): string {
+    return String(fileName || "")
+      .trim()
+      .toLowerCase();
+  }
+
+  private async getAcpOrFail(acpId: string): Promise<Acp> {
+    assertUuidParam(acpId, "ACP ID");
+    const acp = await this.acpRepository.findOne({ where: { id: acpId } });
+    if (!acp) {
+      throw new NotFoundException(`ACP with ID ${acpId} not found`);
+    }
+    return acp;
+  }
+}

--- a/backend/src/files/file-storage.service.ts
+++ b/backend/src/files/file-storage.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { InjectRepository } from "@nestjs/typeorm";
+import * as crypto from "crypto";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { Repository } from "typeorm";
+import { AcpFile } from "../database/entities";
+
+@Injectable()
+export class FileStorageService {
+  private readonly storagePath: string;
+
+  constructor(
+    @InjectRepository(AcpFile)
+    private readonly fileRepository: Repository<AcpFile>,
+    configService: ConfigService,
+  ) {
+    this.storagePath = configService.get<string>(
+      "FILE_STORAGE_PATH",
+      "./uploads",
+    );
+  }
+
+  async stageUpload(
+    acpId: string,
+    uploadedFile: Express.Multer.File,
+  ): Promise<AcpFile> {
+    const acpDir = path.join(this.storagePath, acpId);
+    await fs.mkdir(acpDir, { recursive: true });
+
+    const ext = path.extname(uploadedFile.originalname);
+    const filePath = path.join(acpDir, `${crypto.randomUUID()}${ext}`);
+
+    try {
+      await fs.writeFile(filePath, uploadedFile.buffer);
+    } catch (error) {
+      await this.removePath(filePath);
+      throw error;
+    }
+
+    const checksum = crypto
+      .createHash("sha256")
+      .update(uploadedFile.buffer)
+      .digest("hex");
+
+    return this.fileRepository.create({
+      acpId,
+      filePath,
+      originalName: uploadedFile.originalname,
+      fileType: uploadedFile.mimetype,
+      fileSize: uploadedFile.size,
+      checksum,
+    });
+  }
+
+  async read(file: AcpFile): Promise<Buffer> {
+    return fs.readFile(file.filePath);
+  }
+
+  async removePhysicalFile(file: Pick<AcpFile, "filePath">): Promise<void> {
+    await this.removePath(file.filePath);
+  }
+
+  async removePhysicalFiles(
+    files: Array<Pick<AcpFile, "filePath">>,
+  ): Promise<void> {
+    for (const file of files) {
+      await this.removePhysicalFile(file);
+    }
+  }
+
+  private async removePath(filePath: string): Promise<void> {
+    try {
+      await fs.unlink(filePath);
+    } catch {
+      // Missing files and best-effort rollback cleanup are safe to ignore.
+    }
+  }
+}

--- a/backend/src/files/files.controller.spec.ts
+++ b/backend/src/files/files.controller.spec.ts
@@ -619,7 +619,7 @@ describe("FilesController", () => {
     expect(filesService.uploadMultiple).toHaveBeenCalledWith(
       "acp-1",
       [{ originalname: "unit-1.xml" }],
-      "overwrite",
+      { conflictStrategy: "overwrite" },
     );
     expect(payload).toEqual({
       files: [baseFile],

--- a/backend/src/files/files.controller.ts
+++ b/backend/src/files/files.controller.ts
@@ -14,7 +14,6 @@ import {
   Request,
   Res,
   Sse,
-  UsePipes,
 } from "@nestjs/common";
 import { Response } from "express";
 import { FilesInterceptor } from "@nestjs/platform-express";
@@ -34,11 +33,10 @@ import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { FileProcessingJobsService } from "./file-processing-jobs.service";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
-import { UuidRouteParamsPipe } from "../common/uuid-param";
+import { UuidParam } from "../common/uuid-param";
 
 @ApiTags("ACP Files")
 @Controller("acp/:acpId/files")
-@UsePipes(new UuidRouteParamsPipe())
 export class FilesController {
   constructor(
     private readonly filesService: FilesService,
@@ -52,7 +50,7 @@ export class FilesController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "List all files for an ACP" })
   async findAll(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Query("format") format?: string,
     @Query("unitId") unitId?: string,
     @Query("sequenceId") sequenceId?: string,
@@ -106,7 +104,7 @@ export class FilesController {
   @Roles("ACP_MANAGER")
   @ApiBearerAuth()
   @ApiOperation({ summary: "Delete all files for an ACP" })
-  async deleteAll(@Param("acpId") acpId: string) {
+  async deleteAll(@UuidParam("acpId") acpId: string) {
     await this.filesService.deleteAll(acpId);
     const cleanupResult =
       await this.filesService.cleanupReferencesAfterFileMutation(acpId);
@@ -123,7 +121,7 @@ export class FilesController {
   @Roles("ACP_MANAGER")
   @ApiBearerAuth()
   @ApiOperation({ summary: "Validate completeness of all unit files" })
-  async validateUnits(@Param("acpId") acpId: string) {
+  async validateUnits(@UuidParam("acpId") acpId: string) {
     const files = await this.filesService.findByAcp(acpId);
     const [unitResults, validationRun] = await Promise.all([
       this.unitParserService.validateUnitFiles(acpId),
@@ -140,7 +138,7 @@ export class FilesController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Extract item list with metadata from .vomd files" })
   async getItemList(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Request() req: any,
     @Query("perspective") perspective?: string,
   ) {
@@ -175,7 +173,7 @@ export class FilesController {
   @ApiOperation({
     summary: "Recalculate stable Item Explorer row numbers",
   })
-  async recalculateItemRowNumbers(@Param("acpId") acpId: string) {
+  async recalculateItemRowNumbers(@UuidParam("acpId") acpId: string) {
     return this.unitParserService.recalculatePublishedItemRowNumbers(acpId);
   }
 
@@ -185,7 +183,7 @@ export class FilesController {
     summary: "Get unit view data from uploaded files (player, definition)",
   })
   async getUnitView(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Param("unitId") unitId: string,
     @Request() req: any,
     @Query("perspective") perspective?: string,
@@ -206,8 +204,8 @@ export class FilesController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Get file processing job status" })
   async getProcessingJob(
-    @Param("acpId") acpId: string,
-    @Param("jobId") jobId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("jobId") jobId: string,
   ) {
     return this.fileProcessingJobsService.getJobSnapshot(acpId, jobId);
   }
@@ -218,8 +216,8 @@ export class FilesController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Stream file processing job progress" })
   async streamProcessingJob(
-    @Param("acpId") acpId: string,
-    @Param("jobId") jobId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("jobId") jobId: string,
   ) {
     await this.fileProcessingJobsService.ensureJobExists(acpId, jobId);
     return this.fileProcessingJobsService.streamJob(jobId);
@@ -233,8 +231,8 @@ export class FilesController {
     summary: "Download generated ZIP archive for a completed file job",
   })
   async downloadJobArchive(
-    @Param("acpId") acpId: string,
-    @Param("jobId") jobId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("jobId") jobId: string,
     @Res({ passthrough: true }) res?: Response,
   ) {
     const archive = await this.fileProcessingJobsService.downloadArchive(
@@ -254,8 +252,8 @@ export class FilesController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get file metadata" })
   async findOne(
-    @Param("acpId") acpId: string,
-    @Param("fileId") fileId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("fileId") fileId: string,
     @Request() req: any,
   ) {
     const isManager =
@@ -275,8 +273,8 @@ export class FilesController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get preview data for a file" })
   async getPreview(
-    @Param("acpId") acpId: string,
-    @Param("fileId") fileId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("fileId") fileId: string,
     @Request() req: any,
   ) {
     const file = await this.filesService.findByIdForAcp(acpId, fileId);
@@ -297,16 +295,14 @@ export class FilesController {
   })
   @ApiOperation({ summary: "Upload files to ACP" })
   async upload(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @UploadedFiles() files: Express.Multer.File[],
     @Query("conflictStrategy") conflictStrategy?: string,
   ) {
     return {
-      files: await this.filesService.uploadMultiple(
-        acpId,
-        files,
+      files: await this.filesService.uploadMultiple(acpId, files, {
         conflictStrategy,
-      ),
+      }),
     };
   }
 
@@ -318,7 +314,7 @@ export class FilesController {
     summary: "Download all or selected ACP files as ZIP archive",
   })
   async bulkDownload(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() body: { fileIds?: string[] } = {},
     @Res({ passthrough: true }) res?: Response,
   ) {
@@ -340,7 +336,7 @@ export class FilesController {
     summary: "Start ZIP creation job for all or selected ACP files",
   })
   async startBulkDownloadJob(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() body: { fileIds?: string[] } = {},
     @Request() req?: any,
   ) {
@@ -357,7 +353,7 @@ export class FilesController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Start processing for freshly uploaded ACP files" })
   async processUpload(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() body: { fileIds?: string[]; runCleanup?: boolean },
     @Request() req: any,
   ) {
@@ -377,7 +373,7 @@ export class FilesController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Delete multiple files for an ACP" })
   async bulkDelete(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() body: { fileIds?: string[] },
   ) {
     const deletedFileIds = await this.filesService.deleteManyForAcp(
@@ -405,7 +401,7 @@ export class FilesController {
     summary:
       "Synchronize ACP-Index from uploaded unit files (non-destructive merge)",
   })
-  async syncIndex(@Param("acpId") acpId: string) {
+  async syncIndex(@UuidParam("acpId") acpId: string) {
     return this.unitParserService.syncIndexFromFiles(acpId);
   }
 
@@ -418,8 +414,8 @@ export class FilesController {
   })
   @ApiOperation({ summary: "Download a file" })
   async download(
-    @Param("acpId") acpId: string,
-    @Param("fileId") fileId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("fileId") fileId: string,
     @Query("disposition") disposition: string | undefined,
     @Request() req: any,
     @Res() res: Response,
@@ -442,7 +438,10 @@ export class FilesController {
   @Roles("ACP_MANAGER")
   @ApiBearerAuth()
   @ApiOperation({ summary: "Delete a file" })
-  async delete(@Param("acpId") acpId: string, @Param("fileId") fileId: string) {
+  async delete(
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("fileId") fileId: string,
+  ) {
     await this.filesService.deleteForAcp(acpId, fileId);
     const cleanupResult =
       await this.filesService.cleanupReferencesAfterFileMutation(acpId);
@@ -460,8 +459,8 @@ export class FilesController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Get validation result for a file" })
   async getValidation(
-    @Param("acpId") acpId: string,
-    @Param("fileId") fileId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("fileId") fileId: string,
   ) {
     return this.filesService.getValidationResultForAcp(acpId, fileId);
   }

--- a/backend/src/files/files.controller.ts
+++ b/backend/src/files/files.controller.ts
@@ -14,6 +14,7 @@ import {
   Request,
   Res,
   Sse,
+  UsePipes,
 } from "@nestjs/common";
 import { Response } from "express";
 import { FilesInterceptor } from "@nestjs/platform-express";
@@ -33,9 +34,11 @@ import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { FileProcessingJobsService } from "./file-processing-jobs.service";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
+import { UuidRouteParamsPipe } from "../common/uuid-param";
 
 @ApiTags("ACP Files")
 @Controller("acp/:acpId/files")
+@UsePipes(new UuidRouteParamsPipe())
 export class FilesController {
   constructor(
     private readonly filesService: FilesService,

--- a/backend/src/files/files.module.ts
+++ b/backend/src/files/files.module.ts
@@ -18,6 +18,9 @@ import { ValidationModule } from "../validation/validation.module";
 import { FileProcessingJobsService } from "./file-processing-jobs.service";
 import { ItemExplorerModule } from "../item-explorer/item-explorer.module";
 import { ItemRowNumberingService } from "./item-row-numbering.service";
+import { ArchiveExpansionService } from "./archive-expansion.service";
+import { FileMutationService } from "./file-mutation.service";
+import { FileStorageService } from "./file-storage.service";
 
 const MAX_UPLOAD_FILE_SIZE_BYTES = 512 * 1024 * 1024;
 
@@ -42,6 +45,9 @@ const MAX_UPLOAD_FILE_SIZE_BYTES = 512 * 1024 * 1024;
   controllers: [FilesController],
   providers: [
     FilesService,
+    ArchiveExpansionService,
+    FileMutationService,
+    FileStorageService,
     UnitParserService,
     FileProcessingJobsService,
     ItemRowNumberingService,

--- a/backend/src/files/files.service.spec.ts
+++ b/backend/src/files/files.service.spec.ts
@@ -25,6 +25,8 @@ jest.mock("fs/promises", () => ({
 }));
 
 describe("FilesService", () => {
+  const acpId = "11111111-1111-4111-8111-111111111111";
+  const unknownAcpId = "99999999-9999-4999-8999-999999999999";
   let service: FilesService;
   let repo: any;
   let acpRepo: any;
@@ -35,7 +37,7 @@ describe("FilesService", () => {
 
   const mockFile = {
     id: "file-1",
-    acpId: "acp-1",
+    acpId: acpId,
     filePath: "/uploads/acp-1/test.json",
     originalName: "test.json",
     fileType: "application/json",
@@ -57,7 +59,7 @@ describe("FilesService", () => {
     };
     acpRepo = {
       findOne: jest.fn().mockResolvedValue({
-        id: "acp-1",
+        id: acpId,
         acpIndex: {
           units: [
             {
@@ -166,9 +168,26 @@ describe("FilesService", () => {
 
   describe("findByAcp", () => {
     it("should return files for ACP", async () => {
-      const result = await service.findByAcp("acp-1");
+      const result = await service.findByAcp(acpId);
       expect(result).toHaveLength(1);
       expect(result[0].originalName).toBe("test.json");
+    });
+
+    it("should reject an unknown ACP before querying files", async () => {
+      acpRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.findByAcp(unknownAcpId)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(repo.find).not.toHaveBeenCalled();
+    });
+
+    it("should reject a malformed ACP ID before querying repositories", async () => {
+      await expect(
+        service.findByAcp("__coding-box-connection-test__"),
+      ).rejects.toThrow(BadRequestException);
+      expect(acpRepo.findOne).not.toHaveBeenCalled();
+      expect(repo.find).not.toHaveBeenCalled();
     });
   });
 
@@ -185,7 +204,7 @@ describe("FilesService", () => {
 
     it("should throw when ACP-scoped lookup does not match ACP", async () => {
       repo.findOne.mockResolvedValue({ ...mockFile, acpId: "other-acp" });
-      await expect(service.findByIdForAcp("acp-1", "file-1")).rejects.toThrow(
+      await expect(service.findByIdForAcp(acpId, "file-1")).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -200,9 +219,28 @@ describe("FilesService", () => {
         buffer: Buffer.from('{"test": true}'),
       } as Express.Multer.File;
 
-      await service.upload("acp-1", multerFile);
+      await service.upload(acpId, multerFile);
       expect(repo.create).toHaveBeenCalled();
       expect(repo.save).toHaveBeenCalled();
+    });
+
+    it("should reject an unknown ACP before writing to disk", async () => {
+      acpRepo.findOne.mockResolvedValue(null);
+      (fs.mkdir as jest.Mock).mockClear();
+      (fs.writeFile as jest.Mock).mockClear();
+      const incoming = {
+        originalname: "test.json",
+        mimetype: "application/json",
+        size: 2,
+        buffer: Buffer.from("{}"),
+      } as Express.Multer.File;
+
+      await expect(service.upload(unknownAcpId, incoming)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+      expect(repo.save).not.toHaveBeenCalled();
     });
   });
 
@@ -213,6 +251,19 @@ describe("FilesService", () => {
       size: 128,
       buffer: Buffer.from('{"fresh": true}'),
     } as Express.Multer.File;
+
+    it("should reject an unknown ACP before processing uploads", async () => {
+      acpRepo.findOne.mockResolvedValue(null);
+      (fs.mkdir as jest.Mock).mockClear();
+      (fs.writeFile as jest.Mock).mockClear();
+
+      await expect(
+        service.uploadMultiple(unknownAcpId, [incoming]),
+      ).rejects.toThrow(NotFoundException);
+      expect(repo.find).not.toHaveBeenCalled();
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
 
     it("should extract ZIP uploads before storing metadata", async () => {
       repo.find.mockResolvedValue([]);
@@ -225,24 +276,7 @@ describe("FilesService", () => {
       zip.file(".DS_Store", "ignore");
       const buffer = await zip.generateAsync({ type: "nodebuffer" });
 
-      const uploadSpy = jest
-        .spyOn(service, "upload")
-        .mockResolvedValueOnce({
-          ...mockFile,
-          id: "file-xml",
-          originalName: "unit-1.xml",
-          fileType: "application/xml",
-          fileSize: 8,
-        } as unknown as AcpFile)
-        .mockResolvedValueOnce({
-          ...mockFile,
-          id: "file-vomd",
-          originalName: "unit-1.vomd",
-          fileType: "application/json",
-          fileSize: 12,
-        } as unknown as AcpFile);
-
-      const result = await service.uploadMultiple("acp-1", [
+      const result = await service.uploadMultiple(acpId, [
         {
           originalname: "bundle.zip",
           mimetype: "application/zip",
@@ -251,38 +285,81 @@ describe("FilesService", () => {
         } as Express.Multer.File,
       ]);
 
-      expect(uploadSpy).toHaveBeenCalledTimes(2);
-      expect(uploadSpy).toHaveBeenNthCalledWith(
+      expect(repo.create).toHaveBeenCalledTimes(2);
+      expect(repo.create).toHaveBeenNthCalledWith(
         1,
-        "acp-1",
         expect.objectContaining({
-          originalname: "unit-1.xml",
-          mimetype: "application/xml",
-          size: 8,
-          buffer: Buffer.from("<Unit />"),
+          acpId: acpId,
+          originalName: "unit-1.xml",
+          fileType: "application/xml",
+          fileSize: 8,
         }),
       );
-      expect(uploadSpy).toHaveBeenNthCalledWith(
+      expect(repo.create).toHaveBeenNthCalledWith(
         2,
-        "acp-1",
         expect.objectContaining({
-          originalname: "unit-1.vomd",
-          mimetype: "application/json",
-          size: 12,
-          buffer: Buffer.from('{"items":[]}'),
+          acpId: acpId,
+          originalName: "unit-1.vomd",
+          fileType: "application/json",
+          fileSize: 12,
         }),
       );
+      expect(acpRepo.findOne).toHaveBeenCalledTimes(1);
       expect(result.map((file) => file.originalName)).toEqual([
         "unit-1.xml",
         "unit-1.vomd",
       ]);
     });
 
+    it("should preserve archive-like uploads when expansion is disabled", async () => {
+      const JSZip = require("jszip");
+      const zip = new JSZip();
+      zip.file("arbitrary.json", '{"unexpected":true}');
+      const buffer = await zip.generateAsync({ type: "nodebuffer" });
+      const existingVocs = {
+        ...mockFile,
+        id: "vocs-file",
+        originalName: "UNIT-1.VOCS",
+      };
+      repo.find.mockResolvedValue([existingVocs]);
+      const deleteSpy = jest
+        .spyOn(service, "deleteForAcp")
+        .mockResolvedValue(undefined);
+      (fs.writeFile as jest.Mock).mockClear();
+
+      const result = await service.uploadMultiple(
+        acpId,
+        [
+          {
+            originalname: "UNIT-1.VOCS",
+            mimetype: "application/zip",
+            size: buffer.length,
+            buffer,
+          } as Express.Multer.File,
+        ],
+        "overwrite",
+        { expandArchives: false },
+      );
+
+      expect(deleteSpy).toHaveBeenCalledWith(acpId, "vocs-file");
+      expect(repo.create).toHaveBeenCalledTimes(1);
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          acpId: acpId,
+          originalName: "UNIT-1.VOCS",
+          fileType: "application/zip",
+          fileSize: buffer.length,
+        }),
+      );
+      expect(fs.writeFile).toHaveBeenCalledWith(expect.any(String), buffer);
+      expect(result.map((file) => file.originalName)).toEqual(["UNIT-1.VOCS"]);
+    });
+
     it("should reject invalid ZIP uploads", async () => {
       repo.find.mockResolvedValue([]);
 
       await expect(
-        service.uploadMultiple("acp-1", [
+        service.uploadMultiple(acpId, [
           {
             originalname: "broken.zip",
             mimetype: "application/zip",
@@ -294,7 +371,7 @@ describe("FilesService", () => {
     });
 
     it("should reject conflicts by default", async () => {
-      await expect(service.uploadMultiple("acp-1", [incoming])).rejects.toThrow(
+      await expect(service.uploadMultiple(acpId, [incoming])).rejects.toThrow(
         ConflictException,
       );
     });
@@ -303,20 +380,21 @@ describe("FilesService", () => {
       const deleteSpy = jest
         .spyOn(service, "deleteForAcp")
         .mockResolvedValue(undefined);
-      const uploadSpy = jest.spyOn(service, "upload").mockResolvedValue({
-        ...mockFile,
-        id: "new-file",
-        originalName: "test.json",
-      } as unknown as AcpFile);
 
       const result = await service.uploadMultiple(
-        "acp-1",
+        acpId,
         [incoming],
         "overwrite",
       );
 
-      expect(deleteSpy).toHaveBeenCalledWith("acp-1", "file-1");
-      expect(uploadSpy).toHaveBeenCalledWith("acp-1", incoming);
+      expect(deleteSpy).toHaveBeenCalledWith(acpId, "file-1");
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          acpId: acpId,
+          originalName: incoming.originalname,
+        }),
+      );
+      expect(acpRepo.findOne).toHaveBeenCalledTimes(1);
       expect(result).toHaveLength(1);
     });
 
@@ -324,31 +402,32 @@ describe("FilesService", () => {
       const deleteSpy = jest
         .spyOn(service, "deleteForAcp")
         .mockResolvedValue(undefined);
-      const uploadSpy = jest.spyOn(service, "upload").mockResolvedValue({
-        ...mockFile,
-        id: "new-file",
-        originalName: "test.json",
-      } as unknown as AcpFile);
 
       const result = await service.uploadMultiple(
-        "acp-1",
+        acpId,
         [incoming],
         "keep-both",
       );
 
       expect(deleteSpy).not.toHaveBeenCalled();
-      expect(uploadSpy).toHaveBeenCalledWith("acp-1", incoming);
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          acpId: acpId,
+          originalName: incoming.originalname,
+        }),
+      );
+      expect(acpRepo.findOne).toHaveBeenCalledTimes(1);
       expect(result).toHaveLength(1);
     });
 
     it("should reject invalid conflict strategy", async () => {
       await expect(
-        service.uploadMultiple("acp-1", [incoming], "invalid-strategy"),
+        service.uploadMultiple(acpId, [incoming], "invalid-strategy"),
       ).rejects.toThrow(BadRequestException);
     });
 
     it("should require at least one file", async () => {
-      await expect(service.uploadMultiple("acp-1", [])).rejects.toThrow(
+      await expect(service.uploadMultiple(acpId, [])).rejects.toThrow(
         BadRequestException,
       );
     });
@@ -360,7 +439,7 @@ describe("FilesService", () => {
       } as Express.Multer.File;
 
       await expect(
-        service.uploadMultiple("acp-1", [invalidFile]),
+        service.uploadMultiple(acpId, [invalidFile]),
       ).rejects.toThrow(BadRequestException);
     });
   });
@@ -380,14 +459,14 @@ describe("FilesService", () => {
     });
 
     it("should download ACP-scoped file and fail on missing disk file", async () => {
-      await expect(service.downloadForAcp("acp-1", "file-1")).resolves.toEqual(
+      await expect(service.downloadForAcp(acpId, "file-1")).resolves.toEqual(
         expect.objectContaining({
           file: expect.objectContaining({ id: "file-1" }),
         }),
       );
 
       (fs.readFile as jest.Mock).mockRejectedValueOnce(new Error("missing"));
-      await expect(service.downloadForAcp("acp-1", "file-1")).rejects.toThrow(
+      await expect(service.downloadForAcp(acpId, "file-1")).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -398,17 +477,18 @@ describe("FilesService", () => {
         { ...mockFile, id: "file-2", originalName: "second.json" },
       ]);
 
-      await expect(service.createFilesZip("acp-1")).resolves.toEqual(
+      await expect(service.createFilesZip(acpId)).resolves.toEqual(
         expect.objectContaining({
-          fileName: "acp-acp-1-all-files.zip",
+          fileName: "acp-11111111-1111-4111-8111-111111111111-all-files.zip",
         }),
       );
 
       await expect(
-        service.createFilesZip("acp-1", ["file-2", "file-1", "file-2"]),
+        service.createFilesZip(acpId, ["file-2", "file-1", "file-2"]),
       ).resolves.toEqual(
         expect.objectContaining({
-          fileName: "acp-acp-1-selected-files.zip",
+          fileName:
+            "acp-11111111-1111-4111-8111-111111111111-selected-files.zip",
         }),
       );
     });
@@ -417,7 +497,7 @@ describe("FilesService", () => {
       repo.find.mockResolvedValue([{ ...mockFile, id: "file-1" }]);
 
       await expect(
-        service.createFilesZip("acp-1", ["missing-file"]),
+        service.createFilesZip(acpId, ["missing-file"]),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -447,10 +527,11 @@ describe("FilesService", () => {
       };
 
       await expect(
-        service.createFilesZipArchive("acp-1", ["file-1", "file-2"], progress),
+        service.createFilesZipArchive(acpId, ["file-1", "file-2"], progress),
       ).resolves.toEqual(
         expect.objectContaining({
-          fileName: "acp-acp-1-selected-files.zip",
+          fileName:
+            "acp-11111111-1111-4111-8111-111111111111-selected-files.zip",
         }),
       );
 
@@ -487,7 +568,7 @@ describe("FilesService", () => {
 
     it("should delete by ACP and remove all files", async () => {
       await expect(
-        service.deleteForAcp("acp-1", "file-1"),
+        service.deleteForAcp(acpId, "file-1"),
       ).resolves.toBeUndefined();
       expect(repo.remove).toHaveBeenCalledWith(mockFile);
 
@@ -499,7 +580,7 @@ describe("FilesService", () => {
         .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(new Error("missing"));
 
-      await expect(service.deleteAll("acp-1")).resolves.toBeUndefined();
+      await expect(service.deleteAll(acpId)).resolves.toBeUndefined();
       expect(repo.remove).toHaveBeenCalledWith([
         expect.objectContaining({ id: "file-1" }),
         expect.objectContaining({ id: "file-2" }),
@@ -512,7 +593,7 @@ describe("FilesService", () => {
         { ...mockFile, id: "file-2", filePath: "/x/2" },
       ]);
 
-      const result = await service.deleteManyForAcp("acp-1", [
+      const result = await service.deleteManyForAcp(acpId, [
         "file-1",
         "file-2",
         "file-1",
@@ -526,14 +607,14 @@ describe("FilesService", () => {
     });
 
     it("should reject empty and unknown IDs during bulk delete", async () => {
-      await expect(service.deleteManyForAcp("acp-1", [])).rejects.toThrow(
+      await expect(service.deleteManyForAcp(acpId, [])).rejects.toThrow(
         BadRequestException,
       );
 
       repo.find.mockResolvedValue([{ ...mockFile, id: "file-1" }]);
 
       await expect(
-        service.deleteManyForAcp("acp-1", ["missing-file"]),
+        service.deleteManyForAcp(acpId, ["missing-file"]),
       ).rejects.toThrow(NotFoundException);
     });
   });
@@ -567,7 +648,7 @@ describe("FilesService", () => {
         codingSchemes: {},
       });
 
-      const result = await service.cleanupOrphanedResponseStates("acp-1");
+      const result = await service.cleanupOrphanedResponseStates(acpId);
 
       expect(stateRepo.delete).toHaveBeenCalledWith(["state-2"]);
       expect(result).toEqual({
@@ -580,7 +661,7 @@ describe("FilesService", () => {
     it("returns zero cleanup when no response states exist", async () => {
       stateRepo.find.mockResolvedValueOnce([]);
 
-      const result = await service.cleanupOrphanedResponseStates("acp-1");
+      const result = await service.cleanupOrphanedResponseStates(acpId);
 
       expect(unitParserService.getItemListFromFiles).not.toHaveBeenCalled();
       expect(stateRepo.delete).not.toHaveBeenCalled();
@@ -620,7 +701,7 @@ describe("FilesService", () => {
         codingSchemes: {},
       });
 
-      const result = await service.cleanupOrphanedResponseStates("acp-1");
+      const result = await service.cleanupOrphanedResponseStates(acpId);
 
       expect(stateRepo.delete).toHaveBeenCalledWith(["state-orphaned-partial"]);
       expect(result).toEqual({
@@ -633,13 +714,13 @@ describe("FilesService", () => {
 
   describe("cleanupReferencesAfterFileMutation", () => {
     it("runs dependency, response state, and validation cleanup", async () => {
-      const result = await service.cleanupReferencesAfterFileMutation("acp-1");
+      const result = await service.cleanupReferencesAfterFileMutation(acpId);
 
       expect(unitParserService.pruneMissingDependencies).toHaveBeenCalledWith(
-        "acp-1",
+        acpId,
       );
       expect(validationService.autoValidateUploadedFiles).toHaveBeenCalledWith(
-        "acp-1",
+        acpId,
         expect.any(Array),
       );
       expect(result).toEqual(
@@ -664,12 +745,12 @@ describe("FilesService", () => {
     });
 
     it("can skip validation step for bulk mutation flows", async () => {
-      const result = await service.cleanupReferencesAfterFileMutation("acp-1", {
+      const result = await service.cleanupReferencesAfterFileMutation(acpId, {
         skipValidation: true,
       });
 
       expect(unitParserService.pruneMissingDependencies).toHaveBeenCalledWith(
-        "acp-1",
+        acpId,
       );
       expect(
         validationService.autoValidateUploadedFiles,
@@ -702,7 +783,7 @@ describe("FilesService", () => {
         valid: true,
       });
       await expect(
-        service.getValidationResultForAcp("acp-1", "file-1"),
+        service.getValidationResultForAcp(acpId, "file-1"),
       ).resolves.toEqual({ valid: true });
     });
   });
@@ -724,7 +805,7 @@ describe("FilesService", () => {
   <Reference>unit-1.vomd</Reference>
 </Unit>`);
 
-      const preview = await service.getPreviewForAcp("acp-1", "file-1");
+      const preview = await service.getPreviewForAcp(acpId, "file-1");
 
       expect(preview).toEqual(
         expect.objectContaining({
@@ -780,7 +861,7 @@ describe("FilesService", () => {
         }),
       );
 
-      const preview = await service.getPreviewForAcp("acp-1", "file-1");
+      const preview = await service.getPreviewForAcp(acpId, "file-1");
 
       expect(preview).toEqual(
         expect.objectContaining({
@@ -821,7 +902,7 @@ describe("FilesService", () => {
         JSON.stringify({ variableCodings: variables }),
       );
 
-      const preview = await service.getPreviewForAcp("acp-1", "file-1");
+      const preview = await service.getPreviewForAcp(acpId, "file-1");
 
       expect(preview).toEqual(
         expect.objectContaining({
@@ -849,7 +930,7 @@ describe("FilesService", () => {
       });
       (fs.readFile as jest.Mock).mockClear();
 
-      const preview = await service.getPreviewForAcp("acp-1", "file-1");
+      const preview = await service.getPreviewForAcp(acpId, "file-1");
 
       expect(preview).toEqual(
         expect.objectContaining({
@@ -867,14 +948,16 @@ describe("FilesService", () => {
         { ...mockFile, id: "f1", originalName: "test.json" },
         { ...mockFile, id: "f2", originalName: "unit-1.xml" },
       ]);
-      const result = await service.createUnitZip("acp-1", "unit-1");
-      expect(result.fileName).toBe("acp-acp-1-unit-unit-1.zip");
+      const result = await service.createUnitZip(acpId, "unit-1");
+      expect(result.fileName).toBe(
+        "acp-11111111-1111-4111-8111-111111111111-unit-unit-1.zip",
+      );
       expect(result.buffer.length).toBeGreaterThan(0);
     });
 
     it("should throw when unit has no files", async () => {
       repo.find.mockResolvedValue([]);
-      await expect(service.createUnitZip("acp-1", "unit-1")).rejects.toThrow(
+      await expect(service.createUnitZip(acpId, "unit-1")).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -888,20 +971,22 @@ describe("FilesService", () => {
         { ...mockFile, id: "f3", originalName: "second.json" },
         { ...mockFile, id: "f4", originalName: "unit-2.xml" },
       ]);
-      const result = await service.createSequenceZip("acp-1", "seq-1");
-      expect(result.fileName).toBe("acp-acp-1-sequence-seq-1.zip");
+      const result = await service.createSequenceZip(acpId, "seq-1");
+      expect(result.fileName).toBe(
+        "acp-11111111-1111-4111-8111-111111111111-sequence-seq-1.zip",
+      );
       expect(result.buffer.length).toBeGreaterThan(0);
     });
 
     it("should throw when sequence does not exist", async () => {
       await expect(
-        service.createSequenceZip("acp-1", "unknown-seq"),
+        service.createSequenceZip(acpId, "unknown-seq"),
       ).rejects.toThrow(NotFoundException);
     });
 
     it("should throw when sequence exists but no files are available", async () => {
       repo.find.mockResolvedValue([]);
-      await expect(service.createSequenceZip("acp-1", "seq-1")).rejects.toThrow(
+      await expect(service.createSequenceZip(acpId, "seq-1")).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -915,7 +1000,7 @@ describe("FilesService", () => {
         },
       });
 
-      await expect(service.getFeatureConfig("acp-1")).resolves.toEqual(
+      await expect(service.getFeatureConfig(acpId)).resolves.toEqual(
         expect.objectContaining({
           metadataColumns: {
             visible: ["metaA"],
@@ -927,13 +1012,13 @@ describe("FilesService", () => {
 
     it("detects dependency files from ACP index", async () => {
       await expect(
-        service.isUnitDependencyFile("acp-1", "unit-1.xml"),
+        service.isUnitDependencyFile(acpId, "unit-1.xml"),
       ).resolves.toBe(true);
       await expect(
-        service.isUnitDependencyFile("acp-1", "test.json"),
+        service.isUnitDependencyFile(acpId, "test.json"),
       ).resolves.toBe(true);
       await expect(
-        service.isUnitDependencyFile("acp-1", "missing.json"),
+        service.isUnitDependencyFile(acpId, "missing.json"),
       ).resolves.toBe(false);
     });
   });

--- a/backend/src/files/files.service.spec.ts
+++ b/backend/src/files/files.service.spec.ts
@@ -16,6 +16,11 @@ import {
   AcpAccessConfig,
   ItemResponseState,
 } from "../database/entities";
+import { DataSource } from "typeorm";
+import { ArchiveExpansionService } from "./archive-expansion.service";
+import { FileMutationService } from "./file-mutation.service";
+import { FileStorageService } from "./file-storage.service";
+import { createAcpFileFixture, TEST_UUIDS } from "../testing/test-fixtures";
 
 jest.mock("fs/promises", () => ({
   mkdir: jest.fn().mockResolvedValue(undefined),
@@ -25,8 +30,8 @@ jest.mock("fs/promises", () => ({
 }));
 
 describe("FilesService", () => {
-  const acpId = "11111111-1111-4111-8111-111111111111";
-  const unknownAcpId = "99999999-9999-4999-8999-999999999999";
+  const acpId = TEST_UUIDS.acp;
+  const unknownAcpId = TEST_UUIDS.unknownAcp;
   let service: FilesService;
   let repo: any;
   let acpRepo: any;
@@ -34,20 +39,18 @@ describe("FilesService", () => {
   let stateRepo: any;
   let unitParserService: any;
   let validationService: any;
+  let dataSource: any;
 
-  const mockFile = {
+  const mockFile = createAcpFileFixture({
     id: "file-1",
-    acpId: acpId,
     filePath: "/uploads/acp-1/test.json",
     originalName: "test.json",
-    fileType: "application/json",
     fileSize: 1024,
     checksum: "abc123",
-    validationResult: null,
-    uploadedAt: new Date(),
-  };
+  });
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     repo = {
       find: jest.fn().mockResolvedValue([mockFile]),
       findOne: jest.fn().mockResolvedValue(mockFile),
@@ -143,10 +146,20 @@ describe("FilesService", () => {
         },
       }),
     };
+    dataSource = {
+      transaction: jest.fn().mockImplementation(async (work) =>
+        work({
+          getRepository: (entity: unknown) => (entity === Acp ? acpRepo : repo),
+        }),
+      ),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FilesService,
+        ArchiveExpansionService,
+        FileMutationService,
+        FileStorageService,
         { provide: getRepositoryToken(AcpFile), useValue: repo },
         { provide: getRepositoryToken(Acp), useValue: acpRepo },
         {
@@ -160,6 +173,7 @@ describe("FilesService", () => {
         },
         { provide: UnitParserService, useValue: unitParserService },
         { provide: ValidationService, useValue: validationService },
+        { provide: DataSource, useValue: dataSource },
       ],
     }).compile();
 
@@ -304,7 +318,7 @@ describe("FilesService", () => {
           fileSize: 12,
         }),
       );
-      expect(acpRepo.findOne).toHaveBeenCalledTimes(1);
+      expect(acpRepo.findOne).toHaveBeenCalledTimes(2);
       expect(result.map((file) => file.originalName)).toEqual([
         "unit-1.xml",
         "unit-1.vomd",
@@ -322,9 +336,6 @@ describe("FilesService", () => {
         originalName: "UNIT-1.VOCS",
       };
       repo.find.mockResolvedValue([existingVocs]);
-      const deleteSpy = jest
-        .spyOn(service, "deleteForAcp")
-        .mockResolvedValue(undefined);
       (fs.writeFile as jest.Mock).mockClear();
 
       const result = await service.uploadMultiple(
@@ -337,11 +348,13 @@ describe("FilesService", () => {
             buffer,
           } as Express.Multer.File,
         ],
-        "overwrite",
-        { expandArchives: false },
+        {
+          conflictStrategy: "overwrite",
+          expandArchives: false,
+        },
       );
 
-      expect(deleteSpy).toHaveBeenCalledWith(acpId, "vocs-file");
+      expect(repo.remove).toHaveBeenCalledWith([existingVocs]);
       expect(repo.create).toHaveBeenCalledTimes(1);
       expect(repo.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -371,58 +384,132 @@ describe("FilesService", () => {
     });
 
     it("should reject conflicts by default", async () => {
+      (fs.writeFile as jest.Mock).mockClear();
+      (fs.unlink as jest.Mock).mockClear();
+
       await expect(service.uploadMultiple(acpId, [incoming])).rejects.toThrow(
         ConflictException,
       );
+
+      expect(repo.save).not.toHaveBeenCalled();
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+      expect(fs.unlink).not.toHaveBeenCalled();
+    });
+
+    it("should recheck reject conflicts after acquiring the ACP lock", async () => {
+      repo.find.mockResolvedValueOnce([]).mockResolvedValueOnce([mockFile]);
+      (fs.unlink as jest.Mock).mockClear();
+
+      await expect(service.uploadMultiple(acpId, [incoming])).rejects.toThrow(
+        ConflictException,
+      );
+
+      expect(repo.find).toHaveBeenCalledTimes(2);
+      expect(fs.writeFile).toHaveBeenCalledTimes(1);
+      expect(repo.save).not.toHaveBeenCalled();
+      expect(fs.unlink).toHaveBeenCalledTimes(1);
+      expect(fs.unlink).not.toHaveBeenCalledWith(mockFile.filePath);
     });
 
     it("should overwrite existing files when strategy is overwrite", async () => {
-      const deleteSpy = jest
-        .spyOn(service, "deleteForAcp")
-        .mockResolvedValue(undefined);
+      const result = await service.uploadMultiple(acpId, [incoming], {
+        conflictStrategy: "overwrite",
+      });
 
-      const result = await service.uploadMultiple(
-        acpId,
-        [incoming],
-        "overwrite",
-      );
-
-      expect(deleteSpy).toHaveBeenCalledWith(acpId, "file-1");
+      expect(repo.remove).toHaveBeenCalledWith([mockFile]);
       expect(repo.create).toHaveBeenCalledWith(
         expect.objectContaining({
           acpId: acpId,
           originalName: incoming.originalname,
         }),
       );
-      expect(acpRepo.findOne).toHaveBeenCalledTimes(1);
+      expect(acpRepo.findOne).toHaveBeenCalledTimes(2);
+      expect(acpRepo.findOne).toHaveBeenNthCalledWith(2, {
+        where: { id: acpId },
+        lock: { mode: "pessimistic_write" },
+      });
       expect(result).toHaveLength(1);
+      expect(
+        (fs.writeFile as jest.Mock).mock.invocationCallOrder[0],
+      ).toBeLessThan(dataSource.transaction.mock.invocationCallOrder[0]);
+      expect(dataSource.transaction.mock.invocationCallOrder[0]).toBeLessThan(
+        acpRepo.findOne.mock.invocationCallOrder[1],
+      );
+      expect(acpRepo.findOne.mock.invocationCallOrder[1]).toBeLessThan(
+        repo.find.mock.invocationCallOrder[0],
+      );
+      expect(repo.save.mock.invocationCallOrder[0]).toBeLessThan(
+        repo.remove.mock.invocationCallOrder[0],
+      );
+      expect(repo.remove.mock.invocationCallOrder[0]).toBeLessThan(
+        (fs.unlink as jest.Mock).mock.invocationCallOrder[0],
+      );
+    });
+
+    it("should keep original files when the metadata transaction fails", async () => {
+      dataSource.transaction.mockRejectedValueOnce(
+        new Error("transaction failed"),
+      );
+      (fs.unlink as jest.Mock).mockClear();
+
+      await expect(
+        service.uploadMultiple(acpId, [incoming], {
+          conflictStrategy: "overwrite",
+        }),
+      ).rejects.toThrow("transaction failed");
+
+      expect(repo.remove).not.toHaveBeenCalled();
+      expect(fs.unlink).toHaveBeenCalledTimes(1);
+      expect(fs.unlink).not.toHaveBeenCalledWith(mockFile.filePath);
+    });
+
+    it("should keep original files when staging a batch fails", async () => {
+      (fs.writeFile as jest.Mock)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("disk full"));
+      (fs.unlink as jest.Mock).mockClear();
+
+      await expect(
+        service.uploadMultiple(
+          acpId,
+          [
+            incoming,
+            {
+              ...incoming,
+              originalname: "second.json",
+            } as Express.Multer.File,
+          ],
+          { conflictStrategy: "overwrite" },
+        ),
+      ).rejects.toThrow("disk full");
+
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+      expect(repo.remove).not.toHaveBeenCalled();
+      expect(fs.unlink).not.toHaveBeenCalledWith(mockFile.filePath);
     });
 
     it("should keep both files when strategy is keep-both", async () => {
-      const deleteSpy = jest
-        .spyOn(service, "deleteForAcp")
-        .mockResolvedValue(undefined);
+      const result = await service.uploadMultiple(acpId, [incoming], {
+        conflictStrategy: "keep-both",
+      });
 
-      const result = await service.uploadMultiple(
-        acpId,
-        [incoming],
-        "keep-both",
-      );
-
-      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(repo.remove).not.toHaveBeenCalled();
       expect(repo.create).toHaveBeenCalledWith(
         expect.objectContaining({
           acpId: acpId,
           originalName: incoming.originalname,
         }),
       );
-      expect(acpRepo.findOne).toHaveBeenCalledTimes(1);
+      expect(acpRepo.findOne).toHaveBeenCalledTimes(2);
       expect(result).toHaveLength(1);
     });
 
     it("should reject invalid conflict strategy", async () => {
       await expect(
-        service.uploadMultiple(acpId, [incoming], "invalid-strategy"),
+        service.uploadMultiple(acpId, [incoming], {
+          conflictStrategy: "invalid-strategy",
+        }),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -585,6 +672,35 @@ describe("FilesService", () => {
         expect.objectContaining({ id: "file-1" }),
         expect.objectContaining({ id: "file-2" }),
       ]);
+    });
+
+    it("should remove physical files sequentially", async () => {
+      repo.find.mockResolvedValue([
+        { ...mockFile, id: "file-1", filePath: "/x/1" },
+        { ...mockFile, id: "file-2", filePath: "/x/2" },
+      ]);
+      let signalFirstUnlink!: () => void;
+      let releaseFirstUnlink!: () => void;
+      const firstUnlinkStarted = new Promise<void>((resolve) => {
+        signalFirstUnlink = resolve;
+      });
+      (fs.unlink as jest.Mock)
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((resolve) => {
+              releaseFirstUnlink = resolve;
+              signalFirstUnlink();
+            }),
+        )
+        .mockResolvedValueOnce(undefined);
+
+      const deletion = service.deleteAll(acpId);
+      await firstUnlinkStarted;
+
+      expect(fs.unlink).toHaveBeenCalledTimes(1);
+      releaseFirstUnlink();
+      await deletion;
+      expect(fs.unlink).toHaveBeenCalledTimes(2);
     });
 
     it("should bulk delete ACP files for the provided IDs", async () => {

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -2,7 +2,6 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
-  ConflictException,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
@@ -31,11 +30,11 @@ import {
 import { FileProcessingProgressReporter } from "./file-processing-progress";
 import { parseItemRowKeyParts } from "../items/item-row-key.util";
 import { assertUuidParam } from "../common/uuid-param";
-
-type UploadConflictStrategy = "reject" | "overwrite" | "keep-both";
-type UploadMultipleOptions = {
-  expandArchives?: boolean;
-};
+import {
+  FileMutationService,
+  UploadMultipleOptions,
+} from "./file-mutation.service";
+import { FileStorageService } from "./file-storage.service";
 export type FilePreviewMode =
   | "text"
   | "image"
@@ -161,6 +160,8 @@ export class FilesService {
     private readonly configService: ConfigService,
     private readonly unitParserService: UnitParserService,
     private readonly validationService: ValidationService,
+    private readonly fileMutationService: FileMutationService,
+    private readonly fileStorageService: FileStorageService,
   ) {
     this.storagePath = this.configService.get<string>(
       "FILE_STORAGE_PATH",
@@ -202,97 +203,21 @@ export class FilesService {
     acpId: string,
     uploadedFile: Express.Multer.File,
   ): Promise<AcpFile> {
-    await this.getAcpOrFail(acpId);
-    return this.persistUpload(acpId, uploadedFile);
+    return this.fileMutationService.upload(acpId, uploadedFile);
   }
 
   async uploadMultiple(
     acpId: string,
     files: Express.Multer.File[],
-    conflictStrategyInput?: string,
     options: UploadMultipleOptions = {},
   ): Promise<AcpFile[]> {
-    const conflictStrategy = this.resolveUploadConflictStrategy(
-      conflictStrategyInput,
-    );
-
-    if (!files?.length) {
-      throw new BadRequestException("At least one file is required");
-    }
-
-    await this.getAcpOrFail(acpId);
-    const normalizedFiles =
-      options.expandArchives === false
-        ? files
-        : await this.expandUploadedFiles(files);
-    const existingFiles = await this.findFileRecordsByAcp(acpId);
-    const existingByName = new Map<string, AcpFile[]>();
-    for (const existing of existingFiles) {
-      const key = this.normalizeFileName(existing.originalName);
-      if (!key) {
-        continue;
-      }
-      const bucket = existingByName.get(key) || [];
-      bucket.push(existing);
-      existingByName.set(key, bucket);
-    }
-
-    const seenIncomingNames = new Set<string>();
-    const conflicts = new Set<string>();
-    for (const incoming of normalizedFiles) {
-      const incomingName = String(incoming?.originalname || "").trim();
-      const key = this.normalizeFileName(incomingName);
-      if (!key) {
-        throw new BadRequestException("All files must include a filename");
-      }
-
-      if (existingByName.has(key) || seenIncomingNames.has(key)) {
-        conflicts.add(incomingName);
-      }
-      seenIncomingNames.add(key);
-    }
-
-    if (conflictStrategy === "reject" && conflicts.size > 0) {
-      throw new ConflictException({
-        message:
-          "File conflicts detected. Resolve duplicates by skipping or uploading with conflictStrategy=overwrite.",
-        conflicts: Array.from(conflicts).sort((a, b) => a.localeCompare(b)),
-      });
-    }
-
-    const results: AcpFile[] = [];
-
-    for (const file of normalizedFiles) {
-      const key = this.normalizeFileName(file.originalname);
-      if (!key) {
-        throw new BadRequestException("All files must include a filename");
-      }
-
-      if (conflictStrategy === "overwrite") {
-        const matches = existingByName.get(key) || [];
-        for (const match of matches) {
-          await this.deleteForAcp(acpId, match.id);
-        }
-        existingByName.delete(key);
-      }
-
-      results.push(await this.persistUpload(acpId, file));
-
-      if (conflictStrategy === "keep-both") {
-        const bucket = existingByName.get(key) || [];
-        bucket.push(results[results.length - 1]);
-        existingByName.set(key, bucket);
-      } else {
-        existingByName.set(key, [results[results.length - 1]]);
-      }
-    }
-    return results;
+    return this.fileMutationService.uploadMultiple(acpId, files, options);
   }
 
   async download(id: string): Promise<{ buffer: Buffer; file: AcpFile }> {
     const file = await this.findById(id);
     try {
-      const buffer = await fs.readFile(file.filePath);
+      const buffer = await this.fileStorageService.read(file);
       return { buffer, file };
     } catch {
       throw new NotFoundException("File not found on disk");
@@ -305,7 +230,7 @@ export class FilesService {
   ): Promise<{ buffer: Buffer; file: AcpFile }> {
     const file = await this.findByIdForAcp(acpId, id);
     try {
-      const buffer = await fs.readFile(file.filePath);
+      const buffer = await this.fileStorageService.read(file);
       return { buffer, file };
     } catch {
       throw new NotFoundException("File not found on disk");
@@ -314,22 +239,14 @@ export class FilesService {
 
   async delete(id: string): Promise<void> {
     const file = await this.findById(id);
-    try {
-      await fs.unlink(file.filePath);
-    } catch {
-      // File may already be deleted from disk
-    }
     await this.fileRepository.remove(file);
+    await this.fileStorageService.removePhysicalFile(file);
   }
 
   async deleteForAcp(acpId: string, id: string): Promise<void> {
     const file = await this.findByIdForAcp(acpId, id);
-    try {
-      await fs.unlink(file.filePath);
-    } catch {
-      // File may already be deleted from disk
-    }
     await this.fileRepository.remove(file);
+    await this.fileStorageService.removePhysicalFile(file);
   }
 
   async deleteManyForAcp(acpId: string, ids: string[]): Promise<string[]> {
@@ -355,27 +272,15 @@ export class FilesService {
     }
 
     const filesToDelete = normalizedIds.map((id) => filesById.get(id)!);
-    for (const file of filesToDelete) {
-      try {
-        await fs.unlink(file.filePath);
-      } catch {
-        // File may already be deleted from disk
-      }
-    }
     await this.fileRepository.remove(filesToDelete);
+    await this.fileStorageService.removePhysicalFiles(filesToDelete);
     return normalizedIds;
   }
 
   async deleteAll(acpId: string): Promise<void> {
     const files = await this.findByAcp(acpId);
-    for (const file of files) {
-      try {
-        await fs.unlink(file.filePath);
-      } catch {
-        // File may already be deleted from disk
-      }
-    }
     await this.fileRepository.remove(files);
+    await this.fileStorageService.removePhysicalFiles(files);
   }
 
   async cleanupOrphanedResponseStates(acpId: string): Promise<{
@@ -732,36 +637,6 @@ export class FilesService {
       throw new NotFoundException(`ACP with ID ${acpId} not found`);
     }
     return acp;
-  }
-
-  private async persistUpload(
-    acpId: string,
-    uploadedFile: Express.Multer.File,
-  ): Promise<AcpFile> {
-    const acpDir = path.join(this.storagePath, acpId);
-    await fs.mkdir(acpDir, { recursive: true });
-
-    const ext = path.extname(uploadedFile.originalname);
-    const uniqueName = `${crypto.randomUUID()}${ext}`;
-    const filePath = path.join(acpDir, uniqueName);
-
-    await fs.writeFile(filePath, uploadedFile.buffer);
-
-    const checksum = crypto
-      .createHash("sha256")
-      .update(uploadedFile.buffer)
-      .digest("hex");
-
-    const file = this.fileRepository.create({
-      acpId,
-      filePath,
-      originalName: uploadedFile.originalname,
-      fileType: uploadedFile.mimetype,
-      fileSize: uploadedFile.size,
-      checksum,
-    });
-
-    return this.fileRepository.save(file);
   }
 
   private buildBasePreview(
@@ -1473,212 +1348,5 @@ export class FilesService {
       files: normalizedIds.map((id) => filesById.get(id)!),
       fileName: `acp-${acpId}-selected-files.zip`,
     };
-  }
-
-  private resolveUploadConflictStrategy(
-    conflictStrategyInput?: string,
-  ): UploadConflictStrategy {
-    const strategy = (conflictStrategyInput || "reject").trim().toLowerCase();
-    if (
-      strategy === "reject" ||
-      strategy === "overwrite" ||
-      strategy === "keep-both"
-    ) {
-      return strategy;
-    }
-    throw new BadRequestException(
-      "Invalid conflictStrategy. Expected one of: reject, overwrite, keep-both",
-    );
-  }
-
-  private async expandUploadedFiles(
-    files: Express.Multer.File[],
-  ): Promise<Express.Multer.File[]> {
-    const expandedFiles: Express.Multer.File[] = [];
-
-    for (const file of files) {
-      const incomingName = String(file?.originalname || "").trim();
-      if (!incomingName) {
-        throw new BadRequestException("All files must include a filename");
-      }
-
-      if (!this.isZipUpload(file)) {
-        expandedFiles.push(file);
-        continue;
-      }
-
-      const extractedFiles = await this.extractZipEntries(file);
-      if (!extractedFiles.length) {
-        throw new BadRequestException(
-          `ZIP archive "${incomingName}" does not contain any uploadable files`,
-        );
-      }
-
-      expandedFiles.push(...extractedFiles);
-    }
-
-    return expandedFiles;
-  }
-
-  private isZipUpload(file: Express.Multer.File): boolean {
-    const fileName = String(file?.originalname || "")
-      .trim()
-      .toLowerCase();
-    const mimeType = this.normalizeMimeType(file?.mimetype);
-    return (
-      fileName.endsWith(".zip") ||
-      mimeType === "application/zip" ||
-      mimeType === "application/x-zip-compressed"
-    );
-  }
-
-  private async extractZipEntries(
-    uploadedZip: Express.Multer.File,
-  ): Promise<Express.Multer.File[]> {
-    const JSZip = require("jszip");
-
-    let archive: any;
-    try {
-      archive = await JSZip.loadAsync(uploadedZip.buffer);
-    } catch {
-      throw new BadRequestException(
-        `ZIP archive "${uploadedZip.originalname}" could not be extracted`,
-      );
-    }
-
-    const extractedFiles: Express.Multer.File[] = [];
-    const archiveEntries = Object.values(archive.files || {});
-
-    for (const entry of archiveEntries as Array<{
-      dir?: boolean;
-      name?: string;
-    }>) {
-      if (entry?.dir) {
-        continue;
-      }
-
-      const originalEntryName = String(entry?.name || "");
-      const extractedName = this.getArchiveEntryFileName(originalEntryName);
-      if (
-        !extractedName ||
-        this.shouldSkipArchiveEntry(originalEntryName, extractedName)
-      ) {
-        continue;
-      }
-
-      const zipEntry = archive.file(originalEntryName);
-      if (!zipEntry) {
-        continue;
-      }
-
-      const buffer = Buffer.from(await zipEntry.async("nodebuffer"));
-      extractedFiles.push({
-        ...uploadedZip,
-        originalname: extractedName,
-        mimetype: this.inferMimeTypeFromFileName(extractedName),
-        size: buffer.length,
-        buffer,
-      });
-    }
-
-    return extractedFiles;
-  }
-
-  private getArchiveEntryFileName(entryName: string): string {
-    const normalizedPath = String(entryName || "")
-      .replace(/\\/g, "/")
-      .trim();
-    return path.posix.basename(normalizedPath).trim();
-  }
-
-  private shouldSkipArchiveEntry(
-    entryName: string,
-    extractedName: string,
-  ): boolean {
-    const normalizedPath = String(entryName || "")
-      .replace(/\\/g, "/")
-      .trim();
-    if (!normalizedPath) {
-      return true;
-    }
-
-    if (normalizedPath.startsWith("__MACOSX/")) {
-      return true;
-    }
-
-    return extractedName === ".DS_Store";
-  }
-
-  private inferMimeTypeFromFileName(fileName: string): string {
-    const extension = this.getFileExtension(fileName);
-
-    switch (extension) {
-      case "xml":
-        return "application/xml";
-      case "json":
-      case "voud":
-      case "vomd":
-      case "vocs":
-        return "application/json";
-      case "html":
-      case "htm":
-        return "text/html";
-      case "csv":
-        return "text/csv";
-      case "tsv":
-        return "text/tab-separated-values";
-      case "txt":
-      case "md":
-      case "log":
-      case "yml":
-      case "yaml":
-      case "ini":
-      case "properties":
-        return "text/plain";
-      case "pdf":
-        return "application/pdf";
-      case "png":
-        return "image/png";
-      case "jpg":
-      case "jpeg":
-        return "image/jpeg";
-      case "gif":
-        return "image/gif";
-      case "webp":
-        return "image/webp";
-      case "svg":
-      case "svgz":
-        return "image/svg+xml";
-      case "bmp":
-        return "image/bmp";
-      case "mp3":
-        return "audio/mpeg";
-      case "wav":
-        return "audio/wav";
-      case "ogg":
-        return "audio/ogg";
-      case "m4a":
-        return "audio/mp4";
-      case "aac":
-        return "audio/aac";
-      case "mp4":
-        return "video/mp4";
-      case "webm":
-        return "video/webm";
-      case "mov":
-        return "video/quicktime";
-      case "m4v":
-        return "video/x-m4v";
-      case "ogv":
-        return "video/ogg";
-      default:
-        return "application/octet-stream";
-    }
-  }
-
-  private normalizeFileName(fileName: string): string {
-    return String(fileName || "")
-      .trim()
-      .toLowerCase();
   }
 }

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -30,8 +30,12 @@ import {
 } from "../validation/validation.service";
 import { FileProcessingProgressReporter } from "./file-processing-progress";
 import { parseItemRowKeyParts } from "../items/item-row-key.util";
+import { assertUuidParam } from "../common/uuid-param";
 
 type UploadConflictStrategy = "reject" | "overwrite" | "keep-both";
+type UploadMultipleOptions = {
+  expandArchives?: boolean;
+};
 export type FilePreviewMode =
   | "text"
   | "image"
@@ -165,6 +169,11 @@ export class FilesService {
   }
 
   async findByAcp(acpId: string): Promise<AcpFile[]> {
+    await this.getAcpOrFail(acpId);
+    return this.findFileRecordsByAcp(acpId);
+  }
+
+  private async findFileRecordsByAcp(acpId: string): Promise<AcpFile[]> {
     return this.fileRepository.find({
       where: { acpId },
       order: { originalName: "ASC" },
@@ -193,41 +202,15 @@ export class FilesService {
     acpId: string,
     uploadedFile: Express.Multer.File,
   ): Promise<AcpFile> {
-    // Ensure directory exists
-    const acpDir = path.join(this.storagePath, acpId);
-    await fs.mkdir(acpDir, { recursive: true });
-
-    // Generate unique filename
-    const ext = path.extname(uploadedFile.originalname);
-    const uniqueName = `${crypto.randomUUID()}${ext}`;
-    const filePath = path.join(acpDir, uniqueName);
-
-    // Write file
-    await fs.writeFile(filePath, uploadedFile.buffer);
-
-    // Compute checksum
-    const checksum = crypto
-      .createHash("sha256")
-      .update(uploadedFile.buffer)
-      .digest("hex");
-
-    // Save metadata
-    const file = this.fileRepository.create({
-      acpId,
-      filePath,
-      originalName: uploadedFile.originalname,
-      fileType: uploadedFile.mimetype,
-      fileSize: uploadedFile.size,
-      checksum,
-    });
-
-    return this.fileRepository.save(file);
+    await this.getAcpOrFail(acpId);
+    return this.persistUpload(acpId, uploadedFile);
   }
 
   async uploadMultiple(
     acpId: string,
     files: Express.Multer.File[],
     conflictStrategyInput?: string,
+    options: UploadMultipleOptions = {},
   ): Promise<AcpFile[]> {
     const conflictStrategy = this.resolveUploadConflictStrategy(
       conflictStrategyInput,
@@ -237,8 +220,12 @@ export class FilesService {
       throw new BadRequestException("At least one file is required");
     }
 
-    const normalizedFiles = await this.expandUploadedFiles(files);
-    const existingFiles = await this.findByAcp(acpId);
+    await this.getAcpOrFail(acpId);
+    const normalizedFiles =
+      options.expandArchives === false
+        ? files
+        : await this.expandUploadedFiles(files);
+    const existingFiles = await this.findFileRecordsByAcp(acpId);
     const existingByName = new Map<string, AcpFile[]>();
     for (const existing of existingFiles) {
       const key = this.normalizeFileName(existing.originalName);
@@ -289,7 +276,7 @@ export class FilesService {
         existingByName.delete(key);
       }
 
-      results.push(await this.upload(acpId, file));
+      results.push(await this.persistUpload(acpId, file));
 
       if (conflictStrategy === "keep-both") {
         const bucket = existingByName.get(key) || [];
@@ -709,6 +696,7 @@ export class FilesService {
   }
 
   async getFeatureConfig(acpId: string): Promise<Record<string, any>> {
+    await this.getAcpOrFail(acpId);
     const config = await this.accessConfigRepository.findOne({
       where: { acpId },
     });
@@ -735,6 +723,45 @@ export class FilesService {
       }
     }
     return false;
+  }
+
+  private async getAcpOrFail(acpId: string): Promise<Acp> {
+    assertUuidParam(acpId, "ACP ID");
+    const acp = await this.acpRepository.findOne({ where: { id: acpId } });
+    if (!acp) {
+      throw new NotFoundException(`ACP with ID ${acpId} not found`);
+    }
+    return acp;
+  }
+
+  private async persistUpload(
+    acpId: string,
+    uploadedFile: Express.Multer.File,
+  ): Promise<AcpFile> {
+    const acpDir = path.join(this.storagePath, acpId);
+    await fs.mkdir(acpDir, { recursive: true });
+
+    const ext = path.extname(uploadedFile.originalname);
+    const uniqueName = `${crypto.randomUUID()}${ext}`;
+    const filePath = path.join(acpDir, uniqueName);
+
+    await fs.writeFile(filePath, uploadedFile.buffer);
+
+    const checksum = crypto
+      .createHash("sha256")
+      .update(uploadedFile.buffer)
+      .digest("hex");
+
+    const file = this.fileRepository.create({
+      acpId,
+      filePath,
+      originalName: uploadedFile.originalname,
+      fileType: uploadedFile.mimetype,
+      fileSize: uploadedFile.size,
+      checksum,
+    });
+
+    return this.fileRepository.save(file);
   }
 
   private buildBasePreview(

--- a/backend/src/items/items.controller.ts
+++ b/backend/src/items/items.controller.ts
@@ -14,7 +14,6 @@ import {
   ForbiddenException,
   BadRequestException,
   ConflictException,
-  UsePipes,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -34,7 +33,7 @@ import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { IsObject } from "class-validator";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
-import { UuidRouteParamsPipe } from "../common/uuid-param";
+import { UuidParam } from "../common/uuid-param";
 
 type ItemParameterImportKind = "item-parameters" | "empirical-difficulty";
 type ItemParameterImportTarget = "draft" | "published";
@@ -60,7 +59,6 @@ class SaveItemTagsDto {
 
 @ApiTags("Items")
 @Controller("acp/:acpId/items")
-@UsePipes(new UuidRouteParamsPipe())
 export class ItemsController {
   constructor(
     private readonly itemsService: ItemsService,
@@ -77,7 +75,7 @@ export class ItemsController {
   @ApiQuery({ name: "sortBy", required: false })
   @ApiQuery({ name: "sortDir", required: false, enum: ["asc", "desc"] })
   async getItems(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Query("filter") filter?: string,
     @Query("sortBy") sortBy?: string,
     @Query("sortDir") sortDir?: "asc" | "desc",
@@ -91,7 +89,7 @@ export class ItemsController {
   @UseGuards(JwtAuthGuard, AcpAccessGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: "Get persisted item tags for an ACP" })
-  async getItemTags(@Param("acpId") acpId: string, @Request() req: any) {
+  async getItemTags(@UuidParam("acpId") acpId: string, @Request() req: any) {
     const isManager = req.user?.isAppAdmin || req.acpAccessLevel === "MANAGER";
     if (!isManager && !(await this.itemsService.canUseItemTags(acpId))) {
       throw new ForbiddenException("Item tags are not enabled for this ACP");
@@ -104,7 +102,7 @@ export class ItemsController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Persist item tags for an ACP" })
   async saveItemTags(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() dto: SaveItemTagsDto,
     @Request() req: any,
   ) {
@@ -128,7 +126,7 @@ export class ItemsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get a single item by ID" })
   async getItem(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Param("itemId") itemId: string,
     @Request() req?: any,
   ) {
@@ -154,7 +152,7 @@ export class ItemsController {
   })
   @UseInterceptors(FileInterceptor("file"))
   async uploadItemParameters(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @UploadedFile() file: Express.Multer.File,
     @Query("draft") draft?: string,
     @Query("baseVersion") baseVersion?: string,
@@ -194,7 +192,7 @@ export class ItemsController {
   })
   @UseInterceptors(FileInterceptor("file"))
   async uploadEmpiricalDifficulties(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @UploadedFile() file: Express.Multer.File,
     @Query("draft") draft?: string,
     @Query("baseVersion") baseVersion?: string,
@@ -216,7 +214,7 @@ export class ItemsController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Clear all empirical difficulties for an ACP" })
   async clearEmpiricalDifficulties(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Query("draft") draft?: string,
     @Query("baseVersion") baseVersion?: string,
     @Request() req?: any,
@@ -303,7 +301,7 @@ export class ItemsController {
     summary: "Get all response states for an ACP (Manager only)",
   })
   async getAllResponseStates(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Request() _req: any,
   ) {
     return this.stateService.getAllStatesForAcp(acpId, true);
@@ -317,7 +315,7 @@ export class ItemsController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Save response state for an item (Manager only)" })
   async saveResponseState(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Param("itemId") itemId: string,
     @Body()
     body: {
@@ -341,7 +339,7 @@ export class ItemsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get response state for an item" })
   async getResponseState(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Param("itemId") itemId: string,
     @Query("unitId") unitId?: string,
     @Query("rowKey") rowKey?: string,
@@ -365,7 +363,7 @@ export class ItemsController {
       "Get response state for an item with fallback to previous items in same unit",
   })
   async getResponseStateWithFallback(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Param("itemId") itemId: string,
     @Body()
     body: {
@@ -389,7 +387,7 @@ export class ItemsController {
   @ApiBearerAuth()
   @ApiOperation({ summary: "Delete response state for an item (Manager only)" })
   async deleteResponseState(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Param("itemId") itemId: string,
     @Query("unitId") unitId: string | undefined,
     @Request() _req: any,

--- a/backend/src/items/items.controller.ts
+++ b/backend/src/items/items.controller.ts
@@ -14,6 +14,7 @@ import {
   ForbiddenException,
   BadRequestException,
   ConflictException,
+  UsePipes,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -33,6 +34,7 @@ import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { IsObject } from "class-validator";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
+import { UuidRouteParamsPipe } from "../common/uuid-param";
 
 type ItemParameterImportKind = "item-parameters" | "empirical-difficulty";
 type ItemParameterImportTarget = "draft" | "published";
@@ -58,6 +60,7 @@ class SaveItemTagsDto {
 
 @ApiTags("Items")
 @Controller("acp/:acpId/items")
+@UsePipes(new UuidRouteParamsPipe())
 export class ItemsController {
   constructor(
     private readonly itemsService: ItemsService,

--- a/backend/src/snapshots/snapshots.controller.ts
+++ b/backend/src/snapshots/snapshots.controller.ts
@@ -1,25 +1,15 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Delete,
-  Param,
-  Body,
-  UseGuards,
-  UsePipes,
-} from "@nestjs/common";
+import { Controller, Get, Post, Delete, Body, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiTags, ApiOperation } from "@nestjs/swagger";
 import { SnapshotsService } from "./snapshots.service";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { CreateSnapshotDto } from "../acp/dto/acp.dto";
-import { UuidRouteParamsPipe } from "../common/uuid-param";
+import { UuidParam } from "../common/uuid-param";
 
 @ApiTags("ACP Snapshots")
 @Controller("acp/:acpId/snapshots")
 @UseGuards(JwtAuthGuard, RolesGuard)
-@UsePipes(new UuidRouteParamsPipe())
 @Roles("ACP_MANAGER")
 @ApiBearerAuth()
 export class SnapshotsController {
@@ -27,30 +17,33 @@ export class SnapshotsController {
 
   @Get()
   @ApiOperation({ summary: "List all snapshots for an ACP" })
-  async findAll(@Param("acpId") acpId: string) {
+  async findAll(@UuidParam("acpId") acpId: string) {
     return this.snapshotsService.findByAcp(acpId);
   }
 
   @Get(":snapshotId")
   @ApiOperation({ summary: "Get snapshot details" })
   async findOne(
-    @Param("acpId") acpId: string,
-    @Param("snapshotId") snapshotId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("snapshotId") snapshotId: string,
   ) {
     return this.snapshotsService.findByIdInAcp(acpId, snapshotId);
   }
 
   @Post()
   @ApiOperation({ summary: "Create a new snapshot" })
-  async create(@Param("acpId") acpId: string, @Body() dto: CreateSnapshotDto) {
+  async create(
+    @UuidParam("acpId") acpId: string,
+    @Body() dto: CreateSnapshotDto,
+  ) {
     return this.snapshotsService.create(acpId, dto.changelog);
   }
 
   @Post(":snapshotId/restore")
   @ApiOperation({ summary: "Restore ACP to a snapshot" })
   async restore(
-    @Param("acpId") acpId: string,
-    @Param("snapshotId") snapshotId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("snapshotId") snapshotId: string,
   ) {
     await this.snapshotsService.findByIdInAcp(acpId, snapshotId);
     return this.snapshotsService.restore(snapshotId);
@@ -59,8 +52,8 @@ export class SnapshotsController {
   @Get(":snapshotId/diff")
   @ApiOperation({ summary: "Compare snapshot with previous" })
   async diff(
-    @Param("acpId") acpId: string,
-    @Param("snapshotId") snapshotId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("snapshotId") snapshotId: string,
   ) {
     await this.snapshotsService.findByIdInAcp(acpId, snapshotId);
     return this.snapshotsService.diff(snapshotId);
@@ -69,8 +62,8 @@ export class SnapshotsController {
   @Get(":snapshotId/diff/current")
   @ApiOperation({ summary: "Compare snapshot with current ACP state" })
   async diffWithCurrent(
-    @Param("acpId") acpId: string,
-    @Param("snapshotId") snapshotId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("snapshotId") snapshotId: string,
   ) {
     await this.snapshotsService.findByIdInAcp(acpId, snapshotId);
     return this.snapshotsService.diffWithCurrent(snapshotId);
@@ -79,8 +72,8 @@ export class SnapshotsController {
   @Delete(":snapshotId")
   @ApiOperation({ summary: "Delete snapshot" })
   async delete(
-    @Param("acpId") acpId: string,
-    @Param("snapshotId") snapshotId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("snapshotId") snapshotId: string,
   ) {
     await this.snapshotsService.findByIdInAcp(acpId, snapshotId);
     await this.snapshotsService.delete(snapshotId);

--- a/backend/src/snapshots/snapshots.controller.ts
+++ b/backend/src/snapshots/snapshots.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Body,
   UseGuards,
+  UsePipes,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiTags, ApiOperation } from "@nestjs/swagger";
 import { SnapshotsService } from "./snapshots.service";
@@ -13,10 +14,12 @@ import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { CreateSnapshotDto } from "../acp/dto/acp.dto";
+import { UuidRouteParamsPipe } from "../common/uuid-param";
 
 @ApiTags("ACP Snapshots")
 @Controller("acp/:acpId/snapshots")
 @UseGuards(JwtAuthGuard, RolesGuard)
+@UsePipes(new UuidRouteParamsPipe())
 @Roles("ACP_MANAGER")
 @ApiBearerAuth()
 export class SnapshotsController {

--- a/backend/src/snapshots/snapshots.service.spec.ts
+++ b/backend/src/snapshots/snapshots.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
-import { NotFoundException } from "@nestjs/common";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { SnapshotsService } from "./snapshots.service";
 import {
@@ -21,6 +21,8 @@ jest.mock("fs/promises", () => ({
 }));
 
 describe("SnapshotsService", () => {
+  const acpId = "11111111-1111-4111-8111-111111111111";
+  const unknownAcpId = "99999999-9999-4999-8999-999999999999";
   let service: SnapshotsService;
   let snapshotRepo: any;
   let snapshotFileRepo: any;
@@ -29,13 +31,13 @@ describe("SnapshotsService", () => {
   let configService: any;
 
   const mockAcp = {
-    id: "acp-1",
+    id: acpId,
     acpIndex: { packageId: "test", version: "1.0", units: [{ id: "u1" }] },
   };
 
   const mockSnapshot = {
     id: "snap-1",
-    acpId: "acp-1",
+    acpId: acpId,
     versionNumber: 1,
     acpIndexSnapshot: {
       packageId: "test",
@@ -112,13 +114,30 @@ describe("SnapshotsService", () => {
 
   describe("findByAcp", () => {
     it("should return snapshots ordered by version descending", async () => {
-      const result = await service.findByAcp("acp-1");
+      const result = await service.findByAcp(acpId);
       expect(result).toHaveLength(1);
       expect(snapshotRepo.find).toHaveBeenCalledWith(
         expect.objectContaining({
           order: { versionNumber: "DESC" },
         }),
       );
+    });
+
+    it("should reject an unknown ACP before querying snapshots", async () => {
+      acpRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.findByAcp(unknownAcpId)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(snapshotRepo.find).not.toHaveBeenCalled();
+    });
+
+    it("should reject a malformed ACP ID before querying repositories", async () => {
+      await expect(
+        service.findByAcp("__coding-box-connection-test__"),
+      ).rejects.toThrow(BadRequestException);
+      expect(acpRepo.findOne).not.toHaveBeenCalled();
+      expect(snapshotRepo.find).not.toHaveBeenCalled();
     });
   });
 
@@ -132,7 +151,7 @@ describe("SnapshotsService", () => {
           snapshotFiles: [],
         }); // findById after save
 
-      await service.create("acp-1", "Test changelog");
+      await service.create(acpId, "Test changelog");
       expect(snapshotRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({
           versionNumber: 3,
@@ -146,7 +165,7 @@ describe("SnapshotsService", () => {
         .mockResolvedValueOnce(null) // no latest snapshot
         .mockResolvedValueOnce({ ...mockSnapshot, snapshotFiles: [] }); // findById after save
 
-      await service.create("acp-1");
+      await service.create(acpId);
       expect(snapshotRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({
           versionNumber: 1,
@@ -159,7 +178,7 @@ describe("SnapshotsService", () => {
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce({ ...mockSnapshot, snapshotFiles: [] });
 
-      await service.create("acp-1");
+      await service.create(acpId);
       expect(snapshotFileRepo.create).toHaveBeenCalled();
       expect(snapshotFileRepo.save).toHaveBeenCalled();
     });
@@ -171,11 +190,11 @@ describe("SnapshotsService", () => {
         snapshotFiles: [],
       });
 
-      await service.create("acp-1");
+      await service.create(acpId);
 
       const snapshotDir = path.join(
         "/tmp/uploads-test",
-        "acp-1",
+        acpId,
         "snapshots",
         "new-snap",
       );
@@ -192,7 +211,15 @@ describe("SnapshotsService", () => {
 
     it("should throw NotFoundException for unknown ACP", async () => {
       acpRepo.findOne.mockResolvedValue(null);
-      await expect(service.create("bad")).rejects.toThrow(NotFoundException);
+      await expect(service.create(unknownAcpId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("should reject malformed ACP IDs before creating a snapshot", async () => {
+      await expect(service.create("bad")).rejects.toThrow(BadRequestException);
+      expect(acpRepo.findOne).not.toHaveBeenCalled();
+      expect(snapshotRepo.save).not.toHaveBeenCalled();
     });
   });
 
@@ -220,10 +247,12 @@ describe("SnapshotsService", () => {
           acpIndex: snapshotWithFiles.acpIndexSnapshot,
         }),
       );
-      expect(fileRepo.delete).toHaveBeenCalledWith({ acpId: "acp-1" });
+      expect(fileRepo.delete).toHaveBeenCalledWith({
+        acpId: acpId,
+      });
       expect(fileRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          acpId: "acp-1",
+          acpId: acpId,
           originalName: "f1.json",
         }),
       );
@@ -279,7 +308,7 @@ describe("SnapshotsService", () => {
       snapshotRepo.findOne.mockImplementation((query: any) => {
         if (query?.where?.id === "snap-2")
           return Promise.resolve(currentSnapshot);
-        if (query?.where?.acpId === "acp-1" && query?.where?.versionNumber) {
+        if (query?.where?.acpId === acpId && query?.where?.versionNumber) {
           return Promise.resolve(previousSnapshot);
         }
         return Promise.resolve(null);
@@ -315,11 +344,11 @@ describe("SnapshotsService", () => {
         }),
       );
       expect(fs.rm).toHaveBeenCalledWith(
-        path.join("/tmp/uploads-test", "acp-1", "snapshots", "snap-1"),
+        path.join("/tmp/uploads-test", acpId, "snapshots", "snap-1"),
         { recursive: true, force: true },
       );
       expect(fs.rm).toHaveBeenCalledWith(
-        path.join("/tmp/uploads-test", "acp-1", "snapshot-restore", "snap-1"),
+        path.join("/tmp/uploads-test", acpId, "snapshot-restore", "snap-1"),
         { recursive: true, force: true },
       );
     });
@@ -338,11 +367,11 @@ describe("SnapshotsService", () => {
       await service.delete("snap-1");
 
       expect(fs.rm).toHaveBeenCalledWith(
-        path.join("/tmp/uploads-test", "acp-1", "snapshots", "snap-1"),
+        path.join("/tmp/uploads-test", acpId, "snapshots", "snap-1"),
         { recursive: true, force: true },
       );
       expect(fs.rm).toHaveBeenCalledWith(
-        path.join("/tmp/uploads-test", "acp-1", "snapshot-restore", "snap-1"),
+        path.join("/tmp/uploads-test", acpId, "snapshot-restore", "snap-1"),
         { recursive: true, force: true },
       );
     });

--- a/backend/src/snapshots/snapshots.service.spec.ts
+++ b/backend/src/snapshots/snapshots.service.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../database/entities";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { TEST_UUIDS, createAcpFixture } from "../testing/test-fixtures";
 
 jest.mock("fs/promises", () => ({
   access: jest.fn(),
@@ -21,8 +22,8 @@ jest.mock("fs/promises", () => ({
 }));
 
 describe("SnapshotsService", () => {
-  const acpId = "11111111-1111-4111-8111-111111111111";
-  const unknownAcpId = "99999999-9999-4999-8999-999999999999";
+  const acpId = TEST_UUIDS.acp;
+  const unknownAcpId = TEST_UUIDS.unknownAcp;
   let service: SnapshotsService;
   let snapshotRepo: any;
   let snapshotFileRepo: any;
@@ -30,10 +31,9 @@ describe("SnapshotsService", () => {
   let fileRepo: any;
   let configService: any;
 
-  const mockAcp = {
-    id: acpId,
+  const mockAcp = createAcpFixture({
     acpIndex: { packageId: "test", version: "1.0", units: [{ id: "u1" }] },
-  };
+  });
 
   const mockSnapshot = {
     id: "snap-1",

--- a/backend/src/snapshots/snapshots.service.ts
+++ b/backend/src/snapshots/snapshots.service.ts
@@ -10,6 +10,7 @@ import {
   AcpSnapshotFile,
   AcpFile,
 } from "../database/entities";
+import { assertUuidParam } from "../common/uuid-param";
 
 @Injectable()
 export class SnapshotsService {
@@ -33,6 +34,7 @@ export class SnapshotsService {
   }
 
   async findByAcp(acpId: string): Promise<AcpSnapshot[]> {
+    await this.getAcpOrFail(acpId);
     return this.snapshotRepository.find({
       where: { acpId },
       order: { versionNumber: "DESC" },
@@ -93,10 +95,7 @@ export class SnapshotsService {
   }
 
   async create(acpId: string, changelog?: string): Promise<AcpSnapshot> {
-    const acp = await this.acpRepository.findOne({ where: { id: acpId } });
-    if (!acp) {
-      throw new NotFoundException(`ACP with ID ${acpId} not found`);
-    }
+    const acp = await this.getAcpOrFail(acpId);
 
     // Determine next version number
     const latestSnapshot = await this.snapshotRepository.findOne({
@@ -347,5 +346,14 @@ export class SnapshotsService {
       modified,
       unchanged,
     };
+  }
+
+  private async getAcpOrFail(acpId: string): Promise<Acp> {
+    assertUuidParam(acpId, "ACP ID");
+    const acp = await this.acpRepository.findOne({ where: { id: acpId } });
+    if (!acp) {
+      throw new NotFoundException(`ACP with ID ${acpId} not found`);
+    }
+    return acp;
   }
 }

--- a/backend/src/testing/test-fixtures.ts
+++ b/backend/src/testing/test-fixtures.ts
@@ -1,0 +1,55 @@
+import { Acp, AcpFile } from "../database/entities";
+import {
+  AuthenticatedServerApiClient,
+  AuthenticatedServerApiRequest,
+} from "../api/server-api.types";
+
+export const TEST_UUIDS = {
+  acp: "11111111-1111-4111-8111-111111111111",
+  otherAcp: "22222222-2222-4222-8222-222222222222",
+  file: "33333333-3333-4333-8333-333333333333",
+  otherFile: "44444444-4444-4444-8444-444444444444",
+  unknownAcp: "99999999-9999-4999-8999-999999999999",
+} as const;
+
+export function createAcpFixture(overrides: Partial<Acp> = {}): Acp {
+  return {
+    id: TEST_UUIDS.acp,
+    packageId: "pkg-1",
+    name: "Test ACP",
+    description: "Test fixture",
+    acpIndex: {},
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  } as Acp;
+}
+
+export function createAcpFileFixture(
+  overrides: Partial<AcpFile> = {},
+): AcpFile {
+  return {
+    id: TEST_UUIDS.file,
+    acpId: TEST_UUIDS.acp,
+    filePath: "/uploads/test/file.json",
+    originalName: "file.json",
+    fileType: "application/json",
+    fileSize: 2,
+    checksum: "fixture-checksum",
+    uploadedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  } as AcpFile;
+}
+
+export function createServerApiRequest(
+  overrides: Partial<AuthenticatedServerApiClient> = {},
+): AuthenticatedServerApiRequest {
+  return {
+    serverApiClient: {
+      id: "test-client",
+      scopes: [],
+      allowedAcpIds: null,
+      ...overrides,
+    },
+  } as AuthenticatedServerApiRequest;
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Param,
   UseGuards,
+  UsePipes,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiTags, ApiOperation } from "@nestjs/swagger";
 import { UsersService } from "./users.service";
@@ -14,10 +15,12 @@ import { CreateUserDto, UpdateUserDto } from "./dto/user.dto";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
+import { UuidRouteParamsPipe } from "../common/uuid-param";
 
 @ApiTags("Users")
 @Controller("users")
 @UseGuards(JwtAuthGuard, RolesGuard)
+@UsePipes(new UuidRouteParamsPipe())
 @ApiBearerAuth()
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -5,9 +5,7 @@ import {
   Patch,
   Delete,
   Body,
-  Param,
   UseGuards,
-  UsePipes,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiTags, ApiOperation } from "@nestjs/swagger";
 import { UsersService } from "./users.service";
@@ -15,12 +13,11 @@ import { CreateUserDto, UpdateUserDto } from "./dto/user.dto";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import { RolesGuard } from "../auth/guards/roles.guard";
 import { Roles } from "../auth/roles.decorator";
-import { UuidRouteParamsPipe } from "../common/uuid-param";
+import { UuidParam } from "../common/uuid-param";
 
 @ApiTags("Users")
 @Controller("users")
 @UseGuards(JwtAuthGuard, RolesGuard)
-@UsePipes(new UuidRouteParamsPipe())
 @ApiBearerAuth()
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
@@ -35,7 +32,7 @@ export class UsersController {
   @Get(":id")
   @Roles("APP_ADMIN")
   @ApiOperation({ summary: "Get user by ID (Admin only)" })
-  async findOne(@Param("id") id: string) {
+  async findOne(@UuidParam("id") id: string) {
     return this.usersService.findById(id);
   }
 
@@ -49,14 +46,14 @@ export class UsersController {
   @Patch(":id")
   @Roles("APP_ADMIN")
   @ApiOperation({ summary: "Update user (Admin only)" })
-  async update(@Param("id") id: string, @Body() dto: UpdateUserDto) {
+  async update(@UuidParam("id") id: string, @Body() dto: UpdateUserDto) {
     return this.usersService.update(id, dto);
   }
 
   @Delete(":id")
   @Roles("APP_ADMIN")
   @ApiOperation({ summary: "Delete user (Admin only)" })
-  async delete(@Param("id") id: string) {
+  async delete(@UuidParam("id") id: string) {
     return this.usersService.delete(id);
   }
 
@@ -64,7 +61,7 @@ export class UsersController {
   @Roles("APP_ADMIN")
   @ApiOperation({ summary: "Toggle App-Admin role (Admin only)" })
   async setAppAdmin(
-    @Param("id") id: string,
+    @UuidParam("id") id: string,
     @Body("isAppAdmin") isAppAdmin: boolean,
   ) {
     return this.usersService.setAppAdmin(id, isAppAdmin);

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -13,7 +13,6 @@ import {
   Request,
   Res,
   UseGuards,
-  UsePipes,
 } from "@nestjs/common";
 import {
   ApiBody,
@@ -43,7 +42,7 @@ import {
   resolveStablePreferenceIdentity,
 } from "../item-preferences/preference-identity";
 import { SimpleItemListEntryDto } from "./dto/simple-item-list-entry.dto";
-import { UuidRouteParamsPipe } from "../common/uuid-param";
+import { UuidParam } from "../common/uuid-param";
 
 class SaveItemPreferencesDto {
   @ApiPropertyOptional({
@@ -196,7 +195,6 @@ class ActivateItemCollectionDto {
 
 @ApiTags("Public Views")
 @Controller("view")
-@UsePipes(new UuidRouteParamsPipe())
 export class ViewsController {
   constructor(
     private readonly viewsService: ViewsService,
@@ -221,14 +219,14 @@ export class ViewsController {
   @Get("acp/:acpId")
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "ACP start page data" })
-  async getAcpStartPage(@Param("acpId") acpId: string) {
+  async getAcpStartPage(@UuidParam("acpId") acpId: string) {
     return this.viewsService.getAcpStartPage(acpId);
   }
 
   @Get("acp/:acpId/index")
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get ACP-Index for read-only view" })
-  async getAcpIndex(@Param("acpId") acpId: string) {
+  async getAcpIndex(@UuidParam("acpId") acpId: string) {
     return this.viewsService.getAcpIndex(acpId);
   }
 
@@ -236,7 +234,7 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Export ACP-Index JSON for read-only view" })
   async exportAcpIndex(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Request() req: any,
     @Res() res: Response,
   ) {
@@ -258,7 +256,7 @@ export class ViewsController {
   @Get("acp/:acpId/units")
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "List all units in an ACP" })
-  async getUnits(@Param("acpId") acpId: string) {
+  async getUnits(@UuidParam("acpId") acpId: string) {
     const data = await this.viewsService.getAcpStartPage(acpId);
     return data?.units || [];
   }
@@ -267,7 +265,7 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get unit view data" })
   async getUnit(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Param("unitId") unitId: string,
     @Request() req: any,
   ) {
@@ -282,7 +280,7 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get item list for an ACP" })
   @ApiOkResponse({ type: SimpleItemListEntryDto, isArray: true })
-  async getItems(@Param("acpId") acpId: string, @Request() req: any) {
+  async getItems(@UuidParam("acpId") acpId: string, @Request() req: any) {
     if (!(await this.canUseFeature(acpId, req, "enableItemList", true))) {
       throw new ForbiddenException("Item list is not enabled for this ACP");
     }
@@ -296,7 +294,7 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get shared Item Explorer state for ACP" })
   async getItemExplorerState(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Request() req: any,
   ) {
     const canEdit =
@@ -308,7 +306,7 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get persisted user preferences for item views" })
   async getItemPreferences(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Request() req: any,
     @Query("viewId") viewId?: string,
   ) {
@@ -329,7 +327,7 @@ export class ViewsController {
   @ApiOperation({ summary: "Save persisted user preferences for item views" })
   @ApiBody({ type: SaveItemPreferencesDto })
   async saveItemPreferences(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() dto: SaveItemPreferencesDto,
     @Request() req: any,
   ) {
@@ -360,7 +358,7 @@ export class ViewsController {
   @ApiOperation({ summary: "Patch personal working data for one item row" })
   @ApiBody({ type: PatchPersonalItemRowDto })
   async patchPersonalItemRow(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() dto: PatchPersonalItemRowDto,
     @Request() req: any,
   ) {
@@ -386,7 +384,7 @@ export class ViewsController {
   @ApiOperation({ summary: "Export personal Item Explorer working data" })
   @ApiBody({ type: ExportPersonalItemDataDto })
   async exportPersonalItemDataXlsx(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() dto: ExportPersonalItemDataDto,
     @Request() req: any,
     @Res() res: Response,
@@ -428,7 +426,7 @@ export class ViewsController {
   })
   @ApiBody({ type: ExportAllPersonalItemDataDto })
   async exportAllPersonalItemDataCsv(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() dto: ExportAllPersonalItemDataDto,
     @Request() req: any,
     @Res() res: Response,
@@ -460,7 +458,7 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "List the caller's personal item collections" })
   async getItemCollections(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Query("perspective") perspective: "editor" | "read-only" | undefined,
     @Request() req: any,
   ) {
@@ -476,7 +474,7 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Create a personal item collection" })
   async createItemCollection(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() dto: CreateItemCollectionDto,
     @Request() req: any,
   ) {
@@ -493,8 +491,8 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Update a personal item collection" })
   async updateItemCollection(
-    @Param("acpId") acpId: string,
-    @Param("collectionId") collectionId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("collectionId") collectionId: string,
     @Body() dto: UpdateItemCollectionDto,
     @Request() req: any,
   ) {
@@ -512,7 +510,7 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Persist the active personal item collection" })
   async activateItemCollection(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Body() dto: ActivateItemCollectionDto,
     @Request() req: any,
   ) {
@@ -529,8 +527,8 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Delete a personal item collection" })
   async deleteItemCollection(
-    @Param("acpId") acpId: string,
-    @Param("collectionId") collectionId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("collectionId") collectionId: string,
     @Query("perspective") perspective: "editor" | "read-only" | undefined,
     @Request() req: any,
   ) {
@@ -547,8 +545,8 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Export one personal item collection as CSV" })
   async exportItemCollectionCsv(
-    @Param("acpId") acpId: string,
-    @Param("collectionId") collectionId: string,
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("collectionId") collectionId: string,
     @Query("perspective") perspective: "editor" | "read-only" | undefined,
     @Request() req: any,
     @Res() res: Response,
@@ -571,7 +569,7 @@ export class ViewsController {
   @Get("acp/:acpId/sequences")
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "List task sequences for an ACP" })
-  async getSequences(@Param("acpId") acpId: string, @Request() req: any) {
+  async getSequences(@UuidParam("acpId") acpId: string, @Request() req: any) {
     if (
       !(await this.canUseFeature(acpId, req, "enableSequenceNavigation", true))
     ) {
@@ -588,7 +586,7 @@ export class ViewsController {
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get task sequence with ordered units" })
   async getSequence(
-    @Param("acpId") acpId: string,
+    @UuidParam("acpId") acpId: string,
     @Param("sequenceId") sequenceId: string,
     @Request() req: any,
   ) {

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -13,6 +13,7 @@ import {
   Request,
   Res,
   UseGuards,
+  UsePipes,
 } from "@nestjs/common";
 import {
   ApiBody,
@@ -42,6 +43,7 @@ import {
   resolveStablePreferenceIdentity,
 } from "../item-preferences/preference-identity";
 import { SimpleItemListEntryDto } from "./dto/simple-item-list-entry.dto";
+import { UuidRouteParamsPipe } from "../common/uuid-param";
 
 class SaveItemPreferencesDto {
   @ApiPropertyOptional({
@@ -194,6 +196,7 @@ class ActivateItemCollectionDto {
 
 @ApiTags("Public Views")
 @Controller("view")
+@UsePipes(new UuidRouteParamsPipe())
 export class ViewsController {
   constructor(
     private readonly viewsService: ViewsService,

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "src/testing", "**/*spec.ts"]
 }

--- a/docs/features/integrations-and-api.md
+++ b/docs/features/integrations-and-api.md
@@ -170,6 +170,38 @@ must also be part of the token's `allowedAcpIds`.
 
 ## Main Server API Workflows
 
+### Inspect token capabilities
+
+Endpoint:
+
+```text
+GET /api/server/capabilities
+```
+
+This endpoint requires a valid server API token but no particular scope and no
+ACP ID. It is intended for integration connection tests and returns:
+
+```json
+{
+  "clientId": "coding-box",
+  "scopes": ["acp.read", "files.read", "files.write"],
+  "capabilities": {
+    "acp.read": true,
+    "transfer.read": false,
+    "transfer.write": false,
+    "index.read": false,
+    "index.write": false,
+    "files.read": true,
+    "files.write": true,
+    "audit.read": false
+  },
+  "allowedAcpIds": null
+}
+```
+
+Clients should use this endpoint instead of probing an ACP resource with a
+synthetic or malformed ACP ID.
+
 ### List ACPs
 
 Endpoint:


### PR DESCRIPTION
## Summary

- validate UUID route parameters explicitly before database access and preserve the `400` vs. `404` distinction
- add the authenticated, ACP-independent `GET /api/server/capabilities` endpoint with typed request and response models
- scope file and snapshot operations consistently to their ACP
- split archive expansion, physical storage, and file mutation responsibilities into dedicated services
- make overwrite uploads failure-safe by staging files first, serializing mutations per ACP, committing metadata atomically, and deleting replaced physical files only afterward
- add fail-fast conflict detection, concurrency rechecks, shared test fixtures, API documentation, and regression coverage

## Why

Invalid integration probes could reach PostgreSQL UUID columns and surface database errors instead of a controlled `400 Bad Request`. Integrations also lacked a way to inspect token capabilities without inventing an ACP identifier. File replacement additionally mixed storage, conflict handling, and metadata mutation in one service, which made partial failures and ACP-boundary mistakes difficult to reason about.

The changes establish explicit API boundaries and a safer mutation order while keeping valid but unknown resources distinguishable as `404 Not Found`.

Closes #48

## Validation

- `npm test -- --runInBand` — 53 suites, 622 tests
- `npx tsc --noEmit`
- `npx eslint "{src,apps,libs,test}/**/*.ts"`
- `npx prettier --check "src/**/*.ts"`
- `npm run build`
- `git diff --check`
