### PR TITLE
Implement ACP index 0.5 compliance

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": ["acp/schemas/*.json"],
+    "watchAssets": true
   }
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,10 +16,14 @@
         "@nestjs/platform-express": "^11.0.0",
         "@nestjs/swagger": "^11.0.0",
         "@nestjs/typeorm": "^11.0.0",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "exceljs": "^4.4.0",
+        "fast-xml-parser": "^5.10.1",
+        "ipaddr.js": "^2.4.0",
         "jose": "^6.2.2",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -27,6 +31,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.20",
+        "undici": "^6.27.0",
         "uuid": "^11.1.1"
       },
       "devDependencies": {
@@ -2407,6 +2412,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -3385,7 +3402,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3402,7 +3418,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3514,6 +3529,18 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/app-root-path": {
       "version": "3.1.0",
@@ -5483,7 +5510,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -5510,7 +5536,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5522,6 +5547,45 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -6289,12 +6353,12 @@
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-arrayish": {
@@ -6440,6 +6504,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "2.0.5",
@@ -7350,7 +7426,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -8559,6 +8634,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8969,6 +9059,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9130,7 +9229,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9839,6 +9937,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/strtok3": {
@@ -10857,6 +10970,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -11323,6 +11445,21 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,10 +34,14 @@
     "@nestjs/platform-express": "^11.0.0",
     "@nestjs/swagger": "^11.0.0",
     "@nestjs/typeorm": "^11.0.0",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "exceljs": "^4.4.0",
+    "fast-xml-parser": "^5.10.1",
+    "ipaddr.js": "^2.4.0",
     "jose": "^6.2.2",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
@@ -45,6 +49,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.20",
+    "undici": "^6.27.0",
     "uuid": "^11.1.1"
   },
   "devDependencies": {

--- a/backend/src/acp/acp-index.service.spec.ts
+++ b/backend/src/acp/acp-index.service.spec.ts
@@ -1,0 +1,297 @@
+import { AcpIndexService } from "./acp-index.service";
+
+describe("AcpIndexService", () => {
+  const acpRepository = {
+    findOne: jest.fn(),
+    save: jest.fn(async (value) => value),
+  } as any;
+  const fileRepository = { find: jest.fn(async () => []) } as any;
+  const cacheRepository = {
+    findOne: jest.fn(async () => null),
+    create: jest.fn((value) => value),
+    save: jest.fn(async (value) => value),
+  } as any;
+  const snapshotsService = { create: jest.fn() } as any;
+
+  let service: AcpIndexService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AcpIndexService(
+      acpRepository,
+      fileRepository,
+      cacheRepository,
+      snapshotsService,
+    );
+  });
+
+  it("accepts the schema-conformant empty index and rejects legacy top-level fields", async () => {
+    const empty = {
+      packageId: "pkg",
+      version: "1.0.0",
+      name: [{ lang: "de", value: "Paket" }],
+      status: "IN_DEVELOPMENT",
+    };
+    await expect(service.validateCandidate("acp", empty)).resolves.toMatchObject({
+      schemaId: "acp-index@0.5",
+      valid: true,
+      publishable: true,
+    });
+
+    const invalid = await service.validateCandidate("acp", {
+      ...empty,
+      units: [],
+    });
+    expect(invalid.valid).toBe(false);
+    expect(invalid.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "SCHEMA_ADDITIONALPROPERTIES" }),
+      ]),
+    );
+  });
+
+  it("reports SemVer and part-scoped semantic/file errors", async () => {
+    const report = await service.validateCandidate("acp", {
+      packageId: "pkg",
+      version: "latest",
+      name: [{ lang: "de", value: "Paket" }],
+      assessmentParts: [
+        {
+          id: "p1",
+          name: [{ lang: "de", value: "Teil" }],
+          units: [
+            {
+              id: "u1",
+              dependencies: [{ id: "units/p1/u1.xml", type: "UNIT_INDEX" }],
+            },
+          ],
+          bookletModules: [{ id: "m1", units: [{ id: "missing" }] }],
+          instruments: [
+            {
+              id: "i1",
+              name: [{ lang: "de", value: "I" }],
+              testcenterBooklet: [
+                {
+                  definitionId: "booklets/i1.xml",
+                  modules: [{ moduleId: "missing-module" }],
+                },
+              ],
+              handOutsForTestTaker: [
+                {
+                  file: [[{ id: "missing-handout.pdf", lang: "de", label: "Handout" }]],
+                },
+              ],
+            },
+          ],
+          additionalDocuments: [
+            {
+              contentType: "STUDY_BACKGROUND",
+              targeting: ["TEACHER"],
+              file: [{ id: "missing-background.pdf", lang: "de", label: "Hintergrund" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(report.issues.map((entry) => entry.code)).toEqual(
+      expect.arrayContaining([
+        "INVALID_SEMVER",
+        "MISSING_FILE",
+        "MISSING_BOOKLET_FILE",
+        "UNKNOWN_UNIT_REFERENCE",
+        "UNKNOWN_MODULE_REFERENCE",
+      ]),
+    );
+    expect(report.publishable).toBe(false);
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "MISSING_FILE",
+          path: expect.stringContaining("handOutsForTestTaker"),
+        }),
+        expect.objectContaining({
+          code: "MISSING_FILE",
+          path: expect.stringContaining("additionalDocuments"),
+        }),
+      ]),
+    );
+  });
+
+  it("migrates dependency objects/types and item metadata without data loss", async () => {
+    acpRepository.findOne.mockResolvedValue({
+      id: "acp",
+      packageId: "pkg",
+      name: "Paket",
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      itemProperties: {},
+      acpIndex: {
+        packageId: "pkg",
+        version: "1.0.0",
+        name: [{ lang: "de", value: "Paket" }],
+        assessmentParts: [
+          {
+            id: "p1",
+            name: [{ lang: "de", value: "Teil" }],
+            units: [
+              {
+                id: "u1",
+                dependencies: { id: "./u1.voud", type: "UNIT_DEFINITION" },
+                items: [{ id: "x", sourceVariable: "v", metadata: { a: "b" } }],
+              },
+            ],
+            bookletModules: [{ id: "m", units: [{ id: "u1" }] }],
+            instruments: [
+              {
+                id: "i",
+                name: [{ lang: "de", value: "I" }],
+                testcenterBooklet: [{ definitionId: "booklet.xml", modules: [{ moduleId: "m" }] }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    fileRepository.find.mockResolvedValue([
+      { originalName: "u1.voud", relativePath: "u1.voud" },
+      { originalName: "booklet.xml", relativePath: "booklet.xml" },
+    ]);
+
+    const preview = await service.migrationPreview("acp");
+    const unit = (preview.candidateIndex as any).assessmentParts[0].units[0];
+    expect(unit.dependencies).toEqual([
+      { id: "u1.voud", type: "UNIT_UI_DEFINITION" },
+    ]);
+    expect(unit.items[0].metadata).toBeUndefined();
+    expect(preview.candidateItemProperties["p1/u1/x"]).toEqual({
+      metadata: { a: "b" },
+    });
+  });
+
+  it("accepts a successful vocabulary cache for at most seven days on publish", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch").mockRejectedValue(new Error("offline"));
+    const url = "https://8.8.8.8/vocabulary";
+    cacheRepository.findOne.mockResolvedValue({
+      url,
+      payload: { id: url, hasTopConcept: [] },
+      status: "valid",
+      lastSuccessAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000),
+    });
+    const fresh = await (service as any).loadExternalJson(url, true);
+    expect(fresh.check.status).toBe("cached");
+
+    cacheRepository.findOne.mockResolvedValue({
+      url,
+      payload: { id: url, hasTopConcept: [] },
+      status: "valid",
+      lastSuccessAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000),
+    });
+    const stale = await (service as any).loadExternalJson(url, true);
+    expect(stale.check.status).toBe("unavailable");
+    fetchSpy.mockRestore();
+  });
+
+  it("uses a cache younger than 24 hours without a network request", async () => {
+    const url = "https://8.8.8.8/profile";
+    cacheRepository.findOne.mockResolvedValue({
+      url,
+      payload: { id: url, groups: [] },
+      status: "valid",
+      lastSuccessAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    const fetchSpy = jest.spyOn(global, "fetch");
+
+    const result = await (service as any).loadExternalJson(url, true);
+
+    expect(result.check.status).toBe("cached");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("refreshes the successful cache timestamp after HTTP 304", async () => {
+    const url = "https://8.8.8.8/profile";
+    const cached = {
+      url,
+      payload: { id: url, groups: [] },
+      status: "valid",
+      lastSuccessAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+      etag: '"profile-v1"',
+    };
+    cacheRepository.findOne.mockResolvedValue(cached);
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, {
+        status: 304,
+        headers: { etag: '"profile-v1"' },
+      }),
+    );
+
+    const result = await (service as any).loadExternalJson(url, true);
+
+    expect(result.check.status).toBe("valid");
+    expect(cached.lastSuccessAt.getTime()).toBeGreaterThan(
+      Date.now() - 60_000,
+    );
+    expect(cacheRepository.save).toHaveBeenCalledWith(cached);
+    fetchSpy.mockRestore();
+  });
+
+  it("does not use an old cache when the current resource is known to be invalid", async () => {
+    const url = "https://8.8.8.8/profile";
+    const cached = {
+      url,
+      payload: { id: url, groups: [] },
+      status: "valid",
+      lastSuccessAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+    };
+    cacheRepository.findOne.mockResolvedValue(cached);
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new Response("not-json", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockRejectedValue(new Error("offline"));
+
+    const result = await (service as any).loadExternalJson(url, true);
+    const retry = await (service as any).loadExternalJson(url, true);
+    const laterRetry = await (service as any).loadExternalJson(url, true);
+
+    expect(result.payload).toBeUndefined();
+    expect(result.check.status).toBe("invalid");
+    expect(cached.status).toBe("invalid");
+    expect(retry.payload).toBeUndefined();
+    expect(retry.check.status).toBe("unavailable");
+    expect(laterRetry.payload).toBeUndefined();
+    expect(laterRetry.check.status).toBe("unavailable");
+    fetchSpy.mockRestore();
+  });
+
+  it("aborts an external response once the streamed body exceeds 1 MB", async () => {
+    const url = "https://8.8.8.8/profile";
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(1024 * 1024));
+            controller.enqueue(new Uint8Array([1]));
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await (service as any).loadExternalJson(url, true);
+
+    expect(result.payload).toBeUndefined();
+    expect(result.check.status).toBe("invalid");
+    fetchSpy.mockRestore();
+  });
+
+  it("blocks private IPv4-mapped IPv6 addresses", () => {
+    expect((service as any).isPrivateAddress("::ffff:7f00:1")).toBe(true);
+    expect((service as any).isPrivateAddress("2001:4860:4860::8888")).toBe(false);
+  });
+});

--- a/backend/src/acp/acp-index.service.ts
+++ b/backend/src/acp/acp-index.service.ts
@@ -1,0 +1,772 @@
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnApplicationBootstrap,
+  UnprocessableEntityException,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import Ajv, { ErrorObject, ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
+import { promises as dns } from "dns";
+import { isIP } from "net";
+import * as ipaddr from "ipaddr.js";
+import { Repository } from "typeorm";
+import { Agent } from "undici";
+import {
+  Acp,
+  AcpExternalResourceCache,
+  AcpFile,
+} from "../database/entities";
+import { SnapshotsService } from "../snapshots/snapshots.service";
+import { getAssessmentParts, normalizeIndexForStorage } from "./acp-index.utils";
+import {
+  AcpExternalCheck,
+  AcpIndexMigrationPreview,
+  AcpIndexValidationIssue,
+  AcpIndexValidationReport,
+} from "./acp-index.types";
+
+const ACP_SCHEMA_ID = "acp-index@0.5" as const;
+const RELEASED_STATUSES = new Set([
+  "RELEASED_PUBLIC",
+  "RELEASED_CONFIDENTIAL",
+]);
+const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const NORMAL_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const PUBLISH_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_EXTERNAL_BYTES = 1024 * 1024;
+
+@Injectable()
+export class AcpIndexService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(AcpIndexService.name);
+  private readonly validateSchema: ValidateFunction;
+
+  constructor(
+    @InjectRepository(Acp)
+    private readonly acpRepository: Repository<Acp>,
+    @InjectRepository(AcpFile)
+    private readonly fileRepository: Repository<AcpFile>,
+    @InjectRepository(AcpExternalResourceCache)
+    private readonly cacheRepository: Repository<AcpExternalResourceCache>,
+    private readonly snapshotsService: SnapshotsService,
+  ) {
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const metadataSchema = require("./schemas/metadata-values-3.0.schema.json");
+    const unitSchema = require("./schemas/acp-unit-0.5.schema.json");
+    const scaleSchema = require("./schemas/acp-scale-0.2.schema.json");
+    const indexSchema = require("./schemas/acp-index-0.5.schema.json");
+    ajv.addSchema(metadataSchema);
+    ajv.addSchema(metadataSchema, "https://w3id.org/iqb/spec/metadata-values/3.0");
+    ajv.addSchema(unitSchema);
+    ajv.addSchema(unitSchema, "https://w3id.org/iqb/spec/acp-unit/0.5");
+    ajv.addSchema(scaleSchema);
+    ajv.addSchema(scaleSchema, "https://w3id.org/iqb/spec/acp-scale/0.2");
+    this.validateSchema = ajv.compile(indexSchema);
+  }
+
+  async onApplicationBootstrap(): Promise<void> {
+    try {
+      const acps = await this.acpRepository.find({ select: { id: true } });
+      for (const acp of acps) {
+        await this.validateStoredIndex(acp.id, { external: false, persist: true });
+      }
+    } catch (error) {
+      this.logger.warn(`ACP index inventory could not be completed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  createEmptyIndex(acp: Pick<Acp, "packageId" | "name" | "description">): Record<string, unknown> {
+    return {
+      packageId: acp.packageId,
+      version: "0.5.0",
+      name: [{ lang: "de", value: acp.name || acp.packageId }],
+      ...(acp.description
+        ? { description: [{ lang: "de", value: acp.description }] }
+        : {}),
+      status: "IN_DEVELOPMENT",
+    };
+  }
+
+  async validateStoredIndex(
+    acpId: string,
+    options: { external?: boolean; forPublication?: boolean; persist?: boolean } = {},
+  ): Promise<AcpIndexValidationReport> {
+    const acp = await this.getAcp(acpId);
+    const report = await this.validateCandidate(acpId, acp.acpIndex, options);
+    if (options.persist !== false) {
+      await this.persistValidationReport(acp, report);
+    }
+    return report;
+  }
+
+  async validateCandidate(
+    acpId: string,
+    candidate: Record<string, unknown>,
+    options: { external?: boolean; forPublication?: boolean } = {},
+  ): Promise<AcpIndexValidationReport> {
+    const issues: AcpIndexValidationIssue[] = [];
+    const externalChecks: AcpExternalCheck[] = [];
+    const schemaValid = this.validateSchema(candidate);
+    if (!schemaValid) {
+      issues.push(...this.mapSchemaErrors(this.validateSchema.errors || []));
+    }
+    if (typeof candidate.version === "string" && !SEMVER_PATTERN.test(candidate.version)) {
+      issues.push(this.issue("INVALID_SEMVER", "schema", "error", "/version", "version muss SemVer entsprechen."));
+    }
+
+    const files = await this.fileRepository.find({ where: { acpId } });
+    this.validateSemantics(candidate, files, issues);
+    if (options.external) {
+      await this.validateMetadata(candidate, issues, externalChecks, Boolean(options.forPublication));
+    }
+    const errorCount = issues.filter((entry) => entry.severity === "error").length;
+    return {
+      schemaId: ACP_SCHEMA_ID,
+      valid: schemaValid && !issues.some((entry) => entry.scope === "schema" && entry.severity === "error"),
+      publishable: schemaValid && errorCount === 0 && externalChecks.every((entry) => entry.status === "valid" || entry.status === "cached"),
+      checkedAt: new Date().toISOString(),
+      issues,
+      externalChecks,
+    };
+  }
+
+  async saveCandidate(
+    acpId: string,
+    candidateInput: Record<string, unknown>,
+    expectedUpdatedAt?: string,
+    options: {
+      allowReleasedStatus?: boolean;
+      itemProperties?: Record<string, Record<string, unknown>>;
+      name?: string;
+      description?: string;
+    } = {},
+  ): Promise<Acp> {
+    const acp = await this.getAcp(acpId);
+    this.assertExpectedUpdatedAt(acp, expectedUpdatedAt);
+    if (RELEASED_STATUSES.has(String(acp.acpIndex?.status || ""))) {
+      throw new ConflictException("Published ACP must be reopened before it can be changed");
+    }
+    const candidate = normalizeIndexForStorage(candidateInput);
+    if (candidate.packageId !== acp.packageId) {
+      throw new UnprocessableEntityException("packageId must match the ACP packageId");
+    }
+    if (!options.allowReleasedStatus && RELEASED_STATUSES.has(String(candidate.status || ""))) {
+      throw new UnprocessableEntityException("Released status can only be set through the publish endpoint");
+    }
+    const report = await this.validateCandidate(acpId, candidate);
+    if (!report.valid) {
+      throw new UnprocessableEntityException({ message: "ACP index violates acp-index@0.5", report });
+    }
+    return this.saveLocked(acpId, expectedUpdatedAt || acp.updatedAt.toISOString(), (locked) => {
+      if (RELEASED_STATUSES.has(String(locked.acpIndex?.status || ""))) {
+        throw new ConflictException("Published ACP must be reopened before it can be changed");
+      }
+      if (locked.packageId !== candidate.packageId) {
+        throw new UnprocessableEntityException("packageId must match the ACP packageId");
+      }
+      locked.acpIndex = candidate;
+      locked.acpIndexSchemaId = ACP_SCHEMA_ID;
+      locked.acpIndexValidationStatus = report.publishable ? "CONFORMANT" : "CONFORMANT_WITH_ISSUES";
+      locked.acpIndexValidationReport = report as unknown as Record<string, unknown>;
+      if (options.itemProperties) locked.itemProperties = options.itemProperties;
+      if (options.name !== undefined) locked.name = options.name;
+      if (options.description !== undefined) locked.description = options.description;
+    });
+  }
+
+  async migrationPreview(acpId: string): Promise<AcpIndexMigrationPreview> {
+    const acp = await this.getAcp(acpId);
+    const candidate = structuredClone(acp.acpIndex || {});
+    const changes: Array<{ path: string; message: string }> = [];
+    const candidateItemProperties = structuredClone(acp.itemProperties || {});
+    const legacyUnits = Array.isArray((candidate as any).units) ? (candidate as any).units : [];
+    const legacyScales = Array.isArray((candidate as any).scales) ? (candidate as any).scales : [];
+    let parts = Array.isArray((candidate as any).assessmentParts)
+      ? (candidate as any).assessmentParts
+      : [];
+
+    if ((legacyUnits.length || legacyScales.length) && !parts.length) {
+      parts = [{
+        id: "default-assessment-part",
+        name: [{ lang: "de", value: "Default Assessment Part" }],
+        units: legacyUnits,
+        ...(legacyScales.length ? { scales: legacyScales } : {}),
+        bookletModules: [],
+        instruments: [],
+      }];
+      changes.push({ path: "/assessmentParts", message: "Top-Level-Units und -Skalen in einen Assessment-Part verschoben." });
+    } else if (parts.length) {
+      if (legacyUnits.length) parts[0].units = [...(parts[0].units || []), ...legacyUnits];
+      if (legacyScales.length) parts[0].scales = [...(parts[0].scales || []), ...legacyScales];
+    }
+    delete (candidate as any).units;
+    delete (candidate as any).scales;
+    if (parts.length) (candidate as any).assessmentParts = parts;
+    else delete (candidate as any).assessmentParts;
+
+    for (const [partIndex, part] of parts.entries()) {
+      for (const [unitIndex, unit] of (part.units || []).entries()) {
+        if (unit.dependencies && !Array.isArray(unit.dependencies)) {
+          unit.dependencies = [unit.dependencies];
+          changes.push({ path: `/assessmentParts/${partIndex}/units/${unitIndex}/dependencies`, message: "Dependency-Objekt in Array umgewandelt." });
+        }
+        for (const dependency of unit.dependencies || []) {
+          const mapped = this.mapLegacyDependencyType(dependency.type);
+          if (mapped !== dependency.type) {
+            changes.push({ path: `/assessmentParts/${partIndex}/units/${unitIndex}/dependencies`, message: `${dependency.type} nach ${mapped} migriert.` });
+            dependency.type = mapped;
+          }
+          if (typeof dependency.id === "string" && dependency.id.startsWith("./")) {
+            dependency.id = dependency.id.replace(/^\.\/+/, "");
+            changes.push({ path: `/assessmentParts/${partIndex}/units/${unitIndex}/dependencies`, message: "Relativen Dateipfad kanonisch normalisiert." });
+          }
+        }
+        for (const item of unit.items || []) {
+          if (item.metadata !== undefined) {
+            const key = `${part.id}/${unit.id}/${item.id}`;
+            candidateItemProperties[key] = {
+              ...(candidateItemProperties[key] || {}),
+              metadata: item.metadata,
+            };
+            delete item.metadata;
+            changes.push({ path: `/assessmentParts/${partIndex}/units/${unitIndex}/items`, message: `Item-Metadaten für ${key} nach itemProperties verschoben.` });
+          }
+        }
+      }
+      for (const instrument of part.instruments || []) {
+        for (const booklet of instrument.testcenterBooklet || []) {
+          if (typeof booklet.definitionId === "string" && booklet.definitionId.startsWith("./")) {
+            booklet.definitionId = booklet.definitionId.replace(/^\.\/+/, "");
+            changes.push({ path: `/assessmentParts/${partIndex}/instruments`, message: "Booklet-Pfad kanonisch normalisiert." });
+          }
+        }
+      }
+    }
+    const validation = await this.validateCandidate(acpId, candidate, { external: true });
+    return {
+      candidateIndex: candidate,
+      candidateItemProperties,
+      changes,
+      unresolved: validation.issues.filter((entry) => entry.severity === "error"),
+      validation,
+      sourceUpdatedAt: acp.updatedAt.toISOString(),
+    };
+  }
+
+  async migrate(acpId: string, expectedUpdatedAt: string): Promise<Acp> {
+    const preview = await this.migrationPreview(acpId);
+    if (!preview.validation.valid) {
+      throw new UnprocessableEntityException({ message: "Migration has unresolved schema errors", preview });
+    }
+    await this.snapshotsService.create(acpId, "ACP-Index 0.5 migration");
+    return this.saveCandidate(acpId, preview.candidateIndex, expectedUpdatedAt, {
+      itemProperties: preview.candidateItemProperties,
+    });
+  }
+
+  async publish(
+    acpId: string,
+    status: "RELEASED_PUBLIC" | "RELEASED_CONFIDENTIAL",
+    expectedUpdatedAt: string,
+  ): Promise<Acp> {
+    if (!RELEASED_STATUSES.has(status)) {
+      throw new UnprocessableEntityException("status must be RELEASED_PUBLIC or RELEASED_CONFIDENTIAL");
+    }
+    const acp = await this.getAcp(acpId);
+    this.assertExpectedUpdatedAt(acp, expectedUpdatedAt);
+    const candidate = { ...acp.acpIndex, status };
+    const report = await this.validateCandidate(acpId, candidate, { external: true, forPublication: true });
+    if (!report.publishable) {
+      throw new UnprocessableEntityException({ message: "ACP index is not publishable", report });
+    }
+    return this.saveLocked(acpId, expectedUpdatedAt || acp.updatedAt.toISOString(), (locked) => {
+      locked.acpIndex = { ...locked.acpIndex, status };
+      locked.acpIndexSchemaId = ACP_SCHEMA_ID;
+      locked.acpIndexValidationStatus = "CONFORMANT";
+      locked.acpIndexValidationReport = report as unknown as Record<string, unknown>;
+    });
+  }
+
+  async reopen(acpId: string, expectedUpdatedAt: string): Promise<Acp> {
+    const acp = await this.getAcp(acpId);
+    this.assertExpectedUpdatedAt(acp, expectedUpdatedAt);
+    if (!RELEASED_STATUSES.has(String(acp.acpIndex?.status || ""))) return acp;
+    await this.snapshotsService.create(acpId, "ACP reopened for editing");
+    return this.saveLocked(acpId, expectedUpdatedAt || acp.updatedAt.toISOString(), (locked) => {
+      locked.acpIndex = { ...locked.acpIndex, status: "IN_DEVELOPMENT" };
+    });
+  }
+
+  private validateSemantics(candidate: Record<string, unknown>, files: AcpFile[], issues: AcpIndexValidationIssue[]): void {
+    const filePaths = new Set(files.map((file) => file.relativePath || file.originalName));
+    const resolvesFile = (id: string) => filePaths.has(id);
+
+    for (const [partIndex, part] of getAssessmentParts(candidate).entries()) {
+      const partPath = `/assessmentParts/${partIndex}`;
+      const unitIds = new Set<string>();
+      for (const [unitIndex, unit] of (part.units || []).entries()) {
+        if (unitIds.has(unit.id)) issues.push(this.issue("DUPLICATE_UNIT_ID", "semantic", "error", `${partPath}/units/${unitIndex}/id`, `Unit-ID ${unit.id} ist innerhalb des Parts doppelt.`));
+        unitIds.add(unit.id);
+        for (const [dependencyIndex, dependency] of (unit.dependencies || []).entries()) {
+          if (dependency?.id && !resolvesFile(dependency.id)) issues.push(this.issue("MISSING_FILE", "file", "error", `${partPath}/units/${unitIndex}/dependencies/${dependencyIndex}/id`, `Datei ${dependency.id} wurde nicht gefunden.`));
+        }
+      }
+      const moduleIds = new Set((part.bookletModules || []).map((module: any) => module.id));
+      for (const [moduleIndex, module] of (part.bookletModules || []).entries()) {
+        for (const [refIndex, ref] of (module.units || []).entries()) {
+          if (!unitIds.has(ref.id)) issues.push(this.issue("UNKNOWN_UNIT_REFERENCE", "semantic", "error", `${partPath}/bookletModules/${moduleIndex}/units/${refIndex}/id`, `Unit ${ref.id} ist in diesem Part nicht definiert.`));
+        }
+      }
+      for (const [instrumentIndex, instrument] of (part.instruments || []).entries()) {
+        for (const [bookletIndex, booklet] of (instrument.testcenterBooklet || []).entries()) {
+          if (!resolvesFile(booklet.definitionId)) issues.push(this.issue("MISSING_BOOKLET_FILE", "file", "error", `${partPath}/instruments/${instrumentIndex}/testcenterBooklet/${bookletIndex}/definitionId`, `Booklet ${booklet.definitionId} wurde nicht gefunden.`));
+          for (const [moduleRefIndex, moduleRef] of (booklet.modules || []).entries()) {
+            if (!moduleIds.has(moduleRef.moduleId)) issues.push(this.issue("UNKNOWN_MODULE_REFERENCE", "semantic", "error", `${partPath}/instruments/${instrumentIndex}/testcenterBooklet/${bookletIndex}/modules/${moduleRefIndex}/moduleId`, `Modul ${moduleRef.moduleId} ist in diesem Part nicht definiert.`));
+          }
+        }
+        for (const [handoutIndex, handout] of (instrument.handOutsForTestTaker || []).entries()) {
+          this.validateFileReferenceTree(
+            handout.file,
+            `${partPath}/instruments/${instrumentIndex}/handOutsForTestTaker/${handoutIndex}/file`,
+            resolvesFile,
+            issues,
+          );
+        }
+      }
+      for (const [documentIndex, document] of (part.additionalDocuments || []).entries()) {
+        this.validateFileReferenceTree(
+          document.file,
+          `${partPath}/additionalDocuments/${documentIndex}/file`,
+          resolvesFile,
+          issues,
+        );
+      }
+      const itemIds = new Set((part.units || []).flatMap((unit: any) => (unit.items || []).map((item: any) => item.id)));
+      const scaleIds = new Set((part.scales || []).map((scale: any) => scale.id));
+      for (const [scaleIndex, scale] of (part.scales || []).entries()) {
+        for (const [itemIndex, item] of (scale.typeParameters?.items || []).entries()) {
+          if (item.id && !itemIds.has(item.id)) issues.push(this.issue("UNKNOWN_SCALE_ITEM", "semantic", "error", `${partPath}/scales/${scaleIndex}/typeParameters/items/${itemIndex}/id`, `Skalen-Item ${item.id} ist nicht auflösbar.`));
+        }
+        if (scale.scaleType === "DERIVED" && scale.typeParameters?.source && !scaleIds.has(scale.typeParameters.source)) {
+          issues.push(this.issue("UNKNOWN_SCALE_REFERENCE", "semantic", "error", `${partPath}/scales/${scaleIndex}/typeParameters/source`, `Skala ${scale.typeParameters.source} ist in diesem Part nicht definiert.`));
+        }
+        for (const [sourceIndex, source] of (scale.typeParameters?.sources || []).entries()) {
+          if (source.id && !scaleIds.has(source.id)) {
+            issues.push(this.issue("UNKNOWN_SCALE_REFERENCE", "semantic", "error", `${partPath}/scales/${scaleIndex}/typeParameters/sources/${sourceIndex}/id`, `Skala ${source.id} ist in diesem Part nicht definiert.`));
+          }
+        }
+      }
+    }
+  }
+
+  private validateFileReferenceTree(
+    value: unknown,
+    path: string,
+    resolvesFile: (id: string) => boolean,
+    issues: AcpIndexValidationIssue[],
+  ): void {
+    if (Array.isArray(value)) {
+      value.forEach((entry, index) =>
+        this.validateFileReferenceTree(
+          entry,
+          `${path}/${index}`,
+          resolvesFile,
+          issues,
+        ),
+      );
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    const id = (value as Record<string, unknown>).id;
+    if (typeof id === "string" && !resolvesFile(id)) {
+      issues.push(
+        this.issue(
+          "MISSING_FILE",
+          "file",
+          "error",
+          `${path}/id`,
+          `Datei ${id} wurde nicht gefunden.`,
+        ),
+      );
+    }
+  }
+
+  private async validateMetadata(candidate: Record<string, unknown>, issues: AcpIndexValidationIssue[], checks: AcpExternalCheck[], forPublication: boolean): Promise<void> {
+    const metadataNodes: Array<{ path: string; value: any }> = [];
+    const visit = (value: unknown, path: string) => {
+      if (!value || typeof value !== "object") return;
+      if (!Array.isArray(value) && typeof (value as any).profileId === "string") metadataNodes.push({ path, value });
+      if (Array.isArray(value)) value.forEach((entry, index) => visit(entry, `${path}/${index}`));
+      else Object.entries(value).forEach(([key, entry]) => visit(entry, `${path}/${key}`));
+    };
+    visit(candidate, "");
+    const vocabularies = new Map<string, Record<string, unknown> | undefined>();
+    for (const node of metadataNodes) {
+      const resource = await this.loadExternalJson(node.value.profileId, forPublication);
+      checks.push(resource.check);
+      if (!resource.payload) {
+        issues.push(this.issue("PROFILE_UNAVAILABLE", "vocabulary", "error", `${node.path}/profileId`, `Metadatenprofil ${node.value.profileId} ist nicht verfügbar.`));
+        continue;
+      }
+      const profileEntries = this.collectProfileEntries(resource.payload);
+      if ((resource.payload as any).id !== node.value.profileId || profileEntries.size === 0) {
+        resource.check.status = "invalid";
+        issues.push(this.issue("INVALID_PROFILE_STRUCTURE", "vocabulary", "error", `${node.path}/profileId`, `Metadatenprofil ${node.value.profileId} hat keine passende ID oder keine Einträge.`));
+        continue;
+      }
+      for (const [entryIndex, entry] of (node.value.entries || []).entries()) {
+        const definition = profileEntries.get(entry.id);
+        if (!definition) {
+          issues.push(this.issue("UNKNOWN_PROFILE_ENTRY", "vocabulary", "error", `${node.path}/entries/${entryIndex}/id`, `Eintrag ${entry.id} existiert nicht im Profil.`));
+          continue;
+        }
+        const vocabularyUrl = definition?.parameters?.url;
+        if (typeof vocabularyUrl === "string" && Array.isArray(entry.value)) {
+          if (!vocabularies.has(vocabularyUrl)) {
+            const vocabulary = await this.loadExternalJson(vocabularyUrl, forPublication);
+            checks.push(vocabulary.check);
+            vocabularies.set(vocabularyUrl, vocabulary.payload);
+            if (
+              vocabulary.payload &&
+              !Array.isArray((vocabulary.payload as any).hasTopConcept) &&
+              !Array.isArray((vocabulary.payload as any).concepts)
+            ) {
+              vocabulary.check.status = "invalid";
+              issues.push(this.issue("INVALID_VOCABULARY_STRUCTURE", "vocabulary", "error", `${node.path}/entries/${entryIndex}/value`, `Vokabular ${vocabularyUrl} enthält keine Konzepteinträge.`));
+            }
+          }
+          const vocabulary = vocabularies.get(vocabularyUrl);
+          if (!vocabulary) {
+            issues.push(this.issue("VOCABULARY_UNAVAILABLE", "vocabulary", "error", `${node.path}/entries/${entryIndex}/value`, `Vokabular ${vocabularyUrl} ist nicht verfügbar.`));
+          }
+          const vocabularyEntries = new Map<string, any>(
+            [
+              ...((vocabulary as any)?.hasTopConcept || []),
+              ...((vocabulary as any)?.concepts || []),
+            ]
+              .filter((value: any) => typeof value?.id === "string")
+              .map((value: any) => [value.id, value]),
+          );
+          for (const [valueIndex, vocabularyEntry] of entry.value.entries()) {
+            if (
+              typeof vocabularyEntry?.id === "string" &&
+              (!vocabularyEntry.id.startsWith(vocabularyUrl) ||
+                (vocabulary && !vocabularyEntries.has(vocabularyEntry.id)))
+            ) {
+              issues.push(this.issue("WRONG_VOCABULARY", "vocabulary", "error", `${node.path}/entries/${entryIndex}/value/${valueIndex}/id`, `${vocabularyEntry.id} gehört nicht zu ${vocabularyUrl}.`));
+            } else if (vocabularyEntry?.label && vocabularyEntries.has(vocabularyEntry.id)) {
+              const canonical = vocabularyEntries.get(vocabularyEntry.id)?.prefLabel;
+              const supplied = Object.fromEntries((vocabularyEntry.label || []).map((label: any) => [label.lang, label.value]));
+              if (canonical && Object.entries(supplied).some(([lang, value]) => canonical[lang] && canonical[lang] !== value)) {
+                issues.push(this.issue("VOCABULARY_LABEL_MISMATCH", "vocabulary", "warning", `${node.path}/entries/${entryIndex}/value/${valueIndex}/label`, `Label für ${vocabularyEntry.id} weicht vom Vokabular ab.`));
+              }
+            }
+          }
+        }
+        if (entry.label && definition.label && JSON.stringify(entry.label) !== JSON.stringify(definition.label)) {
+          issues.push(this.issue("PROFILE_LABEL_MISMATCH", "vocabulary", "warning", `${node.path}/entries/${entryIndex}/label`, `Label für ${entry.id} weicht vom Profil ab.`));
+        }
+      }
+    }
+  }
+
+  private collectProfileEntries(profile: Record<string, unknown>): Map<string, any> {
+    const entries = new Map<string, any>();
+    for (const group of Array.isArray((profile as any).groups) ? (profile as any).groups : []) {
+      for (const entry of Array.isArray(group?.entries) ? group.entries : []) if (typeof entry?.id === "string") entries.set(entry.id, entry);
+    }
+    return entries;
+  }
+
+  private async loadExternalJson(urlValue: string, forPublication: boolean): Promise<{ payload?: Record<string, unknown>; check: AcpExternalCheck }> {
+    const cached = await this.cacheRepository.findOne({ where: { url: urlValue } });
+    const cacheAge = cached?.lastSuccessAt
+      ? Date.now() - cached.lastSuccessAt.getTime()
+      : Number.POSITIVE_INFINITY;
+    const cacheKnownInvalid = cached?.status === "invalid";
+    const freshCache = Boolean(
+      cached?.payload &&
+      cached.status === "valid" &&
+      cacheAge <= NORMAL_CACHE_MAX_AGE_MS,
+    );
+    const publicationFallback = Boolean(
+      cached?.payload &&
+      !cacheKnownInvalid &&
+      cacheAge <= PUBLISH_CACHE_MAX_AGE_MS,
+    );
+    if (freshCache) {
+      return {
+        payload: cached!.payload,
+        check: {
+          url: urlValue,
+          status: "cached",
+          checkedAt: cached!.lastSuccessAt!.toISOString(),
+        },
+      };
+    }
+    const dispatchers: Agent[] = [];
+    try {
+      let currentUrl = this.assertSafeHttpsUrl(urlValue);
+      const headers: Record<string, string> = {};
+      if (!cacheKnownInvalid && cached?.etag) {
+        headers["If-None-Match"] = cached.etag;
+      }
+      if (!cacheKnownInvalid && cached?.lastModified) {
+        headers["If-Modified-Since"] = cached.lastModified;
+      }
+      let response: Response | undefined;
+      for (let redirects = 0; redirects <= 3; redirects += 1) {
+        const dispatcher = await this.createPinnedDispatcher(
+          currentUrl.hostname,
+        );
+        dispatchers.push(dispatcher);
+        response = await fetch(currentUrl, {
+          headers,
+          redirect: "manual",
+          signal: AbortSignal.timeout(5000),
+          dispatcher,
+        } as RequestInit & { dispatcher: Agent });
+        if (response.status === 304) break;
+        if (response.status >= 300 && response.status < 400) {
+          const location = response.headers.get("location");
+          await response.body?.cancel();
+          if (!location) throw new Error("Redirect without location");
+          const redirectedUrl = this.assertSafeHttpsUrl(
+            new URL(location, currentUrl).toString(),
+          );
+          if (redirectedUrl.origin !== currentUrl.origin) {
+            delete headers["If-None-Match"];
+            delete headers["If-Modified-Since"];
+          }
+          currentUrl = redirectedUrl;
+          continue;
+        }
+        break;
+      }
+      if (!response) throw new Error("No response");
+      if (response.status === 304 && cached?.payload && !cacheKnownInvalid) {
+        const now = new Date();
+        cached.status = "valid";
+        cached.lastSuccessAt = now;
+        cached.lastError = undefined;
+        cached.etag = response.headers.get("etag") || cached.etag;
+        cached.lastModified = response.headers.get("last-modified") || cached.lastModified;
+        await this.cacheRepository.save(cached);
+        return {
+          payload: cached.payload,
+          check: { url: urlValue, status: "valid", checkedAt: now.toISOString() },
+        };
+      }
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const declaredLength = Number(response.headers.get("content-length") || "0");
+      if (declaredLength > MAX_EXTERNAL_BYTES) {
+        await response.body?.cancel();
+        throw new Error("INVALID_RESOURCE: Resource exceeds 1 MB");
+      }
+      const bytes = await this.readLimitedBody(response);
+      let payload: unknown;
+      try {
+        payload = JSON.parse(new TextDecoder().decode(bytes));
+      } catch {
+        throw new Error("INVALID_RESOURCE: Resource is not valid JSON");
+      }
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) throw new Error("INVALID_RESOURCE: Resource is not a JSON object");
+      const jsonObject = payload as Record<string, unknown>;
+      const now = new Date();
+      const entity = cached || this.cacheRepository.create({ url: urlValue });
+      entity.payload = jsonObject;
+      entity.status = "valid";
+      entity.lastSuccessAt = now;
+      entity.lastError = undefined;
+      entity.etag = response.headers.get("etag") || undefined;
+      entity.lastModified = response.headers.get("last-modified") || undefined;
+      await this.cacheRepository.save(entity);
+      return { payload: jsonObject, check: { url: urlValue, status: "valid", checkedAt: now.toISOString() } };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const invalidResource = message.startsWith("INVALID_RESOURCE:");
+      if (cached) {
+        cached.status =
+          invalidResource || cacheKnownInvalid ? "invalid" : "unavailable";
+        cached.lastError = message;
+        await this.cacheRepository.save(cached);
+      }
+      if (invalidResource) {
+        return { check: { url: urlValue, status: "invalid" } };
+      }
+      if (forPublication && publicationFallback) {
+        return {
+          payload: cached!.payload,
+          check: {
+            url: urlValue,
+            status: "cached",
+            checkedAt: cached!.lastSuccessAt!.toISOString(),
+          },
+        };
+      }
+      return { check: { url: urlValue, status: "unavailable" } };
+    } finally {
+      await Promise.all(
+        dispatchers.map((dispatcher) =>
+          dispatcher.close().catch(() => undefined),
+        ),
+      );
+    }
+  }
+
+  private assertSafeHttpsUrl(value: string): URL {
+    let url: URL;
+    try { url = new URL(value); } catch { throw new Error("Invalid URL"); }
+    if (url.protocol !== "https:" || url.username || url.password) throw new Error("Only credential-free HTTPS URLs are allowed");
+    return url;
+  }
+
+  private async createPinnedDispatcher(hostname: string): Promise<Agent> {
+    const normalizedHostname = hostname.replace(/^\[|\]$/g, "");
+    const addresses = isIP(normalizedHostname)
+      ? [{ address: normalizedHostname, family: isIP(normalizedHostname) }]
+      : await dns.lookup(normalizedHostname, { all: true });
+    if (
+      !addresses.length ||
+      addresses.some(({ address }) => this.isPrivateAddress(address))
+    ) {
+      throw new Error("Private and loopback addresses are blocked");
+    }
+    const { address, family } = addresses[0];
+    return new Agent({
+      connect: {
+        lookup: ((_host: string, options: any, callback: any) => {
+          if (options?.all) callback(null, [{ address, family }]);
+          else callback(null, address, family);
+        }) as any,
+      },
+    });
+  }
+
+  private async readLimitedBody(response: Response): Promise<Uint8Array> {
+    if (!response.body) return new Uint8Array();
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        totalBytes += value.byteLength;
+        if (totalBytes > MAX_EXTERNAL_BYTES) {
+          await reader.cancel();
+          throw new Error("INVALID_RESOURCE: Resource exceeds 1 MB");
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    const bytes = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return bytes;
+  }
+
+  private isPrivateAddress(address: string): boolean {
+    try {
+      const normalized = address.toLowerCase().split("%")[0];
+      return ipaddr.process(normalized).range() !== "unicast";
+    } catch {
+      return true;
+    }
+  }
+
+  private mapLegacyDependencyType(type: string): string {
+    return ({ UNIT_DEFINITION: "UNIT_UI_DEFINITION", CODING_SCHEME: "UNIT_CODING_SCHEME", METADATA: "UNIT_METADATA" } as Record<string, string>)[type] || type;
+  }
+
+  private mapSchemaErrors(errors: ErrorObject[]): AcpIndexValidationIssue[] {
+    return errors.map((error) => this.issue(
+      `SCHEMA_${error.keyword.toUpperCase()}`,
+      "schema",
+      "error",
+      error.instancePath || "/",
+      error.message || "Schema validation failed",
+    ));
+  }
+
+  private issue(code: string, scope: AcpIndexValidationIssue["scope"], severity: AcpIndexValidationIssue["severity"], path: string, message: string): AcpIndexValidationIssue {
+    return { code, scope, severity, path, message };
+  }
+
+  private async getAcp(acpId: string): Promise<Acp> {
+    const acp = await this.acpRepository.findOne({ where: { id: acpId } });
+    if (!acp) throw new NotFoundException(`ACP with ID ${acpId} not found`);
+    return acp;
+  }
+
+  private async persistValidationReport(
+    acp: Acp,
+    report: AcpIndexValidationReport,
+  ): Promise<void> {
+    const status = report.valid
+      ? report.publishable
+        ? "CONFORMANT"
+        : "CONFORMANT_WITH_ISSUES"
+      : "LEGACY_NONCONFORMANT";
+
+    if (typeof this.acpRepository.query === "function") {
+      await this.acpRepository.query(
+        `UPDATE "acp"
+         SET "acp_index_schema_id" = $2,
+             "acp_index_validation_status" = $3,
+             "acp_index_validation_report" = $4::jsonb
+         WHERE "id" = $1`,
+        [acp.id, ACP_SCHEMA_ID, status, JSON.stringify(report)],
+      );
+      return;
+    }
+
+    acp.acpIndexSchemaId = ACP_SCHEMA_ID;
+    acp.acpIndexValidationStatus = status;
+    acp.acpIndexValidationReport = report as unknown as Record<string, unknown>;
+    await this.acpRepository.save(acp);
+  }
+
+  private async saveLocked(
+    acpId: string,
+    expectedUpdatedAt: string | undefined,
+    mutate: (acp: Acp) => void,
+  ): Promise<Acp> {
+    const manager = this.acpRepository.manager;
+    if (manager?.transaction) {
+      return manager.transaction(async (transactionManager) => {
+        const repository = transactionManager.getRepository(Acp);
+        const acp = await repository.findOne({
+          where: { id: acpId },
+          lock: { mode: "pessimistic_write" },
+        });
+        if (!acp) {
+          throw new NotFoundException(`ACP with ID ${acpId} not found`);
+        }
+        this.assertExpectedUpdatedAt(acp, expectedUpdatedAt);
+        mutate(acp);
+        return repository.save(acp);
+      });
+    }
+
+    const acp = await this.getAcp(acpId);
+    this.assertExpectedUpdatedAt(acp, expectedUpdatedAt);
+    mutate(acp);
+    return this.acpRepository.save(acp);
+  }
+
+  private assertExpectedUpdatedAt(acp: Acp, expected?: string): void {
+    if (expected && acp.updatedAt.toISOString() !== expected) throw new ConflictException({ message: "ACP has changed since preview", expectedUpdatedAt: expected, actualUpdatedAt: acp.updatedAt.toISOString() });
+  }
+}

--- a/backend/src/acp/acp-index.types.ts
+++ b/backend/src/acp/acp-index.types.ts
@@ -1,0 +1,34 @@
+export type AcpIndexIssueScope = "schema" | "semantic" | "vocabulary" | "file";
+export type AcpIndexIssueSeverity = "error" | "warning" | "info";
+
+export interface AcpIndexValidationIssue {
+  code: string;
+  scope: AcpIndexIssueScope;
+  severity: AcpIndexIssueSeverity;
+  path: string;
+  message: string;
+}
+
+export interface AcpExternalCheck {
+  url: string;
+  status: "valid" | "invalid" | "cached" | "unavailable";
+  checkedAt?: string;
+}
+
+export interface AcpIndexValidationReport {
+  schemaId: "acp-index@0.5";
+  valid: boolean;
+  publishable: boolean;
+  checkedAt: string;
+  issues: AcpIndexValidationIssue[];
+  externalChecks: AcpExternalCheck[];
+}
+
+export interface AcpIndexMigrationPreview {
+  candidateIndex: Record<string, unknown>;
+  candidateItemProperties: Record<string, Record<string, unknown>>;
+  changes: Array<{ path: string; message: string }>;
+  unresolved: AcpIndexValidationIssue[];
+  validation: AcpIndexValidationReport;
+  sourceUpdatedAt: string;
+}

--- a/backend/src/acp/acp-index.utils.spec.ts
+++ b/backend/src/acp/acp-index.utils.spec.ts
@@ -47,16 +47,30 @@ describe("acp-index.utils", () => {
     expect(getIndexScales(index).map((s) => s.id)).toEqual(["modern-s1"]);
   });
 
-  it("normalizes legacy units/scales into assessmentParts", () => {
+  it("keeps equal scale ids separate across assessment parts", () => {
+    const index = {
+      assessmentParts: [
+        { id: "p1", scales: [{ id: "shared", marker: "p1" }] },
+        { id: "p2", scales: [{ id: "shared", marker: "p2" }] },
+      ],
+    };
+
+    expect(getIndexScales(index).map((scale) => scale.marker)).toEqual([
+      "p1",
+      "p2",
+    ]);
+  });
+
+  it("drops legacy top-level units/scales instead of persisting them", () => {
     const normalized = normalizeIndexForStorage({
       units: [{ id: "u1" }],
       scales: [{ id: "s1" }],
       assessmentParts: [],
     }) as any;
 
-    expect(normalized.assessmentParts?.length).toBe(1);
-    expect(normalized.assessmentParts[0].units).toEqual([{ id: "u1" }]);
-    expect(normalized.assessmentParts[0].scales).toEqual([{ id: "s1" }]);
+    expect(normalized.assessmentParts).toBeUndefined();
+    expect(normalized.units).toBeUndefined();
+    expect(normalized.scales).toBeUndefined();
   });
 
   it("adds runtime compatibility units/scales for modern ACPs", () => {

--- a/backend/src/acp/acp-index.utils.ts
+++ b/backend/src/acp/acp-index.utils.ts
@@ -46,8 +46,7 @@ export function getIndexUnits(index: unknown): any[] {
   const partUnits = getAssessmentParts(obj).flatMap((part) =>
     asArray(part?.units),
   );
-  const units = partUnits.length ? partUnits : asArray(obj.units);
-  return dedupeById(units);
+  return partUnits.length ? partUnits : dedupeById(asArray(obj.units));
 }
 
 export function getIndexScales(index: unknown): any[] {
@@ -55,8 +54,7 @@ export function getIndexScales(index: unknown): any[] {
   const partScales = getAssessmentParts(obj).flatMap((part) =>
     asArray(part?.scales),
   );
-  const scales = partScales.length ? partScales : asArray(obj.scales);
-  return dedupeById(scales);
+  return partScales.length ? partScales : dedupeById(asArray(obj.scales));
 }
 
 export function findUnitInIndex(
@@ -64,6 +62,26 @@ export function findUnitInIndex(
   unitId: string,
 ): any | undefined {
   return getIndexUnits(index).find((unit) => unit?.id === unitId);
+}
+
+export function findUnitsInIndex(
+  index: unknown,
+  unitId: string,
+): Array<{ partId: string; unit: any }> {
+  return getAssessmentParts(index).flatMap((part) =>
+    asArray(part?.units)
+      .filter((unit) => unit?.id === unitId)
+      .map((unit) => ({ partId: String(part?.id || ""), unit })),
+  );
+}
+
+export function findUnitInPart(
+  index: unknown,
+  partId: string,
+  unitId: string,
+): any | undefined {
+  const part = getAssessmentParts(index).find((entry) => entry?.id === partId);
+  return asArray(part?.units).find((unit) => unit?.id === unitId);
 }
 
 /**
@@ -89,39 +107,14 @@ export function toRuntimeAcpIndex(index: unknown): UnknownRecord {
 
 /**
  * Storage normalization:
- * - preserve incoming fields
- * - ensure assessmentParts can serve as canonical source for units/scales
+ * - preserve schema-defined incoming fields
+ * - remove legacy top-level units/scales; explicit migration places them in parts
  */
 export function normalizeIndexForStorage(index: unknown): UnknownRecord {
-  const runtime = toRuntimeAcpIndex(index);
-  const parts = getAssessmentParts(runtime).map((part) => ({ ...part }));
-  const units = getIndexUnits(runtime);
-  const scales = getIndexScales(runtime);
-
-  const hasUnitsInParts = parts.some((part) => asArray(part.units).length > 0);
-  const hasScalesInParts = parts.some(
-    (part) => asArray(part.scales).length > 0,
-  );
-
-  if (
-    (units.length && !hasUnitsInParts) ||
-    (scales.length && !hasScalesInParts)
-  ) {
-    if (!parts.length) {
-      parts.push({
-        id: "default-assessment-part",
-        name: [{ lang: "de", value: "Default Assessment Part" }],
-      });
-    }
-
-    const primary = { ...parts[0] };
-    if (!hasUnitsInParts) primary.units = units;
-    if (!hasScalesInParts && scales.length) primary.scales = scales;
-    parts[0] = primary;
-  }
-
-  return {
-    ...runtime,
-    assessmentParts: parts,
-  };
+  const source = asRecord(index);
+  const { units: _legacyUnits, scales: _legacyScales, ...canonical } = source;
+  const parts = getAssessmentParts(source).map((part) => ({ ...part }));
+  if (parts.length) canonical.assessmentParts = parts;
+  else delete canonical.assessmentParts;
+  return canonical;
 }

--- a/backend/src/acp/acp.controller.spec.ts
+++ b/backend/src/acp/acp.controller.spec.ts
@@ -117,21 +117,42 @@ describe("AcpController", () => {
       packageId: "pkg-1",
     });
     await expect(
-      controller.updateIndex("acp-1", { assessmentParts: [] }),
+      controller.updateIndex(
+        "acp-1",
+        { assessmentParts: [] },
+        "2026-01-01T00:00:00.000Z",
+      ),
     ).resolves.toEqual({
       packageId: "pkg-1",
       version: "1.0.0",
     });
     await expect(
-      controller.importIndex("acp-1", { assessmentParts: [] }),
+      controller.importIndex(
+        "acp-1",
+        { assessmentParts: [] },
+        "2026-01-01T00:00:00.000Z",
+      ),
     ).resolves.toEqual({
       packageId: "pkg-1",
       version: "1.1.0",
     });
-    await expect(controller.deleteIndex("acp-1")).resolves.toEqual({
+    await expect(
+      controller.deleteIndex("acp-1", "2026-01-01T00:00:00.000Z"),
+    ).resolves.toEqual({
       packageId: "pkg-1",
       version: "0.5.0",
     });
+    expect(acpService.updateIndex).toHaveBeenCalledWith(
+      "acp-1",
+      { assessmentParts: [] },
+      "2026-01-01T00:00:00.000Z",
+    );
+  });
+
+  it("rejects index mutations without a revision", async () => {
+    await expect(
+      controller.updateIndex("acp-1", { assessmentParts: [] }),
+    ).rejects.toThrow("expectedUpdatedAt");
   });
 
   it("exports ACP index as JSON attachment", async () => {

--- a/backend/src/acp/acp.controller.ts
+++ b/backend/src/acp/acp.controller.ts
@@ -12,12 +12,15 @@ import {
   Res,
   Header,
   Logger,
+  Optional,
   ForbiddenException,
+  BadRequestException,
 } from "@nestjs/common";
 import {
   ArrayNotEmpty,
   IsArray,
   IsDateString,
+  IsIn,
   IsNotEmpty,
   IsOptional,
   IsString,
@@ -28,6 +31,7 @@ import {
   ApiOperation,
   ApiProperty,
   ApiPropertyOptional,
+  ApiQuery,
   ApiTags,
 } from "@nestjs/swagger";
 import { AcpService } from "./acp.service";
@@ -50,6 +54,18 @@ import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.s
 import { AdminService } from "../admin/admin.service";
 import { ALL_SERVER_API_SCOPES } from "../api/server-api-scopes";
 import { UuidParam } from "../common/uuid-param";
+import { AcpIndexService } from "./acp-index.service";
+
+class RequiredRevisionDto {
+  @IsDateString()
+  expectedUpdatedAt!: string;
+}
+
+class PublishIndexDto extends RequiredRevisionDto {
+  @IsString()
+  @IsIn(["RELEASED_PUBLIC", "RELEASED_CONFIDENTIAL"])
+  status!: "RELEASED_PUBLIC" | "RELEASED_CONFIDENTIAL";
+}
 
 class CreateAcpApplicationTokenDto {
   @ApiProperty({ description: "Human-readable application name" })
@@ -86,6 +102,7 @@ export class AcpController {
     private readonly acpService: AcpService,
     private readonly itemExplorerStateService: ItemExplorerStateService,
     private readonly adminService: AdminService,
+    @Optional() private readonly acpIndexService?: AcpIndexService,
   ) {}
 
   @Get()
@@ -144,30 +161,98 @@ export class AcpController {
   @UseGuards(RolesGuard)
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Update ACP-Index" })
+  @ApiQuery({ name: "expectedUpdatedAt", required: true })
   async updateIndex(
     @UuidParam("id") id: string,
     @Body() index: Record<string, unknown>,
+    @Query("expectedUpdatedAt") expectedUpdatedAt?: string,
   ) {
-    return this.acpService.updateIndex(id, index);
+    return this.acpService.updateIndex(
+      id,
+      index,
+      this.requireRevision(expectedUpdatedAt),
+    );
   }
 
   @Post(":id/index/import")
   @UseGuards(RolesGuard)
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Import ACP-Index from JSON (replaces existing)" })
+  @ApiQuery({ name: "expectedUpdatedAt", required: true })
   async importIndex(
     @UuidParam("id") id: string,
     @Body() index: Record<string, unknown>,
+    @Query("expectedUpdatedAt") expectedUpdatedAt?: string,
   ) {
-    return this.acpService.importIndex(id, index);
+    return this.acpService.importIndex(
+      id,
+      index,
+      this.requireRevision(expectedUpdatedAt),
+    );
   }
 
   @Delete(":id/index")
   @UseGuards(RolesGuard)
   @Roles("ACP_MANAGER")
   @ApiOperation({ summary: "Reset ACP-Index to defaults" })
-  async deleteIndex(@UuidParam("id") id: string) {
-    return this.acpService.deleteIndex(id);
+  @ApiQuery({ name: "expectedUpdatedAt", required: true })
+  async deleteIndex(
+    @UuidParam("id") id: string,
+    @Query("expectedUpdatedAt") expectedUpdatedAt?: string,
+  ) {
+    return this.acpService.deleteIndex(
+      id,
+      this.requireRevision(expectedUpdatedAt),
+    );
+  }
+
+  @Post(":id/index/validate")
+  @UseGuards(RolesGuard)
+  @Roles("ACP_MANAGER")
+  @ApiOperation({ summary: "Validate ACP-Index against acp-index@0.5" })
+  async validateIndex(@UuidParam("id") id: string) {
+    return this.acpIndexService!.validateStoredIndex(id, { external: true });
+  }
+
+  @Post(":id/index/migration-preview")
+  @UseGuards(RolesGuard)
+  @Roles("ACP_MANAGER")
+  @ApiOperation({ summary: "Preview migration to acp-index@0.5" })
+  async migrationPreview(@UuidParam("id") id: string) {
+    return this.acpIndexService!.migrationPreview(id);
+  }
+
+  @Post(":id/index/migrate")
+  @UseGuards(RolesGuard)
+  @Roles("ACP_MANAGER")
+  @ApiOperation({ summary: "Apply snapshot-backed ACP-Index migration" })
+  async migrateIndex(@UuidParam("id") id: string, @Body() dto: RequiredRevisionDto) {
+    return this.acpIndexService!.migrate(id, dto.expectedUpdatedAt);
+  }
+
+  @Post(":id/index/publish")
+  @UseGuards(RolesGuard)
+  @Roles("ACP_MANAGER")
+  @ApiOperation({ summary: "Validate and publish an ACP-Index" })
+  async publishIndex(@UuidParam("id") id: string, @Body() dto: PublishIndexDto) {
+    return this.acpIndexService!.publish(id, dto.status, dto.expectedUpdatedAt);
+  }
+
+  @Post(":id/index/reopen")
+  @UseGuards(RolesGuard)
+  @Roles("ACP_MANAGER")
+  @ApiOperation({ summary: "Snapshot and reopen a published ACP" })
+  async reopenIndex(@UuidParam("id") id: string, @Body() dto: RequiredRevisionDto) {
+    return this.acpIndexService!.reopen(id, dto.expectedUpdatedAt);
+  }
+
+  private requireRevision(value?: string): string {
+    if (!value || Number.isNaN(Date.parse(value))) {
+      throw new BadRequestException(
+        "expectedUpdatedAt must be a valid ISO timestamp",
+      );
+    }
+    return value;
   }
 
   @Get(":id/index/export")

--- a/backend/src/acp/acp.module.ts
+++ b/backend/src/acp/acp.module.ts
@@ -9,10 +9,14 @@ import {
   AcpCredential,
   AppSettings,
   User,
+  AcpFile,
+  AcpExternalResourceCache,
 } from "../database/entities";
 import { AuthModule } from "../auth/auth.module";
 import { ItemExplorerModule } from "../item-explorer/item-explorer.module";
 import { AdminModule } from "../admin/admin.module";
+import { SnapshotsModule } from "../snapshots/snapshots.module";
+import { AcpIndexService } from "./acp-index.service";
 
 @Module({
   imports: [
@@ -23,13 +27,16 @@ import { AdminModule } from "../admin/admin.module";
       AcpCredential,
       AppSettings,
       User,
+      AcpFile,
+      AcpExternalResourceCache,
     ]),
     AuthModule,
     ItemExplorerModule,
     AdminModule,
+    SnapshotsModule,
   ],
   controllers: [AcpController],
-  providers: [AcpService],
-  exports: [AcpService],
+  providers: [AcpService, AcpIndexService],
+  exports: [AcpService, AcpIndexService],
 })
 export class AcpModule {}

--- a/backend/src/acp/acp.service.ts
+++ b/backend/src/acp/acp.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   ConflictException,
   BadRequestException,
+  Optional,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { DataSource, Repository } from "typeorm";
@@ -29,13 +30,8 @@ import {
   CreateCredentialDto,
   UpdateCredentialDto,
 } from "./dto/acp.dto";
-import {
-  ACP_INDEX_ALLOWED_STATUS_VALUES,
-  DEFAULT_ACP_INDEX_VERSION,
-  normalizeIndexForStorage,
-  toRuntimeAcpIndex,
-} from "./acp-index.utils";
 import { normalizeFeatureConfig } from "./feature-config.utils";
+import { AcpIndexService } from "./acp-index.service";
 
 const PLAYER_FOCUS_HIGHLIGHT_FEATURE_KEY = "enablePlayerFocusHighlight";
 
@@ -55,6 +51,7 @@ export class AcpService {
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
     private readonly dataSource: DataSource,
+    @Optional() private readonly acpIndexService?: AcpIndexService,
   ) {}
 
   async findAll(): Promise<Acp[]> {
@@ -87,32 +84,16 @@ export class AcpService {
       );
     }
 
-    // Get default ACP index from settings
-    let defaultIndex: Record<string, unknown> = {};
-    const settings = await this.settingsRepository.findOne({ where: {} });
-    if (settings?.defaultAcpIndex) {
-      defaultIndex = { ...settings.defaultAcpIndex };
-    }
-
-    const normalizedIndex = normalizeIndexForStorage({
-      ...defaultIndex,
-      packageId: dto.packageId,
-      version: DEFAULT_ACP_INDEX_VERSION,
-      name: [{ lang: "de", value: dto.name }],
-      description: dto.description
-        ? [{ lang: "de", value: dto.description }]
-        : [],
-      status: "IN_DEVELOPMENT",
-      units: [],
-      assessmentParts: [],
-    });
-
     const acp = this.acpRepository.create({
       packageId: dto.packageId,
       name: dto.name,
       description: dto.description,
-      acpIndex: normalizedIndex,
+      acpIndex: {},
+      acpIndexSchemaId: "acp-index@0.5",
+      acpIndexValidationStatus: "CONFORMANT",
     });
+
+    acp.acpIndex = this.acpIndexService?.createEmptyIndex(acp) || this.createFallbackIndex(acp);
 
     const savedAcp = await this.acpRepository.save(acp);
     await this.createDefaultAccessConfig(savedAcp.id, false);
@@ -121,7 +102,33 @@ export class AcpService {
 
   async update(id: string, dto: UpdateAcpDto): Promise<Acp> {
     const acp = await this.findById(id);
-    if (dto.name !== undefined) acp.name = dto.name;
+    if (
+      acp.acpIndex?.status === "RELEASED_PUBLIC" ||
+      acp.acpIndex?.status === "RELEASED_CONFIDENTIAL"
+    ) {
+      throw new ConflictException(
+        "Published ACP must be reopened before it can be changed",
+      );
+    }
+    if (dto.name !== undefined) {
+      const localizedNames = Array.isArray(acp.acpIndex?.name)
+        ? [...(acp.acpIndex.name as Array<{ lang: string; value: string }>)]
+        : [];
+      const germanIndex = localizedNames.findIndex((entry) => entry?.lang === "de");
+      if (germanIndex >= 0) localizedNames[germanIndex] = { lang: "de", value: dto.name };
+      else localizedNames.push({ lang: "de", value: dto.name });
+      const candidate = { ...acp.acpIndex, name: localizedNames };
+      if (this.acpIndexService) {
+        return this.acpIndexService.saveCandidate(
+          id,
+          candidate,
+          acp.updatedAt.toISOString(),
+          { name: dto.name, description: dto.description },
+        );
+      }
+      acp.name = dto.name;
+      acp.acpIndex = candidate;
+    }
     if (dto.description !== undefined) acp.description = dto.description;
     return this.acpRepository.save(acp);
   }
@@ -137,51 +144,50 @@ export class AcpService {
   // ACP-Index management
   async getIndex(id: string): Promise<Record<string, unknown>> {
     const acp = await this.findById(id);
-    return toRuntimeAcpIndex(acp.acpIndex);
+    return acp.acpIndex;
   }
 
   async updateIndex(
     id: string,
     index: Record<string, unknown>,
+    expectedUpdatedAt?: string,
   ): Promise<Record<string, unknown>> {
-    const acp = await this.findById(id);
-    acp.acpIndex = this.prepareIndexForSave(acp, index, {});
-    const saved = await this.acpRepository.save(acp);
-    return toRuntimeAcpIndex(saved.acpIndex);
+    const saved = this.acpIndexService
+      ? await this.acpIndexService.saveCandidate(id, index, expectedUpdatedAt)
+      : await this.saveFallbackIndex(id, index);
+    return saved.acpIndex;
   }
 
   async importIndex(
     id: string,
     indexJson: Record<string, unknown>,
+    expectedUpdatedAt?: string,
+  ): Promise<Record<string, unknown>> {
+    const saved = this.acpIndexService
+      ? await this.acpIndexService.saveCandidate(id, indexJson, expectedUpdatedAt)
+      : await this.saveFallbackIndex(id, indexJson);
+    return saved.acpIndex;
+  }
+
+  async deleteIndex(
+    id: string,
+    expectedUpdatedAt?: string,
   ): Promise<Record<string, unknown>> {
     const acp = await this.findById(id);
 
-    // Get default settings for required fields
-    let defaultIndex: Record<string, unknown> = {};
-    const settings = await this.settingsRepository.findOne({ where: {} });
-    if (settings?.defaultAcpIndex) {
-      defaultIndex = { ...settings.defaultAcpIndex };
+    let candidate = this.acpIndexService?.createEmptyIndex(acp) || this.createFallbackIndex(acp);
+    if (!this.acpIndexService) {
+      const settings = await this.settingsRepository.findOne({ where: {} });
+      candidate = this.normalizeFallbackIndex(acp, { ...(settings?.defaultAcpIndex || {}), ...candidate });
     }
-
-    // Merge: uploaded index takes priority, defaults fill in missing required fields
-    acp.acpIndex = this.prepareIndexForSave(acp, indexJson, defaultIndex);
-    const saved = await this.acpRepository.save(acp);
-    return toRuntimeAcpIndex(saved.acpIndex);
-  }
-
-  async deleteIndex(id: string): Promise<Record<string, unknown>> {
-    const acp = await this.findById(id);
-
-    // Reset to default ACP index shape from settings + ACP fallback fields.
-    let defaultIndex: Record<string, unknown> = {};
-    const settings = await this.settingsRepository.findOne({ where: {} });
-    if (settings?.defaultAcpIndex) {
-      defaultIndex = { ...settings.defaultAcpIndex };
-    }
-
-    acp.acpIndex = this.prepareIndexForSave(acp, {}, defaultIndex);
-    const saved = await this.acpRepository.save(acp);
-    return toRuntimeAcpIndex(saved.acpIndex);
+    const saved = this.acpIndexService
+      ? await this.acpIndexService.saveCandidate(
+          id,
+          candidate,
+          expectedUpdatedAt,
+        )
+      : await this.saveFallbackIndex(id, candidate);
+    return saved.acpIndex;
   }
 
   // Role management
@@ -662,146 +668,34 @@ export class AcpService {
     return this.accessConfigRepository.save(config);
   }
 
-  private prepareIndexForSave(
-    acp: Acp,
-    inputIndex: Record<string, unknown>,
-    defaultIndex: Record<string, unknown>,
-  ): Record<string, unknown> {
-    if (
-      !inputIndex ||
-      typeof inputIndex !== "object" ||
-      Array.isArray(inputIndex)
-    ) {
-      throw new BadRequestException("ACP-Index muss ein JSON-Objekt sein.");
-    }
-
-    const merged = { ...defaultIndex, ...inputIndex } as Record<
-      string,
-      unknown
-    >;
-    const packageId = this.resolvePackageId(acp, merged.packageId);
-    const version = this.resolveVersion(merged.version);
-    const status = this.resolveStatus(merged.status);
-    const name = this.resolveLanguageTextArray(
-      merged.name,
-      [{ lang: "de", value: acp.name || acp.packageId }],
-      "name",
-    );
-    const description = this.resolveLanguageTextArray(
-      merged.description,
-      acp.description ? [{ lang: "de", value: acp.description }] : [],
-      "description",
-      true,
-    );
-
-    const sanitizedIndex = {
-      ...merged,
-      packageId,
-      version,
-      status,
-      name,
-      description,
+  private createFallbackIndex(acp: Pick<Acp, "packageId" | "name" | "description">): Record<string, unknown> {
+    return {
+      packageId: acp.packageId,
+      version: "0.5.0",
+      name: [{ lang: "de", value: acp.name || acp.packageId }],
+      ...(acp.description ? { description: [{ lang: "de", value: acp.description }] } : {}),
+      status: "IN_DEVELOPMENT",
     };
-
-    return normalizeIndexForStorage(sanitizedIndex);
   }
 
-  private resolvePackageId(acp: Acp, rawPackageId: unknown): string {
-    if (
-      rawPackageId === undefined ||
-      rawPackageId === null ||
-      rawPackageId === ""
-    ) {
-      return acp.packageId;
+  private normalizeFallbackIndex(acp: Acp, input: Record<string, unknown>): Record<string, unknown> {
+    if (!input || typeof input !== "object" || Array.isArray(input)) throw new BadRequestException("ACP index must be an object");
+    const candidate = { ...this.createFallbackIndex(acp), ...input } as any;
+    if (candidate.packageId !== acp.packageId) throw new BadRequestException("packageId mismatch");
+    if (typeof candidate.version !== "string") throw new BadRequestException("version must be a string");
+    if (!Array.isArray(candidate.name) || candidate.name.some((entry: any) => typeof entry?.value !== "string" || !entry.value.trim() || typeof entry?.lang !== "string" || !/^[a-z]{2}$/.test(entry.lang))) throw new BadRequestException("name must be language-tagged text");
+    if (typeof candidate.status !== "string") throw new BadRequestException("status must be a string");
+    if (!["IN_DEVELOPMENT", "DISCONTINUED", "RELEASED_PUBLIC", "RELEASED_CONFIDENTIAL"].includes(candidate.status)) throw new BadRequestException("Invalid status");
+    if (Array.isArray(candidate.units) && !Array.isArray(candidate.assessmentParts)) {
+      candidate.assessmentParts = [{ id: "default-assessment-part", name: [{ lang: "de", value: "Default Assessment Part" }], units: candidate.units }];
     }
-
-    if (typeof rawPackageId !== "string") {
-      throw new BadRequestException(
-        'Ungültiges Feld "packageId": Muss ein Text sein.',
-      );
-    }
-
-    if (rawPackageId !== acp.packageId) {
-      throw new BadRequestException(
-        `Ungültiges Feld "packageId": Erwartet "${acp.packageId}", erhalten "${rawPackageId}".`,
-      );
-    }
-
-    return rawPackageId;
+    return candidate;
   }
 
-  private resolveVersion(rawVersion: unknown): string {
-    if (rawVersion === undefined || rawVersion === null || rawVersion === "") {
-      return DEFAULT_ACP_INDEX_VERSION;
-    }
-
-    if (typeof rawVersion !== "string") {
-      throw new BadRequestException(
-        'Ungültiges Feld "version": Muss ein Text sein.',
-      );
-    }
-
-    return rawVersion;
+  private async saveFallbackIndex(id: string, input: Record<string, unknown>): Promise<Acp> {
+    const acp = await this.findById(id);
+    acp.acpIndex = this.normalizeFallbackIndex(acp, input);
+    return this.acpRepository.save(acp);
   }
 
-  private resolveStatus(rawStatus: unknown): string {
-    if (rawStatus === undefined || rawStatus === null || rawStatus === "") {
-      return "IN_DEVELOPMENT";
-    }
-
-    if (typeof rawStatus !== "string") {
-      throw new BadRequestException(
-        'Ungültiges Feld "status": Muss ein Text sein.',
-      );
-    }
-
-    if (!ACP_INDEX_ALLOWED_STATUS_VALUES.includes(rawStatus as any)) {
-      throw new BadRequestException(
-        `Ungültiges Feld "status": "${rawStatus}". Erlaubte Werte: ${ACP_INDEX_ALLOWED_STATUS_VALUES.join(", ")}`,
-      );
-    }
-
-    return rawStatus;
-  }
-
-  private resolveLanguageTextArray(
-    rawValue: unknown,
-    fallback: Array<{ lang: string; value: string }>,
-    fieldName: string,
-    optional = false,
-  ): Array<{ lang: string; value: string }> {
-    if (rawValue === undefined || rawValue === null) {
-      return optional ? fallback : [...fallback];
-    }
-
-    if (!Array.isArray(rawValue)) {
-      throw new BadRequestException(
-        `Ungültiges Feld "${fieldName}": Muss ein Array sein.`,
-      );
-    }
-
-    if (rawValue.length === 0) {
-      return optional ? [] : [...fallback];
-    }
-
-    const parsed = rawValue.map((entry: any, idx) => {
-      const lang = entry?.lang;
-      const value = entry?.value;
-
-      if (typeof lang !== "string" || !/^[a-z]{2}$/.test(lang)) {
-        throw new BadRequestException(
-          `Ungültiges Feld "${fieldName}[${idx}].lang": Muss ein ISO-Sprachcode mit 2 Kleinbuchstaben sein.`,
-        );
-      }
-      if (typeof value !== "string" || !value.trim()) {
-        throw new BadRequestException(
-          `Ungültiges Feld "${fieldName}[${idx}].value": Muss ein nicht-leerer Text sein.`,
-        );
-      }
-
-      return { lang, value };
-    });
-
-    return parsed;
-  }
 }

--- a/backend/src/acp/schemas/acp-index-0.5.schema.json
+++ b/backend/src/acp/schemas/acp-index-0.5.schema.json
@@ -1,0 +1,459 @@
+{
+  "$id": "acp-index@0.5",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Assessment Content Package Index",
+  "description": "Specification for assessment content package index.",
+  "type": "object",
+  "properties": {
+    "packageId": {
+      "description": "Identifier for the assessment content package",
+      "type": "string"
+    },
+    "version": {
+      "description": "Package Version in SemVer format.",
+      "type": "string"
+    },
+    "name": {
+      "$ref": "#/$defs/languageTaggedText"
+    },
+    "description": {
+      "$ref": "#/$defs/languageTaggedText"
+    },
+    "maintainerName": {
+      "description": "Name of the person or institution responsable for creating and maintaining",
+      "type": "string",
+      "examples": [
+        "IQB - Institut zur Qualitätsentwicklung im Bildungswesen"
+      ]
+    },
+    "maintainerUrl": {
+      "description": "Url of maintainer to get more information or to get in contact",
+      "type": "string",
+      "examples": [
+        "https://www.iqb.hu-berlin.de/tba"
+      ]
+    },
+    "status": {
+      "description": "Describes the progress of development and visibility issues.",
+      "type": "string",
+      "enum": [
+        "IN_DEVELOPMENT",
+        "DISCONTINUED",
+        "RELEASED_PUBLIC",
+        "RELEASED_CONFIDENTIAL"
+      ],
+      "default": "IN_DEVELOPMENT"
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    },
+    "codingParameters": {
+      "$ref": "#/$defs/codingParameters"
+    },
+    "assessmentParts": {
+      "description": "Groups of instruments, administrated the same way or at the same time.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/assessmentPart"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "packageId",
+    "version",
+    "name"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "languageTaggedText": {
+      "description": "Language tagged text",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "lang": {
+            "description": "ISO-language code",
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[a-z]{2}$"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "lang",
+          "value"
+        ],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "languageTaggedObjectRef": {
+      "description": "Variants of the same object in different languages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "id/path to the object, used as reference",
+            "type": "string"
+          },
+          "lang": {
+            "type": "string",
+            "minLength": 1,
+            "description": "ISO-language code",
+            "pattern": "^[a-z]{2}$"
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "lang",
+          "label"
+        ],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "bookletModule": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Id to be referred in instruments",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "lang": {
+          "description": "ISO-language code",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z]{2}$",
+          "default": "de"
+        },
+        "units": {
+          "description": "All units being part of the module",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "Identifier referring to unit list",
+                "type": "string"
+              },
+              "alias": {
+                "description": "Prefix for full item identifier. If not given, the id will be used instead.",
+                "type": "string"
+              },
+              "order": {
+                "description": "Default sorting is alpha-numeric.",
+                "type": "integer",
+                "minimum": 0,
+                "default": 0
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "id",
+        "units"
+      ],
+      "additionalProperties": false
+    },
+    "instrument": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Identifier for the instrument",
+          "type": "string"
+        },
+        "name": {
+          "$ref": "#/$defs/languageTaggedText"
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        },
+        "testcenterBooklet": {
+          "description": "If part of TBA, this ids refer to the language specific XML definition used to run the instrument in IQB-Testcenter.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string",
+                "minLength": 1,
+                "description": "ISO-language code",
+                "pattern": "^[a-z]{2}$",
+                "default": "de"
+              },
+              "definitionId": {
+                "description": "Id/path to the booklet XML to run this instrument",
+                "type": "string"
+              },
+              "modules": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "moduleId": {
+                      "description": "Reference to the module id at assessmentPart level",
+                      "type": "string"
+                    },
+                    "order": {
+                      "description": "Default sorting is alpha-numeric.",
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 0
+                    }
+                  },
+                  "required": [
+                    "moduleId"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "definitionId",
+              "modules"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "administrationMode": {
+          "type": "string",
+          "enum": [
+            "TEST_BY_TEST_TAKER",
+            "TEST_BY_PROCTOR",
+            "STIMULUS_FOR_TEST_TAKER"
+          ],
+          "default": "TEST_BY_TEST_TAKER"
+        },
+        "handOutsForTestTaker": {
+          "description": "All documents must be presented to the test taker (online or print-out).",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "description": "Default sorting is alpha-numeric.",
+                "type": "integer",
+                "minimum": 0,
+                "default": 0
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "PRINT_SHOW",
+                  "PRINT_WRITE_DRAW",
+                  "ON_SCREEN"
+                ],
+                "default": "PRINT"
+              },
+              "file": {
+                "description": "All language variants of the same hand-out",
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/languageTaggedObjectRef"
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "file"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "testcenterBooklet"
+      ],
+      "additionalProperties": false
+    },
+    "itemValueType": {
+      "type": "string",
+      "enum": [
+        "FULL_CREDIT",
+        "NO_CREDIT",
+        "MISSING"
+      ]
+    },
+    "codingParameters": {
+      "description": "Some parameters for coding and analysis in general",
+      "type": "object",
+      "properties": {
+        "itemValues": {
+          "description": "Mapping logical item values to numeric values. Standards are 1-FULL_CREDIT, 0-NO_CREDIT, -99-MISSING.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "$ref": "#/$defs/itemValueType"
+              },
+              "value": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "statusMapping": {
+          "description": "Rules how to translate response status into item value",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "itemValueType": {
+                "$ref": "#/$defs/itemValueType"
+              },
+              "status": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "UNSET",
+                    "NOT_REACHED",
+                    "DISPLAYED",
+                    "INVALID",
+                    "CODING_ERROR"
+                  ]
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "itemValueType",
+              "status"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "assessmentPart": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier for the assessment part"
+        },
+        "name": {
+          "$ref": "#/$defs/languageTaggedText"
+        },
+        "description": {
+          "$ref": "#/$defs/languageTaggedText"
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        },
+        "units": {
+          "description": "Definition of all units and items used by modules.",
+          "type": "array",
+          "items": {
+            "$ref": "https://w3id.org/iqb/spec/acp-unit/0.5"
+           },
+          "minItems": 1
+        },
+        "bookletModules": {
+          "description": "All modules used in this assessmentPart by instruments",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/bookletModule"
+          },
+          "minItems": 1
+        },
+        "instruments": {
+          "description": "All instruments for the assessment part, online or to hand out",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/instrument"
+          },
+          "minItems": 1
+        },
+        "scales": {
+          "description": "Scales to calculate performance indicators",
+          "type": "array",
+          "items": {
+            "$ref": "https://w3id.org/iqb/spec/acp-scale/0.2"
+          },
+          "minItems": 1
+        },
+        "additionalDocuments": {
+          "description": "Additional documents supporting the assessment",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "contentType": {
+                "type": "string",
+                "enum": [
+                  "CODING_INSTRUCTIONS",
+                  "STUDY_BACKGROUND"
+                ]
+              },
+              "targeting": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "PROCTOR",
+                    "TEST_TAKER",
+                    "TEACHER",
+                    "TEST_ADMINISTRATION",
+                    "GOVERNANCE",
+                    "CODER"
+                  ]
+                },
+                "minItems": 1
+              },
+              "file": {
+                "$ref": "#/$defs/languageTaggedObjectRef"
+              }
+            },
+            "required": [
+              "file",
+              "targeting",
+              "contentType"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "bookletModules",
+        "instruments",
+        "units"
+      ],
+      "additionalProperties": false
+    },
+    "metadata": {
+      "$ref": "https://w3id.org/iqb/spec/metadata-values/3.0"
+    }
+  }
+}

--- a/backend/src/acp/schemas/acp-scale-0.2.schema.json
+++ b/backend/src/acp/schemas/acp-scale-0.2.schema.json
@@ -1,0 +1,362 @@
+{
+  "$id": "acp-scale@0.2",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Assessment Content Package: Scale",
+  "description": "Specification for assessment content package scale.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Identifier referred by other scales and assessment output.",
+      "type": "string"
+    },
+    "name": {
+      "$ref": "#/$defs/languageTaggedText"
+    },
+    "description": {
+      "$ref": "#/$defs/languageTaggedText"
+    },
+    "scaleType": {
+      "type": "string",
+      "enum": [
+        "BASE",
+        "DERIVED",
+        "AGGREGATED"
+      ]
+    },
+    "typeParameters": {
+      "description": "Every type needs a different set of parameters.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/parametersBASE"
+        },
+        {
+          "$ref": "#/$defs/parametersDERIVED"
+        },
+        {
+          "$ref": "#/$defs/parametersAGGREGATED"
+        }
+      ]
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "scaleType",
+    "typeParameters"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "languageTaggedText": {
+      "description": "Language tagged text",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "lang": {
+            "description": "ISO-language code",
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[a-z]{2}$"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "lang",
+          "value"
+        ],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "itemValueType": {
+      "type": "string",
+      "enum": [
+        "FULL_CREDIT",
+        "NO_CREDIT",
+        "MISSING"
+      ]
+    },
+    "methodParametersScoreRatio": {
+      "description": "Parameters for the processing method SCORE_RATIO.",
+      "type": "object",
+      "properties": {
+        "maxValue": {
+          "description": "If methodParameters is not given, the number of items will be taken as maxValue",
+          "type": "number"
+        }
+      },
+      "required": [
+        "maxValue"
+      ],
+      "additionalProperties": false
+    },
+    "methodParametersCodeCount": {
+      "description": "Parameters for the processing method CODE_COUNT.",
+      "type": "object",
+      "properties": {
+        "codeValue": {
+          "description": "Value of code to be counted",
+          "type": "number"
+        }
+      },
+      "required": [
+        "codeValue"
+      ],
+      "additionalProperties": false
+    },
+    "itemInScale": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Identifier referring to unique identifier of item in unit list.",
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "description": "List of item values relevant for processing",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "enum": [
+                  "LOGIT_FULL_CREDIT",
+                  "LOGIT_PARTIAL_CREDIT_1",
+                  "LOGIT_PARTIAL_CREDIT_2",
+                  "LOGIT_PARTIAL_CREDIT_3"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "key"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "weight": {
+          "type": "number",
+          "default": 1
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "parametersBASE": {
+      "description": "These parameters will be used for scaleType BASE",
+      "type": "object",
+      "properties": {
+        "method": {
+          "description": "Way how to process the item values.",
+          "type": "string",
+          "enum": [
+            "SCORE_SUM",
+            "SCORE_RATIO",
+            "SCORE_MEAN",
+            "SCORE_MEDIAN",
+            "WLE",
+            "CODE_COUNT"
+          ]
+        },
+        "methodParameters": {
+          "description": "Depending on the method, different parameters may specify the processing.",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/methodParametersScoreRatio"
+            },
+            {
+              "$ref": "#/$defs/methodParametersCodeCount"
+            }
+          ]
+        },
+        "items": {
+          "description": "List of all items providing it's value to this scale",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/itemInScale"
+          },
+          "minItems": 1
+        },
+        "minItemNumber": {
+          "description": "Minimum number of items in responses for this scale to be reported; set '0' for unlimited",
+          "type": "number",
+          "default": 0
+        }
+      },
+      "required": [
+        "method",
+        "items"
+      ],
+      "additionalProperties": false
+    },
+    "parametersAGGREGATED": {
+      "description": "These parameters will be used for scaleType AGGREGATED",
+      "type": "object",
+      "properties": {
+        "method": {
+          "description": "Way how to process the item values.",
+          "type": "string",
+          "enum": [
+            "SUM",
+            "MEAN"
+          ],
+          "default": "SUM"
+        },
+        "sources": {
+          "description": "List of all scales providing it's value to this scale",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "Id of the scale providing the value for this aggregation.",
+                "type": "string"
+              },
+              "weight": {
+                "description": "Factor to adapt the scale value",
+                "type": "number",
+                "default": 1
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 2
+        }
+      },
+      "required": [
+        "sources"
+      ],
+      "additionalProperties": false
+    },
+    "parametersDERIVED": {
+      "description": "These parameters will be used for scaleType DERIVED",
+      "type": "object",
+      "properties": {
+        "source": {
+          "description": "Id of the scale providing the value for this derived scale.",
+          "type": "string"
+        },
+        "mappings": {
+          "description": "Applies the method to the value. The first match will go.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "method": {
+                "type": "string",
+                "description": "Condition for evaluation",
+                "enum": [
+                  "EQUALS",
+                  "LESS_THAN",
+                  "MORE_THAN",
+                  "MAX",
+                  "MIN"
+                ]
+              },
+              "parameters": {
+                "type": "array",
+                "description": "Depending on the method, additional parameter(s) is needed.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              },
+              "newValue": {
+                "description": "Value as outcome of this scale",
+                "type": "number"
+              },
+              "valueLabel": {
+                "$ref": "#/$defs/languageTaggedText"
+              },
+              "valueDescription": {
+                "$ref": "#/$defs/languageTaggedText"
+              }
+            },
+            "required": [
+              "method",
+              "parameters",
+              "newValue"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 1
+        },
+        "elseValue": {
+          "description": "Value if no mapping matches",
+          "type": "number",
+          "default": 0
+        },
+        "elseValueLabel": {
+          "$ref": "#/$defs/languageTaggedText"
+        },
+        "elseValueDescription": {
+          "$ref": "#/$defs/languageTaggedText"
+        },
+        "relatedVocabularies": {
+          "description": "Refers to public vocabularies to map the proficiency level to well known concepts",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "description": "URL to access the related vocabulary",
+                "type": "string"
+              },
+              "name": {
+                "description": "Shorthand title or name to understand the relation quickly",
+                "type": "string"
+              },
+              "values": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "number"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "relationShip": {
+                      "type": "string",
+                      "enum": [
+                        "SAME_AS",
+                        "ALIKE"
+                      ],
+                      "default": "SAME_AS"
+                    }
+                  },
+                  "required": [
+                    "value",
+                    "url"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "values",
+              "url"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "source",
+        "mappings"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/backend/src/acp/schemas/acp-unit-0.5.schema.json
+++ b/backend/src/acp/schemas/acp-unit-0.5.schema.json
@@ -1,0 +1,97 @@
+{
+  "$id": "acp-unit@0.5",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Assessment Content Package Unit",
+  "description": "Specification for assessment content package unit.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "lang": {
+      "description": "ISO-language code",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z]{2}$",
+      "default": "de"
+    },
+    "items": {
+      "description": "Default sorting is alpha-numeric.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "useUnitAliasAsPrefix": {
+            "description": "If true, the unique item identifier will be composed of the unit alias and the item id. If false, the item id has no prefix.",
+            "type": "boolean",
+            "default": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "sourceVariable": {
+            "description": "Refers to the variable providing its score as item value",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "sourceVariable"
+        ],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "dependencies": {
+      "description": "All digital objects being part of the unit",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/unitDependency"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "id",
+    "dependencies"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "unitDependency": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Id/path to find the digital object",
+          "type": "string"
+        },
+        "type": {
+          "description": "Describes the function of the dependency.",
+          "type": "string",
+          "enum": [
+            "UNIT_INDEX",
+            "UNIT_CODING_SCHEME",
+            "UNIT_METADATA",
+            "UNIT_UI_DEFINITION",
+            "PLAYER",
+            "PLAYER_DEPENDENCY",
+            "WIDGET"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "type"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/backend/src/acp/schemas/metadata-values-3.0.schema.json
+++ b/backend/src/acp/schemas/metadata-values-3.0.schema.json
@@ -1,0 +1,125 @@
+{
+  "$id": "metadata-values@iqb-standard@3.0",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Metadata Values",
+  "description": "Data structure to store metadata",
+  "type": "object",
+  "properties": {
+    "profileId": {
+      "type": "string",
+      "description": "Identifier for the metadata profile",
+      "minLength": 1
+    },
+    "order": {
+      "type": "integer",
+      "description": "Specifies the position of this profile if more than one are used. Set to -1 if you want to hide/disable the profile."
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the profile entry related to these data",
+            "minLength": 1
+          },
+          "label": {
+            "$ref": "#/$defs/language_coded_texts"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/language_coded_texts"
+              },
+              {
+                "$ref": "#/$defs/vocabulary_entries"
+              },
+              {
+                "$ref": "#/$defs/simple_value"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "value"
+        ]
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "profileId",
+    "entries"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "language_coded_texts": {
+      "type": "array",
+      "description": "Used for storing the input of texts. This type applies also in cases when only one language is used.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "lang": {
+            "type": "string",
+            "minLength": 1,
+            "description": "ISO-language code",
+            "pattern": "^[a-z]{2}$"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "lang",
+          "value"
+        ],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "vocabulary_entries": {
+      "type": "array",
+      "description": "Used for storing selected vocabulary entries and (optional) additional texts.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Full id of the vocabulary entry as url - including the vocabulary url"
+          },
+          "label": {
+            "$ref": "#/$defs/language_coded_texts"
+          },
+          "annotation": {
+            "$ref": "#/$defs/language_coded_texts"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "simple_value": {
+      "type": "object",
+      "description": "Used for uncoded text, numbers and boolean.",
+      "properties": {
+        "raw": {
+          "type": "string",
+          "description": "Pure value. Numbers and boolean in JavaScript toString() notation ('true', 'false', '23.566')."
+        },
+        "asText": {
+          "$ref": "#/$defs/language_coded_texts"
+        }
+      },
+      "required": [
+        "raw"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/backend/src/api/server-api.controller.ts
+++ b/backend/src/api/server-api.controller.ts
@@ -22,7 +22,13 @@ import {
   ApiQuery,
   ApiTags,
 } from "@nestjs/swagger";
-import { IsNotEmpty, IsObject, IsOptional, IsString } from "class-validator";
+import {
+  IsDateString,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from "class-validator";
 import { Response } from "express";
 import { FilesInterceptor } from "@nestjs/platform-express";
 import { ServerApiService } from "./server-api.service";
@@ -67,7 +73,7 @@ class ServerImportAcpDto {
     description: "Optimistic concurrency check (ISO timestamp)",
   })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   expectedUpdatedAt?: string;
 }
 
@@ -80,12 +86,11 @@ class UpdateIndexDto {
   @IsObject()
   acpIndex!: Record<string, any>;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     description: "Optimistic concurrency check (ISO timestamp)",
   })
-  @IsOptional()
-  @IsString()
-  expectedUpdatedAt?: string;
+  @IsDateString()
+  expectedUpdatedAt!: string;
 }
 
 class ReplaceCodingSchemeDto {

--- a/backend/src/api/server-api.module.ts
+++ b/backend/src/api/server-api.module.ts
@@ -14,6 +14,7 @@ import { ServerApiAuthGuard } from "./server-api-auth.guard";
 import { ServerApiAuditService } from "./server-api-audit.service";
 import { ServerApiAuditInterceptor } from "./server-api-audit.interceptor";
 import { SnapshotsModule } from "../snapshots/snapshots.module";
+import { AcpModule } from "../acp/acp.module";
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { SnapshotsModule } from "../snapshots/snapshots.module";
     ]),
     FilesModule,
     SnapshotsModule,
+    AcpModule,
   ],
   controllers: [ServerApiController],
   providers: [

--- a/backend/src/api/server-api.service.spec.ts
+++ b/backend/src/api/server-api.service.spec.ts
@@ -94,7 +94,7 @@ describe("ServerApiService", () => {
         {
           packageId: "pkg-1",
           name: "Demo",
-          acpIndex: { version: "0.5.0" },
+          acpIndex: { packageId: "pkg-1", version: "0.5.0" },
         },
         "reject",
       ),
@@ -126,6 +126,7 @@ describe("ServerApiService", () => {
         name: "New Name",
         description: "New Desc",
         acpIndex: {
+          packageId: "pkg-1",
           nested: { y: 2 },
           extra: true,
         },
@@ -141,6 +142,8 @@ describe("ServerApiService", () => {
         name: "New Name",
         description: "New Desc",
         acpIndex: {
+          packageId: "pkg-1",
+          name: [{ lang: "de", value: "New Name" }],
           header: { a: 1 },
           nested: { x: 1, y: 2 },
           extra: true,
@@ -479,6 +482,7 @@ describe("ServerApiService", () => {
         {
           id: "33333333-3333-4333-8333-333333333333",
           originalName: "unit.xml",
+          relativePath: "unit.xml",
           fileType: "text/xml",
           fileSize: 21,
           checksum: "abc",
@@ -871,7 +875,11 @@ describe("ServerApiService", () => {
     });
 
     const result = await service.receiveAcp(
-      { packageId: "pkg-1", name: "New ACP", acpIndex: { version: "0.5.0" } },
+      {
+        packageId: "pkg-1",
+        name: "New ACP",
+        acpIndex: { packageId: "pkg-1", version: "0.5.0" },
+      },
       "overwrite",
     );
 
@@ -879,7 +887,11 @@ describe("ServerApiService", () => {
       packageId: "pkg-1",
       name: "New ACP",
       description: "",
-      acpIndex: { version: "0.5.0" },
+      acpIndex: {
+        packageId: "pkg-1",
+        version: "0.5.0",
+        name: [{ lang: "de", value: "New ACP" }],
+      },
       settings: {},
     });
     expect(result.operation).toBe("created");
@@ -906,7 +918,7 @@ describe("ServerApiService", () => {
         packageId: "pkg-1",
         name: "Updated",
         description: "Updated Desc",
-        acpIndex: { replaced: true },
+        acpIndex: { packageId: "pkg-1", replaced: true },
         expectedUpdatedAt: "2026-01-01T00:00:00.000Z",
       },
       "overwrite",
@@ -918,7 +930,11 @@ describe("ServerApiService", () => {
       expect.objectContaining({
         name: "Updated",
         description: "Updated Desc",
-        acpIndex: { replaced: true },
+        acpIndex: {
+          packageId: "pkg-1",
+          name: [{ lang: "de", value: "Updated" }],
+          replaced: true,
+        },
       }),
     );
   });

--- a/backend/src/api/server-api.service.ts
+++ b/backend/src/api/server-api.service.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   Injectable,
   NotFoundException,
+  Optional,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { In, Repository } from "typeorm";
@@ -11,6 +12,8 @@ import { Acp, AcpFile } from "../database/entities";
 import { FilesService } from "../files/files.service";
 import { SnapshotsService } from "../snapshots/snapshots.service";
 import { assertUuidParam } from "../common/uuid-param";
+import { AcpIndexService } from "../acp/acp-index.service";
+import { UnprocessableEntityException } from "@nestjs/common";
 
 export type ConflictStrategy = "reject" | "overwrite" | "merge";
 export type IndexUpdateStrategy = "overwrite" | "merge";
@@ -40,6 +43,7 @@ export class ServerApiService {
     private readonly fileRepository: Repository<AcpFile>,
     private readonly filesService: FilesService,
     private readonly snapshotsService: SnapshotsService,
+    @Optional() private readonly acpIndexService?: AcpIndexService,
   ) {}
 
   /**
@@ -123,18 +127,20 @@ export class ServerApiService {
     if (!acpIndex || typeof acpIndex !== "object" || Array.isArray(acpIndex)) {
       throw new BadRequestException("acpIndex must be an object");
     }
+    this.requireExpectedUpdatedAt(expectedUpdatedAt);
 
     this.assertAcpAllowed(acpId, allowedAcpIds);
     const acp = await this.getAcpOrFail(acpId);
     this.assertExpectedUpdatedAt(acp, expectedUpdatedAt);
 
     const strategy = this.resolveIndexUpdateStrategy(strategyInput);
-    acp.acpIndex =
+    const candidate =
       strategy === "merge"
         ? this.deepMergeObjects(acp.acpIndex as Record<string, any>, acpIndex)
         : acpIndex;
-
-    const saved = await this.acpRepository.save(acp);
+    const saved = this.acpIndexService
+      ? await this.acpIndexService.saveCandidate(acpId, candidate, expectedUpdatedAt)
+      : await this.acpRepository.save({ ...acp, acpIndex: candidate });
     return {
       acpId: saved.id,
       packageId: saved.packageId,
@@ -150,6 +156,7 @@ export class ServerApiService {
     Array<{
       id: string;
       originalName: string;
+      relativePath: string;
       fileType?: string;
       fileSize: number;
       checksum?: string;
@@ -173,6 +180,7 @@ export class ServerApiService {
   ): Promise<{
     id: string;
     originalName: string;
+    relativePath: string;
     fileType?: string;
     fileSize: number;
     checksum?: string;
@@ -212,6 +220,7 @@ export class ServerApiService {
     Array<{
       id: string;
       originalName: string;
+      relativePath: string;
       fileType?: string;
       fileSize: number;
       checksum?: string;
@@ -297,6 +306,7 @@ export class ServerApiService {
     const replacementPlan: Array<{
       incoming: Express.Multer.File;
       canonicalName: string;
+      relativePath: string;
     }> = [];
 
     for (const incoming of files) {
@@ -324,10 +334,17 @@ export class ServerApiService {
           `Coding scheme "${incomingName}" does not exist in ACP and cannot be replaced`,
         );
       }
+      if (matches.length > 1) {
+        throw new ConflictException({
+          message: `Coding scheme "${incomingName}" is ambiguous`,
+          possiblePaths: matches.map((file) => file.relativePath || file.originalName),
+        });
+      }
 
       replacementPlan.push({
         incoming,
         canonicalName: matches[0].originalName,
+        relativePath: matches[0].relativePath || matches[0].originalName,
       });
     }
 
@@ -336,6 +353,7 @@ export class ServerApiService {
         ({
           ...plan.incoming,
           originalname: plan.canonicalName,
+          relativePath: plan.relativePath,
         }) as Express.Multer.File,
     );
     const replacedFiles = await this.filesService.uploadMultiple(
@@ -407,6 +425,20 @@ export class ServerApiService {
     const conflictStrategy = this.resolveConflictStrategy(
       conflictStrategyInput,
     );
+    const incomingIndex = this.withGermanName(data.acpIndex, data.name);
+    if (incomingIndex.packageId !== data.packageId) {
+      throw new UnprocessableEntityException(
+        "acpIndex.packageId must match packageId",
+      );
+    }
+    if (
+      incomingIndex.status === "RELEASED_PUBLIC" ||
+      incomingIndex.status === "RELEASED_CONFIDENTIAL"
+    ) {
+      throw new UnprocessableEntityException(
+        "Released status can only be set through the publish endpoint",
+      );
+    }
 
     let acp = await this.acpRepository.findOne({
       where: { packageId: data.packageId },
@@ -420,12 +452,26 @@ export class ServerApiService {
       this.assertAcpAllowed(acp.id, allowedAcpIds);
     }
     if (!acp) {
+      const validation = this.acpIndexService ? await this.acpIndexService.validateCandidate(
+        "00000000-0000-4000-8000-000000000000",
+        incomingIndex,
+      ) : { valid: true, publishable: false } as any;
+      if (!validation.valid) {
+        throw new UnprocessableEntityException({ message: "ACP index violates acp-index@0.5", report: validation });
+      }
       acp = this.acpRepository.create({
         packageId: data.packageId,
         name: data.name,
         description: data.description || "",
-        acpIndex: data.acpIndex,
+        acpIndex: incomingIndex,
         settings: {},
+        ...(this.acpIndexService
+          ? {
+              acpIndexSchemaId: "acp-index@0.5",
+              acpIndexValidationStatus: validation.publishable ? "CONFORMANT" : "CONFORMANT_WITH_ISSUES",
+              acpIndexValidationReport: validation as unknown as Record<string, unknown>,
+            }
+          : {}),
       });
       const saved = await this.acpRepository.save(acp);
       return { acp: saved, operation: "created", conflictStrategy };
@@ -438,21 +484,33 @@ export class ServerApiService {
         `ACP with packageId \"${data.packageId}\" already exists. Use conflictStrategy=overwrite or conflictStrategy=merge.`,
       );
     }
+    this.requireExpectedUpdatedAt(data.expectedUpdatedAt);
 
-    acp.name = data.name;
-    if (data.description !== undefined) {
-      acp.description = data.description;
-    }
-
-    acp.acpIndex =
+    const candidate =
       conflictStrategy === "merge"
         ? this.deepMergeObjects(
             acp.acpIndex as Record<string, any>,
-            data.acpIndex,
+            incomingIndex,
           )
-        : data.acpIndex;
+        : incomingIndex;
 
-    const saved = await this.acpRepository.save(acp);
+    const synchronizedCandidate = this.withGermanName(candidate, data.name);
+
+    const saved = this.acpIndexService
+      ? await this.acpIndexService.saveCandidate(
+          acp.id,
+          synchronizedCandidate,
+          data.expectedUpdatedAt,
+          { name: data.name, description: data.description },
+        )
+      : await this.acpRepository.save({
+          ...acp,
+          name: data.name,
+          ...(data.description !== undefined
+            ? { description: data.description }
+            : {}),
+          acpIndex: synchronizedCandidate,
+        });
     return { acp: saved, operation: "updated", conflictStrategy };
   }
 
@@ -497,6 +555,7 @@ export class ServerApiService {
   private toTransferFileMeta(file: AcpFile): {
     id: string;
     originalName: string;
+    relativePath: string;
     fileType?: string;
     fileSize: number;
     checksum?: string;
@@ -506,6 +565,7 @@ export class ServerApiService {
     return {
       id: file.id,
       originalName: file.originalName,
+      relativePath: file.relativePath || file.originalName,
       fileType: file.fileType,
       fileSize: Number(file.fileSize),
       checksum: file.checksum,
@@ -529,6 +589,14 @@ export class ServerApiService {
     if (acp.updatedAt.toISOString() !== parsed.toISOString()) {
       throw new ConflictException(
         "ACP was modified since the expected version timestamp",
+      );
+    }
+  }
+
+  private requireExpectedUpdatedAt(expectedUpdatedAt?: string): asserts expectedUpdatedAt is string {
+    if (!expectedUpdatedAt || Number.isNaN(Date.parse(expectedUpdatedAt))) {
+      throw new BadRequestException(
+        "expectedUpdatedAt must be a valid ISO timestamp",
       );
     }
   }
@@ -601,6 +669,19 @@ export class ServerApiService {
     }
 
     return result;
+  }
+
+  private withGermanName(
+    index: Record<string, any>,
+    name: string,
+  ): Record<string, any> {
+    const localizedNames = Array.isArray(index.name)
+      ? index.name.filter((entry) => entry?.lang !== "de")
+      : [];
+    return {
+      ...index,
+      name: [{ lang: "de", value: name }, ...localizedNames],
+    };
   }
 
   private isRecord(value: unknown): value is Record<string, any> {

--- a/backend/src/database/entities/acp-external-resource-cache.entity.ts
+++ b/backend/src/database/entities/acp-external-resource-cache.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity("acp_external_resource_cache")
+export class AcpExternalResourceCache {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ unique: true })
+  url!: string;
+
+  @Column({ nullable: true })
+  etag?: string;
+
+  @Column({ name: "last_modified", nullable: true })
+  lastModified?: string;
+
+  @Column({ type: "jsonb", nullable: true })
+  payload?: Record<string, unknown>;
+
+  @Column({ default: "unavailable" })
+  status!: string;
+
+  @Column({ name: "last_success_at", type: "timestamptz", nullable: true })
+  lastSuccessAt?: Date;
+
+  @Column({ name: "last_error", type: "text", nullable: true })
+  lastError?: string;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt!: Date;
+}

--- a/backend/src/database/entities/acp-file.entity.ts
+++ b/backend/src/database/entities/acp-file.entity.ts
@@ -22,6 +22,9 @@ export class AcpFile {
   @Column({ name: "original_name" })
   originalName!: string;
 
+  @Column({ name: "relative_path" })
+  relativePath!: string;
+
   @Column({ name: "file_type", nullable: true })
   fileType?: string;
 

--- a/backend/src/database/entities/acp-snapshot-file.entity.ts
+++ b/backend/src/database/entities/acp-snapshot-file.entity.ts
@@ -21,6 +21,9 @@ export class AcpSnapshotFile {
   @Column({ name: "original_name" })
   originalName!: string;
 
+  @Column({ name: "relative_path" })
+  relativePath!: string;
+
   @Column({ nullable: true })
   checksum?: string;
 

--- a/backend/src/database/entities/acp.entity.ts
+++ b/backend/src/database/entities/acp.entity.ts
@@ -29,6 +29,15 @@ export class Acp {
   @Column({ name: "acp_index", type: "jsonb", default: {} })
   acpIndex!: Record<string, unknown>;
 
+  @Column({ name: "acp_index_schema_id", nullable: true })
+  acpIndexSchemaId?: string;
+
+  @Column({ name: "acp_index_validation_status", default: "UNKNOWN" })
+  acpIndexValidationStatus!: string;
+
+  @Column({ name: "acp_index_validation_report", type: "jsonb", nullable: true })
+  acpIndexValidationReport?: Record<string, unknown>;
+
   @Column({ name: "item_properties", type: "jsonb", default: {} })
   itemProperties!: Record<string, Record<string, any>>;
 

--- a/backend/src/database/entities/index.ts
+++ b/backend/src/database/entities/index.ts
@@ -2,6 +2,7 @@ export { User } from "./user.entity";
 export { Acp } from "./acp.entity";
 export { AcpUserRole, AcpRole } from "./acp-user-role.entity";
 export { AcpFile } from "./acp-file.entity";
+export { AcpExternalResourceCache } from "./acp-external-resource-cache.entity";
 export { AcpFileProcessingJob } from "./acp-file-processing-job.entity";
 export { AcpSnapshot } from "./acp-snapshot.entity";
 export { AcpSnapshotFile } from "./acp-snapshot-file.entity";

--- a/backend/src/database/migrations/1785000000000-AcpIndex05Compliance.ts
+++ b/backend/src/database/migrations/1785000000000-AcpIndex05Compliance.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AcpIndex05Compliance1785000000000 implements MigrationInterface {
+  name = "AcpIndex05Compliance1785000000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "acp" ADD COLUMN IF NOT EXISTS "acp_index_schema_id" character varying`);
+    await queryRunner.query(`ALTER TABLE "acp" ADD COLUMN IF NOT EXISTS "acp_index_validation_status" character varying NOT NULL DEFAULT 'UNKNOWN'`);
+    await queryRunner.query(`ALTER TABLE "acp" ADD COLUMN IF NOT EXISTS "acp_index_validation_report" jsonb`);
+    await queryRunner.query(`ALTER TABLE "acp_files" ADD COLUMN IF NOT EXISTS "relative_path" character varying`);
+    await queryRunner.query(`UPDATE "acp_files" SET "relative_path" = "original_name" WHERE "relative_path" IS NULL`);
+    await queryRunner.query(`WITH ranked AS (
+      SELECT id, row_number() OVER (PARTITION BY acp_id, lower(relative_path) ORDER BY uploaded_at, id) AS rn
+      FROM acp_files
+    ) UPDATE acp_files f SET relative_path = 'legacy-duplicates/' || f.id || '/' || f.original_name
+      FROM ranked r WHERE f.id = r.id AND r.rn > 1`);
+    await queryRunner.query(`ALTER TABLE "acp_files" ALTER COLUMN "relative_path" SET NOT NULL`);
+    await queryRunner.query(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_acp_files_acp_relative_path" ON "acp_files" ("acp_id", lower("relative_path"))`);
+    await queryRunner.query(`ALTER TABLE "acp_snapshot_files" ADD COLUMN IF NOT EXISTS "relative_path" character varying`);
+    await queryRunner.query(`UPDATE "acp_snapshot_files" SET "relative_path" = "original_name" WHERE "relative_path" IS NULL`);
+    await queryRunner.query(`ALTER TABLE "acp_snapshot_files" ALTER COLUMN "relative_path" SET NOT NULL`);
+    await queryRunner.query(`CREATE TABLE IF NOT EXISTS "acp_external_resource_cache" (
+      "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "url" character varying NOT NULL,
+      "etag" character varying, "last_modified" character varying, "payload" jsonb,
+      "status" character varying NOT NULL DEFAULT 'unavailable', "last_success_at" TIMESTAMPTZ,
+      "last_error" text, "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+      "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_acp_external_resource_cache_url" UNIQUE ("url"),
+      CONSTRAINT "PK_acp_external_resource_cache" PRIMARY KEY ("id"))`);
+    await queryRunner.query(`UPDATE "acp" SET "acp_index_schema_id" = 'acp-index@0.5', "acp_index_validation_status" = 'LEGACY_NONCONFORMANT' WHERE "acp_index_schema_id" IS NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "acp_external_resource_cache"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_acp_files_acp_relative_path"`);
+    await queryRunner.query(`ALTER TABLE "acp_snapshot_files" DROP COLUMN IF EXISTS "relative_path"`);
+    await queryRunner.query(`ALTER TABLE "acp_files" DROP COLUMN IF EXISTS "relative_path"`);
+    await queryRunner.query(`ALTER TABLE "acp" DROP COLUMN IF EXISTS "acp_index_validation_report"`);
+    await queryRunner.query(`ALTER TABLE "acp" DROP COLUMN IF EXISTS "acp_index_validation_status"`);
+    await queryRunner.query(`ALTER TABLE "acp" DROP COLUMN IF EXISTS "acp_index_schema_id"`);
+  }
+}

--- a/backend/src/files/archive-expansion.service.ts
+++ b/backend/src/files/archive-expansion.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
 import * as path from "path";
+import { normalizeRelativePath } from "./relative-path";
 
 @Injectable()
 export class ArchiveExpansionService {
@@ -65,13 +66,15 @@ export class ArchiveExpansionService {
     for (const entry of archiveEntries as Array<{
       dir?: boolean;
       name?: string;
+      unsafeOriginalName?: string;
     }>) {
       if (entry?.dir) {
         continue;
       }
 
-      const originalEntryName = String(entry?.name || "");
-      const extractedName = this.getArchiveEntryFileName(originalEntryName);
+      const originalEntryName = String(entry?.unsafeOriginalName || entry?.name || "");
+      const relativePath = normalizeRelativePath(originalEntryName);
+      const extractedName = this.getArchiveEntryFileName(relativePath);
       if (
         !extractedName ||
         this.shouldSkipArchiveEntry(originalEntryName, extractedName)
@@ -79,7 +82,7 @@ export class ArchiveExpansionService {
         continue;
       }
 
-      const zipEntry = archive.file(originalEntryName);
+      const zipEntry = archive.file(String(entry?.name || originalEntryName));
       if (!zipEntry) {
         continue;
       }
@@ -91,7 +94,8 @@ export class ArchiveExpansionService {
         mimetype: this.inferMimeTypeFromFileName(extractedName),
         size: buffer.length,
         buffer,
-      });
+        relativePath,
+      } as Express.Multer.File & { relativePath: string });
     }
 
     return extractedFiles;

--- a/backend/src/files/file-mutation.service.ts
+++ b/backend/src/files/file-mutation.service.ts
@@ -5,17 +5,20 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { DataSource, Repository } from "typeorm";
+import { DataSource, In, Repository } from "typeorm";
+import * as crypto from "crypto";
 import { assertUuidParam } from "../common/uuid-param";
 import { Acp, AcpFile } from "../database/entities";
 import { ArchiveExpansionService } from "./archive-expansion.service";
 import { FileStorageService } from "./file-storage.service";
+import { getUploadRelativePath, normalizeRelativePath } from "./relative-path";
 
 export type UploadConflictStrategy = "reject" | "overwrite" | "keep-both";
 
 export interface UploadMultipleOptions {
   conflictStrategy?: string;
   expandArchives?: boolean;
+  relativePaths?: string[];
 }
 
 @Injectable()
@@ -34,18 +37,10 @@ export class FileMutationService {
     acpId: string,
     uploadedFile: Express.Multer.File,
   ): Promise<AcpFile> {
-    await this.getAcpOrFail(acpId);
-    const stagedFile = await this.fileStorageService.stageUpload(
-      acpId,
-      uploadedFile,
-    );
-
-    try {
-      return await this.fileRepository.save(stagedFile);
-    } catch (error) {
-      await this.fileStorageService.removePhysicalFile(stagedFile);
-      throw error;
-    }
+    const [saved] = await this.uploadMultiple(acpId, [uploadedFile], {
+      expandArchives: false,
+    });
+    return saved;
   }
 
   async uploadMultiple(
@@ -61,6 +56,14 @@ export class FileMutationService {
     }
 
     await this.getAcpOrFail(acpId);
+    if (options.relativePaths) {
+      if (options.relativePaths.length !== files.length) {
+        throw new BadRequestException("relativePaths must have the same number of entries as files");
+      }
+      files.forEach((file, index) => {
+        (file as Express.Multer.File & { relativePath?: string }).relativePath = normalizeRelativePath(options.relativePaths![index]);
+      });
+    }
     const normalizedFiles =
       options.expandArchives === false
         ? files
@@ -72,7 +75,7 @@ export class FileMutationService {
     if (conflictStrategy === "reject") {
       const existingFiles = await this.fileRepository.find({
         where: { acpId },
-        order: { originalName: "ASC" },
+        order: { relativePath: "ASC" },
       });
       this.assertNoRejectedConflicts(
         filesToPersist,
@@ -103,11 +106,12 @@ export class FileMutationService {
         if (!lockedAcp) {
           throw new NotFoundException(`ACP with ID ${acpId} not found`);
         }
+        this.assertEditable(lockedAcp);
 
         const repository = manager.getRepository(AcpFile);
         const existingFiles = await repository.find({
           where: { acpId },
-          order: { originalName: "ASC" },
+          order: { relativePath: "ASC" },
         });
         const existingByName = this.groupByNormalizedName(existingFiles);
         this.assertNoRejectedConflicts(
@@ -115,15 +119,20 @@ export class FileMutationService {
           existingByName,
           conflictStrategy,
         );
+        if (conflictStrategy === "keep-both") {
+          this.ensureKeepBothPaths(stagedFiles, existingFiles);
+        }
 
         const replacedFiles =
           conflictStrategy === "overwrite"
             ? this.collectOverwriteMatches(filesToPersist, existingByName)
             : [];
-        const savedFiles = await repository.save(stagedFiles);
         if (replacedFiles.length) {
           await repository.remove(replacedFiles);
         }
+        const savedFiles = await repository.save(stagedFiles);
+        lockedAcp.updatedAt = new Date();
+        await acpRepository.save(lockedAcp);
         return { savedFiles, replacedFiles };
       });
 
@@ -135,6 +144,34 @@ export class FileMutationService {
     }
   }
 
+  async deleteMultiple(acpId: string, fileIds: string[]): Promise<AcpFile[]> {
+    await this.getAcpOrFail(acpId);
+    const normalizedIds = Array.from(new Set(fileIds));
+    const deletedFiles = await this.dataSource.transaction(async (manager) => {
+      const acpRepository = manager.getRepository(Acp);
+      const acp = await acpRepository.findOne({
+        where: { id: acpId },
+        lock: { mode: "pessimistic_write" },
+      });
+      if (!acp) throw new NotFoundException(`ACP with ID ${acpId} not found`);
+      this.assertEditable(acp);
+
+      const repository = manager.getRepository(AcpFile);
+      const files = await repository.find({
+        where: { acpId, id: In(normalizedIds) },
+      });
+      if (files.length !== normalizedIds.length) {
+        throw new NotFoundException("One or more files were not found in the ACP");
+      }
+      await repository.remove(files);
+      acp.updatedAt = new Date();
+      await acpRepository.save(acp);
+      return files;
+    });
+    await this.fileStorageService.removePhysicalFiles(deletedFiles);
+    return deletedFiles;
+  }
+
   private resolveIncomingFiles(
     files: Express.Multer.File[],
     conflictStrategy: UploadConflictStrategy,
@@ -143,7 +180,7 @@ export class FileMutationService {
     const duplicates = new Set<string>();
 
     for (const file of files) {
-      const name = String(file?.originalname || "").trim();
+      const name = getUploadRelativePath(file);
       const key = this.normalizeFileName(name);
       if (!key) {
         throw new BadRequestException("All files must include a filename");
@@ -174,8 +211,9 @@ export class FileMutationService {
 
     const conflicts = new Set<string>();
     for (const file of files) {
-      if (existingByName.has(this.normalizeFileName(file.originalname))) {
-        conflicts.add(file.originalname);
+      const relativePath = getUploadRelativePath(file);
+      if (existingByName.has(this.normalizeFileName(relativePath))) {
+        conflicts.add(relativePath);
       }
     }
     if (conflicts.size) {
@@ -198,7 +236,7 @@ export class FileMutationService {
     const matches = new Map<string, AcpFile>();
     for (const file of files) {
       for (const match of existingByName.get(
-        this.normalizeFileName(file.originalname),
+        this.normalizeFileName(getUploadRelativePath(file)),
       ) || []) {
         matches.set(match.id, match);
       }
@@ -209,7 +247,7 @@ export class FileMutationService {
   private groupByNormalizedName(files: AcpFile[]): Map<string, AcpFile[]> {
     const grouped = new Map<string, AcpFile[]>();
     for (const file of files) {
-      const key = this.normalizeFileName(file.originalName);
+      const key = this.normalizeFileName(file.relativePath || file.originalName);
       if (!key) {
         continue;
       }
@@ -218,6 +256,18 @@ export class FileMutationService {
       grouped.set(key, bucket);
     }
     return grouped;
+  }
+
+  private ensureKeepBothPaths(incoming: AcpFile[], existing: AcpFile[]): void {
+    const occupied = new Set(existing.map((file) => this.normalizeFileName(file.relativePath || file.originalName)));
+    for (const file of incoming) {
+      let candidate = file.relativePath || file.originalName;
+      if (occupied.has(this.normalizeFileName(candidate))) {
+        candidate = `duplicates/${crypto.randomUUID()}/${candidate}`;
+      }
+      file.relativePath = candidate;
+      occupied.add(this.normalizeFileName(candidate));
+    }
   }
 
   private resolveConflictStrategy(input?: string): UploadConflictStrategy {
@@ -246,6 +296,18 @@ export class FileMutationService {
     if (!acp) {
       throw new NotFoundException(`ACP with ID ${acpId} not found`);
     }
+    this.assertEditable(acp);
     return acp;
+  }
+
+  private assertEditable(acp: Acp): void {
+    if (
+      acp.acpIndex?.status === "RELEASED_PUBLIC" ||
+      acp.acpIndex?.status === "RELEASED_CONFIDENTIAL"
+    ) {
+      throw new ConflictException(
+        "Published ACP must be reopened before files can be changed",
+      );
+    }
   }
 }

--- a/backend/src/files/file-processing-jobs.service.ts
+++ b/backend/src/files/file-processing-jobs.service.ts
@@ -5,6 +5,7 @@ import {
   Logger,
   MessageEvent,
   NotFoundException,
+  Optional,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { In, Repository } from "typeorm";
@@ -19,6 +20,7 @@ import {
   FileProcessingJobSnapshot,
   FileProcessingProgressReporter,
 } from "./file-processing-progress";
+import { IndexGenerationService } from "./index-generation.service";
 
 @Injectable()
 export class FileProcessingJobsService {
@@ -37,6 +39,7 @@ export class FileProcessingJobsService {
     private readonly filesService: FilesService,
     private readonly unitParserService: UnitParserService,
     private readonly validationService: ValidationService,
+    @Optional() private readonly indexGenerationService?: IndexGenerationService,
   ) {}
 
   async createAndStartJob(
@@ -248,10 +251,12 @@ export class FileProcessingJobsService {
         });
       } else {
         const uploadedFiles = await this.loadUploadedFiles(job);
-        const syncReport = await this.unitParserService.syncIndexFromFiles(
-          job.acpId,
-          reporter,
-        );
+        const syncReport = this.indexGenerationService
+          ? await this.buildGenerationPreviewReport(job.acpId)
+          : await this.unitParserService.syncIndexFromFiles(
+              job.acpId,
+              reporter,
+            );
         const validationRun =
           await this.validationService.autoValidateUploadedFiles(
             job.acpId,
@@ -321,6 +326,27 @@ export class FileProcessingJobsService {
     } finally {
       this.runningJobs.delete(jobId);
     }
+  }
+
+  private async buildGenerationPreviewReport(
+    acpId: string,
+  ): Promise<Record<string, unknown>> {
+    const preview = await this.indexGenerationService!.preview(acpId);
+    return {
+      unitsAdded: 0,
+      unitsUpdated: 0,
+      itemsAdded: 0,
+      itemsUpdated: 0,
+      requiresConfirmation: true,
+      canApply: preview.canApply,
+      sourceRevision: preview.sourceRevision,
+      unassignedUnitPaths: preview.unassignedUnitPaths,
+      ambiguousBooklets: preview.ambiguousBooklets,
+      warnings: [
+        "Der ACP-Index wurde nicht automatisch geändert. Bitte die Generatorvorschau prüfen und übernehmen.",
+        ...preview.warnings,
+      ],
+    };
   }
 
   private async ensureNoActiveJob(acpId: string): Promise<void> {

--- a/backend/src/files/file-storage.service.ts
+++ b/backend/src/files/file-storage.service.ts
@@ -6,6 +6,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { Repository } from "typeorm";
 import { AcpFile } from "../database/entities";
+import { getUploadRelativePath } from "./relative-path";
 
 @Injectable()
 export class FileStorageService {
@@ -48,6 +49,7 @@ export class FileStorageService {
       acpId,
       filePath,
       originalName: uploadedFile.originalname,
+      relativePath: getUploadRelativePath(uploadedFile),
       fileType: uploadedFile.mimetype,
       fileSize: uploadedFile.size,
       checksum,

--- a/backend/src/files/files.controller.ts
+++ b/backend/src/files/files.controller.ts
@@ -5,6 +5,7 @@ import {
   Controller,
   Get,
   Logger,
+  Optional,
   Post,
   Delete,
   Param,
@@ -39,6 +40,7 @@ import { Roles } from "../auth/roles.decorator";
 import { FileProcessingJobsService } from "./file-processing-jobs.service";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
 import { UuidParam } from "../common/uuid-param";
+import { IndexGenerationService } from "./index-generation.service";
 
 @ApiTags("ACP Files")
 @Controller("acp/:acpId/files")
@@ -51,6 +53,7 @@ export class FilesController {
     private readonly validationService: ValidationService,
     private readonly fileProcessingJobsService: FileProcessingJobsService,
     private readonly itemExplorerStateService: ItemExplorerStateService,
+    @Optional() private readonly indexGenerationService?: IndexGenerationService,
   ) {}
 
   @Get()
@@ -63,6 +66,7 @@ export class FilesController {
     @Query("sequenceId") sequenceId?: string,
     @Request() req?: any,
     @Res({ passthrough: true }) res?: Response,
+    @Query("partId") partId?: string,
   ) {
     const isManager =
       req?.acpAccessLevel === "MANAGER" || req?.acpAccessLevel === "ADMIN";
@@ -87,7 +91,9 @@ export class FilesController {
       }
 
       const archive = unitId
-        ? await this.filesService.createUnitZip(acpId, unitId)
+        ? partId
+          ? await this.filesService.createUnitZip(acpId, unitId, partId)
+          : await this.filesService.createUnitZip(acpId, unitId)
         : await this.filesService.createSequenceZip(acpId, sequenceId!);
 
       res?.setHeader("Content-Type", "application/zip");
@@ -251,6 +257,24 @@ export class FilesController {
     return unitView;
   }
 
+  @Get("unit-view/:partId/:unitId")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "Get uploaded unit view scoped to an assessment part" })
+  async getPartUnitView(
+    @UuidParam("acpId") acpId: string,
+    @Param("partId") partId: string,
+    @Param("unitId") unitId: string,
+    @Request() req: any,
+    @Query("perspective") perspective?: string,
+  ) {
+    const isManager = this.isManagerViewContext(req, perspective);
+    if (!isManager) {
+      const featureConfig = await this.filesService.getFeatureConfig(acpId);
+      if (featureConfig.enableUnitView === false) throw new ForbiddenException("Unit view is not enabled for this ACP");
+    }
+    return this.unitParserService.getUnitViewFromFiles(acpId, unitId, undefined, "", partId);
+  }
+
   @Get("jobs/:jobId")
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles("ACP_MANAGER")
@@ -351,12 +375,26 @@ export class FilesController {
     @UuidParam("acpId") acpId: string,
     @UploadedFiles() files: Express.Multer.File[],
     @Query("conflictStrategy") conflictStrategy?: string,
+    @Body("relativePaths") relativePathsInput?: string | string[],
   ) {
+    const relativePaths = this.parseRelativePaths(relativePathsInput);
     return {
       files: await this.filesService.uploadMultiple(acpId, files, {
         conflictStrategy,
+        relativePaths,
       }),
     };
+  }
+
+  private parseRelativePaths(input?: string | string[]): string[] | undefined {
+    if (input === undefined) return undefined;
+    if (Array.isArray(input)) return input;
+    try {
+      const parsed = JSON.parse(input);
+      return Array.isArray(parsed) ? parsed.map(String) : [String(input)];
+    } catch {
+      return [String(input)];
+    }
   }
 
   @Post("bulk-download")
@@ -455,7 +493,9 @@ export class FilesController {
       "Synchronize ACP-Index from uploaded unit files (non-destructive merge)",
   })
   async syncIndex(@UuidParam("acpId") acpId: string) {
-    return this.unitParserService.syncIndexFromFiles(acpId);
+    return this.indexGenerationService
+      ? this.indexGenerationService.preview(acpId)
+      : this.unitParserService.syncIndexFromFiles(acpId);
   }
 
   @Get(":fileId/download")

--- a/backend/src/files/files.module.ts
+++ b/backend/src/files/files.module.ts
@@ -25,6 +25,10 @@ import { FileCatalogCache } from "./file-catalog.cache";
 import { ItemListParser } from "./item-list.parser";
 import { NumberedItemListCache } from "./numbered-item-list.cache";
 import { UnitViewResolver } from "./unit-view.resolver";
+import { AcpModule } from "../acp/acp.module";
+import { SnapshotsModule } from "../snapshots/snapshots.module";
+import { IndexGenerationService } from "./index-generation.service";
+import { IndexGenerationController } from "./index-generation.controller";
 
 const MAX_UPLOAD_FILE_SIZE_BYTES = 512 * 1024 * 1024;
 
@@ -45,8 +49,10 @@ const MAX_UPLOAD_FILE_SIZE_BYTES = 512 * 1024 * 1024;
     AuthModule,
     ValidationModule,
     ItemExplorerModule,
+    AcpModule,
+    SnapshotsModule,
   ],
-  controllers: [FilesController],
+  controllers: [FilesController, IndexGenerationController],
   providers: [
     FilesService,
     ArchiveExpansionService,
@@ -59,6 +65,7 @@ const MAX_UPLOAD_FILE_SIZE_BYTES = 512 * 1024 * 1024;
     UnitParserService,
     FileProcessingJobsService,
     ItemRowNumberingService,
+    IndexGenerationService,
   ],
   exports: [
     FilesService,

--- a/backend/src/files/files.service.spec.ts
+++ b/backend/src/files/files.service.spec.ts
@@ -89,6 +89,7 @@ describe("FilesService", () => {
           ],
         },
       }),
+      save: jest.fn().mockImplementation(async (entity) => entity),
     };
     accessConfigRepo = {
       findOne: jest.fn().mockResolvedValue({ featureConfig: {} }),
@@ -259,6 +260,39 @@ describe("FilesService", () => {
       expect(fs.mkdir).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
       expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it("should report a path conflict for a direct upload", async () => {
+      const incoming = {
+        originalname: "test.json",
+        mimetype: "application/json",
+        size: 2,
+        buffer: Buffer.from("{}"),
+      } as Express.Multer.File;
+
+      await expect(service.upload(acpId, incoming)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(repo.save).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it("should require reopening before uploading to a released ACP", async () => {
+      acpRepo.findOne.mockResolvedValue({
+        id: acpId,
+        acpIndex: { status: "RELEASED_PUBLIC" },
+      });
+      const incoming = {
+        originalname: "new.json",
+        mimetype: "application/json",
+        size: 2,
+        buffer: Buffer.from("{}"),
+      } as Express.Multer.File;
+
+      await expect(service.upload(acpId, incoming)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(fs.writeFile).not.toHaveBeenCalled();
     });
   });
 
@@ -443,10 +477,10 @@ describe("FilesService", () => {
       expect(acpRepo.findOne.mock.invocationCallOrder[1]).toBeLessThan(
         repo.find.mock.invocationCallOrder[0],
       );
-      expect(repo.save.mock.invocationCallOrder[0]).toBeLessThan(
-        repo.remove.mock.invocationCallOrder[0],
-      );
       expect(repo.remove.mock.invocationCallOrder[0]).toBeLessThan(
+        repo.save.mock.invocationCallOrder[0],
+      );
+      expect(repo.save.mock.invocationCallOrder[0]).toBeLessThan(
         (fs.unlink as jest.Mock).mock.invocationCallOrder[0],
       );
     });
@@ -648,7 +682,7 @@ describe("FilesService", () => {
     it("should delete file from disk and DB", async () => {
       repo.findOne.mockResolvedValue(mockFile);
       await service.delete("file-1");
-      expect(repo.remove).toHaveBeenCalledWith(mockFile);
+      expect(repo.remove).toHaveBeenCalledWith([mockFile]);
       expect(unitParserService.invalidateFileCaches).toHaveBeenCalledWith(
         acpId,
       );
@@ -657,14 +691,14 @@ describe("FilesService", () => {
     it("should ignore unlink errors during delete operations", async () => {
       (fs.unlink as jest.Mock).mockRejectedValueOnce(new Error("gone"));
       await expect(service.delete("file-1")).resolves.toBeUndefined();
-      expect(repo.remove).toHaveBeenCalledWith(mockFile);
+      expect(repo.remove).toHaveBeenCalledWith([mockFile]);
     });
 
     it("should delete by ACP and remove all files", async () => {
       await expect(
         service.deleteForAcp(acpId, "file-1"),
       ).resolves.toBeUndefined();
-      expect(repo.remove).toHaveBeenCalledWith(mockFile);
+      expect(repo.remove).toHaveBeenCalledWith([mockFile]);
 
       repo.find.mockResolvedValue([
         { ...mockFile, id: "file-1", filePath: "/x/1" },
@@ -1083,6 +1117,49 @@ describe("FilesService", () => {
       await expect(service.createUnitZip(acpId, "unit-1")).rejects.toThrow(
         NotFoundException,
       );
+    });
+
+    it("requires a part for duplicate unit ids and exports only that part", async () => {
+      acpRepo.findOne.mockResolvedValue({
+        id: acpId,
+        acpIndex: {
+          assessmentParts: ["ma1", "sp1"].map((partId) => ({
+            id: partId,
+            units: [
+              {
+                id: "shared",
+                dependencies: [
+                  {
+                    id: `units/${partId}/shared.xml`,
+                    type: "UNIT_INDEX",
+                  },
+                ],
+              },
+            ],
+          })),
+        },
+      });
+      repo.find.mockResolvedValue(
+        ["ma1", "sp1"].map((partId) => ({
+          ...mockFile,
+          id: `file-${partId}`,
+          originalName: "shared.xml",
+          relativePath: `units/${partId}/shared.xml`,
+        })),
+      );
+
+      await expect(service.createUnitZip(acpId, "shared")).rejects.toThrow(
+        ConflictException,
+      );
+      const archive = await service.createUnitZip(acpId, "shared", "ma1");
+      const JSZip = require("jszip");
+      const zip = await JSZip.loadAsync(archive.buffer);
+      expect(Object.keys(zip.files)).toEqual([
+        "units/",
+        "units/ma1/",
+        "units/ma1/shared.xml",
+      ]);
+      expect(archive.fileName).toContain("part-ma1");
     });
   });
 

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ConflictException,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
@@ -17,6 +18,8 @@ import {
 } from "../database/entities";
 import {
   findUnitInIndex,
+  findUnitInPart,
+  findUnitsInIndex,
   getAssessmentParts,
   getIndexUnits,
   toRuntimeAcpIndex,
@@ -247,15 +250,13 @@ export class FilesService {
 
   async delete(id: string): Promise<void> {
     const file = await this.findById(id);
-    await this.fileRepository.remove(file);
-    await this.fileStorageService.removePhysicalFile(file);
+    await this.fileMutationService.deleteMultiple(file.acpId, [file.id]);
     this.unitParserService.invalidateFileCaches(file.acpId);
   }
 
   async deleteForAcp(acpId: string, id: string): Promise<void> {
     const file = await this.findByIdForAcp(acpId, id);
-    await this.fileRepository.remove(file);
-    await this.fileStorageService.removePhysicalFile(file);
+    await this.fileMutationService.deleteMultiple(acpId, [file.id]);
     this.unitParserService.invalidateFileCaches(acpId);
   }
 
@@ -282,16 +283,22 @@ export class FilesService {
     }
 
     const filesToDelete = normalizedIds.map((id) => filesById.get(id)!);
-    await this.fileRepository.remove(filesToDelete);
-    await this.fileStorageService.removePhysicalFiles(filesToDelete);
+    await this.fileMutationService.deleteMultiple(
+      acpId,
+      filesToDelete.map((file) => file.id),
+    );
     this.unitParserService.invalidateFileCaches(acpId);
     return normalizedIds;
   }
 
   async deleteAll(acpId: string): Promise<void> {
     const files = await this.findByAcp(acpId);
-    await this.fileRepository.remove(files);
-    await this.fileStorageService.removePhysicalFiles(files);
+    if (files.length) {
+      await this.fileMutationService.deleteMultiple(
+        acpId,
+        files.map((file) => file.id),
+      );
+    }
     this.unitParserService.invalidateFileCaches(acpId);
   }
 
@@ -527,16 +534,20 @@ export class FilesService {
   async createUnitZip(
     acpId: string,
     unitId: string,
+    partId?: string,
   ): Promise<{ buffer: Buffer; fileName: string }> {
     const index = await this.getAcpIndex(acpId);
     const allFiles = await this.findByAcp(acpId);
-    const unitFiles = this.collectUnitFiles(index, allFiles, unitId);
+    const unitFiles = this.collectUnitFiles(index, allFiles, unitId, true, partId);
     if (!unitFiles.length) {
       throw new NotFoundException(`No files found for unit "${unitId}"`);
     }
 
     const buffer = await this.createZipBuffer(unitFiles);
-    return { buffer, fileName: `acp-${acpId}-unit-${unitId}.zip` };
+    return {
+      buffer,
+      fileName: `acp-${acpId}${partId ? `-part-${partId}` : ""}-unit-${unitId}.zip`,
+    };
   }
 
   async createSequenceZip(
@@ -545,15 +556,21 @@ export class FilesService {
   ): Promise<{ buffer: Buffer; fileName: string }> {
     const index = await this.getAcpIndex(acpId);
     const allFiles = await this.findByAcp(acpId);
-    const unitIds = this.resolveSequenceUnitIds(index, sequenceId);
+    const sequence = this.resolveSequenceUnitIds(index, sequenceId);
 
-    if (!unitIds.length) {
+    if (!sequence.unitIds.length) {
       throw new NotFoundException(`Sequence "${sequenceId}" not found`);
     }
 
     const fileMap = new Map<string, AcpFile>();
-    for (const unitId of unitIds) {
-      const unitFiles = this.collectUnitFiles(index, allFiles, unitId, false);
+    for (const unitId of sequence.unitIds) {
+      const unitFiles = this.collectUnitFiles(
+        index,
+        allFiles,
+        unitId,
+        false,
+        sequence.partId,
+      );
       for (const file of unitFiles) {
         fileMap.set(file.id, file);
       }
@@ -1189,23 +1206,29 @@ export class FilesService {
     return toRuntimeAcpIndex(acp.acpIndex);
   }
 
-  private resolveSequenceUnitIds(index: any, sequenceId: string): string[] {
+  private resolveSequenceUnitIds(
+    index: any,
+    sequenceId: string,
+  ): { partId?: string; unitIds: string[] } {
     const parts = getAssessmentParts(index);
     for (const part of parts) {
       for (const module of part.bookletModules || []) {
         if (module.id === sequenceId) {
-          return (module.units || [])
+          return {
+            partId: part.id,
+            unitIds: (module.units || [])
             .slice()
             .sort((a: any, b: any) => (a.order || 0) - (b.order || 0))
             .map((u: any) => u.id)
             .filter(
               (id: unknown): id is string =>
                 typeof id === "string" && id.length > 0,
-            );
+            ),
+          };
         }
       }
     }
-    return [];
+    return { unitIds: [] };
   }
 
   private collectUnitFiles(
@@ -1213,8 +1236,18 @@ export class FilesService {
     allFiles: AcpFile[],
     unitId: string,
     throwOnMissingUnit = true,
+    partId?: string,
   ): AcpFile[] {
-    const unit = findUnitInIndex(index, unitId);
+    const matches = findUnitsInIndex(index, unitId);
+    if (!partId && matches.length > 1) {
+      throw new ConflictException({
+        message: `Unit ${unitId} exists in multiple assessment parts`,
+        possibleParts: matches.map((entry) => entry.partId),
+      });
+    }
+    const unit = partId
+      ? findUnitInPart(index, partId, unitId)
+      : matches[0]?.unit || findUnitInIndex(index, unitId);
     if (!unit) {
       if (throwOnMissingUnit) {
         throw new NotFoundException(`Unit "${unitId}" not found`);
@@ -1223,16 +1256,22 @@ export class FilesService {
     }
 
     const dependencyNames = new Set<string>();
+    let hasUnitIndexDependency = false;
     for (const dep of unit.dependencies || []) {
       if (dep?.id && typeof dep.id === "string") {
         dependencyNames.add(dep.id);
+        if (dep.type === "UNIT_INDEX") hasUnitIndexDependency = true;
       }
     }
 
     // Most ACP exports include one XML per unit; include it if available.
-    dependencyNames.add(`${unitId}.xml`);
+    if (!hasUnitIndexDependency) dependencyNames.add(`${unitId}.xml`);
 
-    return allFiles.filter((file) => dependencyNames.has(file.originalName));
+    return allFiles.filter(
+      (file) =>
+        dependencyNames.has(file.relativePath || file.originalName) ||
+        dependencyNames.has(file.originalName),
+    );
   }
 
   private async createZipBuffer(
@@ -1251,7 +1290,7 @@ export class FilesService {
       const fileBytes = this.getArchiveProgressBytes(file);
       try {
         const data = await fs.readFile(file.filePath);
-        zip.file(file.originalName, data);
+        zip.file(file.relativePath || file.originalName, data);
         added++;
       } catch {
         // Ignore missing on-disk files; we still zip what is available.

--- a/backend/src/files/index-generation.controller.ts
+++ b/backend/src/files/index-generation.controller.ts
@@ -1,0 +1,64 @@
+import { Body, Controller, Post, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import {
+  IsArray,
+  IsDateString,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Matches,
+} from "class-validator";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { RolesGuard } from "../auth/guards/roles.guard";
+import { Roles } from "../auth/roles.decorator";
+import { UuidParam } from "../common/uuid-param";
+import { IndexGenerationOptions, IndexGenerationService } from "./index-generation.service";
+
+class IndexGenerationOptionsDto implements IndexGenerationOptions {
+  @IsOptional()
+  @IsObject()
+  partAssignments?: Record<string, string>;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  omittedUnitPaths?: string[];
+}
+
+class ApplyIndexGenerationDto extends IndexGenerationOptionsDto {
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[a-f0-9]{64}$/)
+  sourceRevision!: string;
+
+  @IsDateString()
+  expectedUpdatedAt!: string;
+}
+
+@ApiTags("ACP Index Generation")
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles("ACP_MANAGER")
+@Controller("files/:acpId/index-generation")
+export class IndexGenerationController {
+  constructor(private readonly generationService: IndexGenerationService) {}
+
+  @Post("preview")
+  @ApiOperation({ summary: "Preview an ACP index generated from files" })
+  preview(
+    @UuidParam("acpId") acpId: string,
+    @Body() options: IndexGenerationOptionsDto = {},
+  ) {
+    return this.generationService.preview(acpId, options || {});
+  }
+
+  @Post("apply")
+  @ApiOperation({ summary: "Apply an unchanged, snapshot-backed generation preview" })
+  apply(
+    @UuidParam("acpId") acpId: string,
+    @Body() input: ApplyIndexGenerationDto,
+  ) {
+    return this.generationService.apply(acpId, input);
+  }
+}

--- a/backend/src/files/index-generation.service.spec.ts
+++ b/backend/src/files/index-generation.service.spec.ts
@@ -1,0 +1,147 @@
+import * as crypto from "crypto";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { AcpIndexService } from "../acp/acp-index.service";
+import { IndexGenerationService } from "./index-generation.service";
+
+describe("IndexGenerationService", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "acp-index-generator-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("keeps duplicate unit ids separate by part and creates modules/instruments", async () => {
+    const definitions = [
+      ["units/Ma1/shared.xml", unitXml("shared")],
+      ["units/Ma1/ma.xml", unitXml("ma")],
+      ["units/Sp1/shared.xml", unitXml("shared")],
+      ["units/Sp1/sp.xml", unitXml("sp")],
+      ["booklets/ma.xml", bookletXml("ma-booklet", ["shared", "ma", "missing"])],
+      ["booklets/sp.xml", bookletXml("sp-booklet", ["shared", "sp"])],
+    ];
+    const files: any[] = [];
+    for (const [relativePath, content] of definitions) {
+      const filePath = path.join(tempDir, relativePath);
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, content);
+      files.push({
+        id: crypto.randomUUID(),
+        acpId: "acp",
+        filePath,
+        originalName: path.basename(relativePath),
+        relativePath,
+        checksum: crypto.createHash("sha256").update(content).digest("hex"),
+        fileSize: content.length,
+      });
+    }
+    const acp = {
+      id: "acp",
+      packageId: "pkg",
+      name: "Paket",
+      description: "",
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      itemProperties: {},
+      acpIndex: {
+        packageId: "pkg",
+        version: "1.0.0",
+        name: [{ lang: "de", value: "Paket" }],
+        status: "IN_DEVELOPMENT",
+        assessmentParts: [
+          {
+            id: "ma1",
+            units: [
+              {
+                id: "shared",
+                dependencies: [],
+                items: [{ id: "item-1", sourceVariable: "score" }],
+              },
+            ],
+          },
+          {
+            id: "manual",
+            name: [{ lang: "de", value: "Manuell" }],
+            units: [
+              {
+                id: "manual-unit",
+                dependencies: [
+                  { id: "units/Ma1/ma.xml", type: "UNIT_INDEX" },
+                ],
+              },
+            ],
+            bookletModules: [
+              { id: "manual-module", units: [{ id: "manual-unit" }] },
+            ],
+            instruments: [
+              {
+                id: "manual-instrument",
+                name: [{ lang: "de", value: "Manuell" }],
+                testcenterBooklet: [
+                  {
+                    definitionId: "booklets/manual.xml",
+                    modules: [{ moduleId: "manual-module" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const acpRepository = { findOne: jest.fn(async () => acp), save: jest.fn(async (value) => value) } as any;
+    const fileRepository = { find: jest.fn(async () => files) } as any;
+    const cacheRepository = { findOne: jest.fn(async () => null), create: jest.fn((value) => value), save: jest.fn(async (value) => value) } as any;
+    const snapshotsService = { create: jest.fn() } as any;
+    const indexService = new AcpIndexService(acpRepository, fileRepository, cacheRepository, snapshotsService);
+    const service = new IndexGenerationService(acpRepository, fileRepository, indexService, snapshotsService);
+
+    const preview = await service.preview("acp");
+    const parts = (preview.candidateIndex as any).assessmentParts;
+    expect(parts.map((part: any) => [part.id, part.units.length])).toEqual([
+      ["ma1", 2],
+      ["sp1", 2],
+      ["manual", 1],
+    ]);
+    expect(parts[0].bookletModules[0].units.map((entry: any) => entry.id)).toEqual([
+      "shared",
+      "ma",
+      "missing",
+    ]);
+    expect(parts[0].instruments[0].testcenterBooklet[0].definitionId).toBe("booklets/ma.xml");
+    expect(parts[0].units[0].items).toEqual([
+      { id: "item-1", sourceVariable: "score" },
+    ]);
+    expect(parts[2]).toEqual(acp.acpIndex.assessmentParts[1]);
+    expect(preview.validation.valid).toBe(true);
+    expect(preview.validation.publishable).toBe(false);
+    expect(preview.validation.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "UNKNOWN_UNIT_REFERENCE" }),
+      ]),
+    );
+
+    files[0].checksum = "changed-after-preview";
+    await expect(
+      service.apply("acp", {
+        sourceRevision: preview.sourceRevision,
+        expectedUpdatedAt: preview.sourceUpdatedAt,
+      }),
+    ).rejects.toThrow("Files changed since index preview");
+    expect(snapshotsService.create).not.toHaveBeenCalled();
+  });
+});
+
+function unitXml(id: string): string {
+  return `<Unit><Metadata><Id>${id}</Id><Label>${id}</Label></Metadata></Unit>`;
+}
+
+function bookletXml(id: string, unitIds: string[]): string {
+  return `<Booklet><Metadata><Id>${id}</Id><Label>${id}</Label></Metadata><Units>${unitIds
+    .map((unitId) => `<Unit id="${unitId}"/>`)
+    .join("")}</Units></Booklet>`;
+}

--- a/backend/src/files/index-generation.service.ts
+++ b/backend/src/files/index-generation.service.ts
@@ -1,0 +1,372 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import * as crypto from "crypto";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { XMLParser } from "fast-xml-parser";
+import { Repository } from "typeorm";
+import { Acp, AcpFile } from "../database/entities";
+import { AcpIndexService } from "../acp/acp-index.service";
+import { AcpIndexValidationReport } from "../acp/acp-index.types";
+import { SnapshotsService } from "../snapshots/snapshots.service";
+import { normalizePartId } from "./relative-path";
+
+export interface IndexGenerationOptions {
+  partAssignments?: Record<string, string>;
+  omittedUnitPaths?: string[];
+}
+
+export interface IndexGenerationPreview {
+  candidateIndex: Record<string, unknown>;
+  validation: AcpIndexValidationReport;
+  sourceRevision: string;
+  sourceUpdatedAt: string;
+  assignments: Record<string, string>;
+  unassignedUnitPaths: string[];
+  ambiguousBooklets: Array<{ path: string; possibleParts: string[] }>;
+  warnings: string[];
+  diff: Array<{ operation: "add" | "remove" | "replace"; path: string }>;
+  canApply: boolean;
+}
+
+@Injectable()
+export class IndexGenerationService {
+  private readonly xmlParser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+    trimValues: true,
+    maxNestedTags: 100,
+    processEntities: {
+      enabled: true,
+      maxEntitySize: 1000,
+      maxExpansionDepth: 5,
+      maxTotalExpansions: 1000,
+      maxExpandedLength: 100_000,
+      maxEntityCount: 100,
+    },
+  });
+
+  constructor(
+    @InjectRepository(Acp) private readonly acpRepository: Repository<Acp>,
+    @InjectRepository(AcpFile) private readonly fileRepository: Repository<AcpFile>,
+    private readonly acpIndexService: AcpIndexService,
+    private readonly snapshotsService: SnapshotsService,
+  ) {}
+
+  async preview(acpId: string, options: IndexGenerationOptions = {}): Promise<IndexGenerationPreview> {
+    const acp = await this.getAcp(acpId);
+    const files = await this.fileRepository.find({ where: { acpId }, order: { relativePath: "ASC" } });
+    const sourceRevision = await this.sourceRevision(files);
+    const warnings: string[] = [];
+    const assignments: Record<string, string> = {};
+    const omitted = new Set(options.omittedUnitPaths || []);
+    const unitsByPart = new Map<string, any[]>();
+    const unitIdsByPart = new Map<string, Set<string>>();
+    const unassignedUnitPaths: string[] = [];
+    const xmlFiles = files.filter((file) => (file.relativePath || file.originalName).toLowerCase().endsWith(".xml"));
+    const parsedBooklets: Array<{ file: AcpFile; id: string; label: string; unitIds: string[] }> = [];
+
+    for (const file of xmlFiles) {
+      const parsed = await this.parseXmlFile(file, warnings);
+      if (!parsed) continue;
+      if (parsed.Booklet) {
+        const metadata = parsed.Booklet.Metadata || {};
+        const id = String(metadata.Id || path.posix.basename(file.relativePath, ".xml"));
+        const refs = this.asArray(parsed.Booklet.Units?.Unit).map((entry: any) => String(entry?.["@_id"] || entry?.Id || "")).filter(Boolean);
+        parsedBooklets.push({ file, id, label: String(metadata.Label || id), unitIds: refs });
+        continue;
+      }
+      if (!parsed.Unit) continue;
+      const relativePath = file.relativePath || file.originalName;
+      const partId = this.resolveUnitPart(relativePath, options.partAssignments);
+      if (!partId) {
+        if (!omitted.has(relativePath)) unassignedUnitPaths.push(relativePath);
+        continue;
+      }
+      assignments[relativePath] = partId;
+      const unit = this.buildUnit(parsed.Unit, file, files, warnings);
+      if (!unit) continue;
+      const bucket = unitsByPart.get(partId) || [];
+      if (bucket.some((entry) => entry.id === unit.id)) {
+        warnings.push(`Unit ${unit.id} ist in Part ${partId} mehrfach vorhanden; ${relativePath} wurde ignoriert.`);
+        continue;
+      }
+      bucket.push(unit);
+      unitsByPart.set(partId, bucket);
+      const ids = unitIdsByPart.get(partId) || new Set<string>();
+      ids.add(unit.id);
+      unitIdsByPart.set(partId, ids);
+    }
+
+    const bookletsByPart = new Map<string, typeof parsedBooklets>();
+    const ambiguousBooklets: Array<{ path: string; possibleParts: string[] }> = [];
+    for (const booklet of parsedBooklets) {
+      const relativePath = booklet.file.relativePath || booklet.file.originalName;
+      const explicit = options.partAssignments?.[relativePath];
+      const scores = Array.from(unitIdsByPart.entries())
+        .map(([partId, ids]) => ({ partId, score: booklet.unitIds.filter((id) => ids.has(id)).length }))
+        .filter((entry) => entry.score > 0)
+        .sort((a, b) => b.score - a.score || a.partId.localeCompare(b.partId));
+      const bestParts = scores.length ? scores.filter((entry) => entry.score === scores[0].score).map((entry) => entry.partId) : [];
+      const partId = explicit ? normalizePartId(explicit) : bestParts.length === 1 ? bestParts[0] : undefined;
+      if (!partId) {
+        ambiguousBooklets.push({ path: relativePath, possibleParts: bestParts.length ? bestParts : Array.from(unitsByPart.keys()) });
+        continue;
+      }
+      assignments[relativePath] = partId;
+      const bucket = bookletsByPart.get(partId) || [];
+      bucket.push(booklet);
+      bookletsByPart.set(partId, bucket);
+    }
+
+    const assessmentParts: any[] = [];
+    for (const partId of Array.from(unitsByPart.keys()).sort()) {
+      const partBooklets = bookletsByPart.get(partId) || [];
+      if (!partBooklets.length) {
+        for (const filePath of Object.entries(assignments).filter(([, assigned]) => assigned === partId).map(([filePath]) => filePath)) {
+          if (!omitted.has(filePath) && filePath.toLowerCase().endsWith(".xml")) unassignedUnitPaths.push(filePath);
+        }
+        continue;
+      }
+      const units = unitsByPart.get(partId) || [];
+      const bookletModules = partBooklets.map((booklet) => ({
+        id: `${booklet.id}-module`,
+        name: booklet.label,
+        lang: "de",
+        units: booklet.unitIds.map((id, order, all) => ({
+          id,
+          order,
+          ...(all.indexOf(id) === order ? {} : { alias: `${id}-${all.slice(0, order + 1).filter((entry) => entry === id).length}` }),
+        })),
+      }));
+      const instruments = partBooklets.map((booklet) => ({
+        id: booklet.id,
+        name: [{ lang: "de", value: booklet.label }],
+        testcenterBooklet: [{
+          lang: "de",
+          definitionId: booklet.file.relativePath || booklet.file.originalName,
+          modules: [{ moduleId: `${booklet.id}-module`, order: 0 }],
+        }],
+        administrationMode: "TEST_BY_TEST_TAKER",
+      }));
+      const generatedPart = {
+        id: partId,
+        name: [{ lang: "de", value: this.humanize(partId) }],
+        units,
+        bookletModules,
+        instruments,
+      };
+      const existingPart = Array.isArray(acp.acpIndex?.assessmentParts)
+        ? acp.acpIndex.assessmentParts.find((part: any) => part?.id === partId)
+        : undefined;
+      assessmentParts.push(
+        existingPart
+          ? this.mergeGeneratedPart(existingPart, generatedPart)
+          : generatedPart,
+      );
+    }
+
+    const generatedPartIds = new Set(
+      assessmentParts.map((part) => String(part.id)),
+    );
+    for (const existingPart of Array.isArray(acp.acpIndex?.assessmentParts)
+      ? acp.acpIndex.assessmentParts
+      : []) {
+      if (!generatedPartIds.has(String(existingPart?.id))) {
+        assessmentParts.push(existingPart);
+      }
+    }
+
+    const candidateIndex: Record<string, unknown> = {
+      ...acp.acpIndex,
+      packageId: acp.packageId,
+      status: "IN_DEVELOPMENT",
+      ...(assessmentParts.length ? { assessmentParts } : {}),
+    };
+    delete (candidateIndex as any).units;
+    delete (candidateIndex as any).scales;
+    if (!assessmentParts.length) delete candidateIndex.assessmentParts;
+    const validation = await this.acpIndexService.validateCandidate(acpId, candidateIndex);
+    const uniqueUnassigned = Array.from(new Set(unassignedUnitPaths)).filter((entry) => !omitted.has(entry)).sort();
+    return {
+      candidateIndex,
+      validation,
+      sourceRevision,
+      sourceUpdatedAt: acp.updatedAt.toISOString(),
+      assignments,
+      unassignedUnitPaths: uniqueUnassigned,
+      ambiguousBooklets,
+      warnings,
+      diff: this.diff(acp.acpIndex, candidateIndex),
+      canApply: validation.valid && uniqueUnassigned.length === 0 && ambiguousBooklets.length === 0,
+    };
+  }
+
+  async apply(
+    acpId: string,
+    input: IndexGenerationOptions & { sourceRevision: string; expectedUpdatedAt: string },
+  ): Promise<{ index: Record<string, unknown>; validation: AcpIndexValidationReport }> {
+    const files = await this.fileRepository.find({ where: { acpId } });
+    const actualRevision = await this.sourceRevision(files);
+    if (actualRevision !== input.sourceRevision) throw new ConflictException({ message: "Files changed since index preview", expectedSourceRevision: input.sourceRevision, actualSourceRevision: actualRevision });
+    const preview = await this.preview(acpId, input);
+    if (preview.sourceRevision !== input.sourceRevision) {
+      throw new ConflictException({
+        message: "Files changed while index generation was being prepared",
+        expectedSourceRevision: input.sourceRevision,
+        actualSourceRevision: preview.sourceRevision,
+      });
+    }
+    if (!preview.canApply) throw new UnprocessableEntityException({ message: "Index generation preview has unresolved assignments or schema errors", preview });
+    await this.snapshotsService.create(acpId, "Generated ACP index from files");
+    const saved = await this.acpIndexService.saveCandidate(acpId, preview.candidateIndex, input.expectedUpdatedAt);
+    return { index: saved.acpIndex, validation: preview.validation };
+  }
+
+  private buildUnit(parsed: any, file: AcpFile, files: AcpFile[], warnings: string[]): any | null {
+    const metadata = parsed.Metadata || {};
+    const id = String(metadata.Id || "").trim();
+    if (!id) {
+      warnings.push(`Unit-Datei ${file.relativePath || file.originalName} enthält keine ID.`);
+      return null;
+    }
+    const dependencies: any[] = [{ id: file.relativePath || file.originalName, type: "UNIT_INDEX" }];
+    const metadataRef = this.text(metadata.Reference);
+    const definitionRef = this.text(parsed.DefinitionRef);
+    const codingRef = this.text(parsed.CodingSchemeRef);
+    if (definitionRef) this.addDependency(dependencies, file, definitionRef, "UNIT_UI_DEFINITION", files, warnings);
+    if (codingRef) this.addDependency(dependencies, file, codingRef, "UNIT_CODING_SCHEME", files, warnings);
+    if (metadataRef) this.addDependency(dependencies, file, metadataRef, "UNIT_METADATA", files, warnings);
+    const player = parsed.DefinitionRef?.["@_player"];
+    if (typeof player === "string") {
+      const normalizedPlayer = player.replace("@", "-").toLowerCase();
+      const candidates = files.filter((entry) => {
+        const value = (entry.relativePath || entry.originalName).split("/").pop()!.toLowerCase();
+        return value.endsWith(".html") && value.startsWith(normalizedPlayer);
+      });
+      if (candidates.length === 1) dependencies.push({ id: candidates[0].relativePath || candidates[0].originalName, type: "PLAYER" });
+      else warnings.push(`Player ${player} für Unit ${id} ist ${candidates.length ? "mehrdeutig" : "nicht vorhanden"}.`);
+    }
+    return {
+      id,
+      name: String(metadata.Label || id),
+      ...(metadata.Description ? { description: String(metadata.Description) } : {}),
+      lang: "de",
+      dependencies,
+    };
+  }
+
+  private addDependency(target: any[], source: AcpFile, reference: string, type: string, files: AcpFile[], warnings: string[]): void {
+    const sourceDir = path.posix.dirname(source.relativePath || source.originalName);
+    const localPath = path.posix.normalize(path.posix.join(sourceDir === "." ? "" : sourceDir, reference));
+    const exact = files.find((file) => (file.relativePath || file.originalName) === localPath);
+    if (exact) {
+      target.push({ id: exact.relativePath || exact.originalName, type });
+      return;
+    }
+    const basename = path.posix.basename(reference);
+    const matches = files.filter((file) => path.posix.basename(file.relativePath || file.originalName) === basename);
+    if (matches.length === 1) {
+      target.push({ id: matches[0].relativePath || matches[0].originalName, type });
+      warnings.push(`${reference} wurde per eindeutigem Dateinamen zu ${matches[0].relativePath || matches[0].originalName} aufgelöst.`);
+    } else {
+      target.push({ id: localPath, type });
+      warnings.push(`${reference} aus ${source.relativePath || source.originalName} ist ${matches.length ? "mehrdeutig" : "nicht vorhanden"}.`);
+    }
+  }
+
+  private resolveUnitPart(relativePath: string, explicit?: Record<string, string>): string | undefined {
+    if (explicit?.[relativePath]) return normalizePartId(explicit[relativePath]);
+    const segments = relativePath.split("/");
+    const unitsIndex = segments.findIndex((segment) => segment.toLowerCase() === "units");
+    return unitsIndex >= 0 && segments[unitsIndex + 1] ? normalizePartId(segments[unitsIndex + 1]) : undefined;
+  }
+
+  private async parseXmlFile(file: AcpFile, warnings: string[]): Promise<any | null> {
+    try {
+      return this.xmlParser.parse(await fs.readFile(file.filePath, "utf8"));
+    } catch (error) {
+      warnings.push(`XML ${file.relativePath || file.originalName} konnte nicht gelesen werden: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+  }
+
+  private async sourceRevision(files: AcpFile[]): Promise<string> {
+    const entries = await Promise.all(
+      files.map(async (file) => {
+        const checksum = file.checksum || crypto
+          .createHash("sha256")
+          .update(await fs.readFile(file.filePath))
+          .digest("hex");
+        return `${file.relativePath || file.originalName}:${checksum}`;
+      }),
+    );
+    const digest = entries.sort().join("\n");
+    return crypto.createHash("sha256").update(digest).digest("hex");
+  }
+
+  private mergeGeneratedPart(existing: any, generated: any): any {
+    const existingUnits = new Map(
+      this.asArray(existing?.units).map((unit: any) => [unit.id, unit]),
+    );
+    const mergeById = (before: any, after: any) => {
+      const entries = new Map(
+        this.asArray(before).map((entry: any) => [entry.id, entry]),
+      );
+      for (const entry of this.asArray(after)) entries.set(entry.id, entry);
+      return Array.from(entries.values());
+    };
+    return {
+      ...existing,
+      ...generated,
+      units: generated.units.map((unit: any) => ({
+        ...(existingUnits.get(unit.id) || {}),
+        ...unit,
+      })),
+      bookletModules: mergeById(
+        existing.bookletModules,
+        generated.bookletModules,
+      ),
+      instruments: mergeById(existing.instruments, generated.instruments),
+    };
+  }
+
+  private diff(before: unknown, after: unknown): Array<{ operation: "add" | "remove" | "replace"; path: string }> {
+    const changes: Array<{ operation: "add" | "remove" | "replace"; path: string }> = [];
+    const walk = (left: any, right: any, pointer: string) => {
+      if (JSON.stringify(left) === JSON.stringify(right)) return;
+      if (!left || !right || typeof left !== "object" || typeof right !== "object" || Array.isArray(left) || Array.isArray(right)) {
+        changes.push({ operation: left === undefined ? "add" : right === undefined ? "remove" : "replace", path: pointer || "/" });
+        return;
+      }
+      for (const key of new Set([...Object.keys(left), ...Object.keys(right)])) walk(left[key], right[key], `${pointer}/${key.replace(/~/g, "~0").replace(/\//g, "~1")}`);
+    };
+    walk(before, after, "");
+    return changes;
+  }
+
+  private text(value: any): string {
+    if (typeof value === "string") return value.trim();
+    if (value && typeof value === "object" && typeof value["#text"] === "string") return value["#text"].trim();
+    return "";
+  }
+
+  private asArray<T>(value: T | T[] | undefined): T[] {
+    return value === undefined ? [] : Array.isArray(value) ? value : [value];
+  }
+
+  private humanize(value: string): string {
+    return value.split("-").filter(Boolean).map((entry) => entry.charAt(0).toUpperCase() + entry.slice(1)).join(" ");
+  }
+
+  private async getAcp(acpId: string): Promise<Acp> {
+    const acp = await this.acpRepository.findOne({ where: { id: acpId } });
+    if (!acp) throw new NotFoundException(`ACP with ID ${acpId} not found`);
+    return acp;
+  }
+}

--- a/backend/src/files/item-list.parser.ts
+++ b/backend/src/files/item-list.parser.ts
@@ -2,7 +2,9 @@ import { ConflictException, Injectable, Logger } from "@nestjs/common";
 import * as fs from "fs/promises";
 import { createHash } from "crypto";
 import { performance } from "perf_hooks";
+import * as path from "path";
 import type { AcpFile } from "../database/entities";
+import { normalizePartId } from "./relative-path";
 import {
   buildItemRowKey,
   parseItemRowKeyParts,
@@ -146,11 +148,10 @@ export class ItemListParser {
 
         const vomdFileName = parsed.metadataRef;
         if (!vomdFileName) continue;
-        const vomdFile = allFiles.find(
-          (file) =>
-            file.originalName === vomdFileName ||
-            file.originalName === `${vomdFileName}.json`,
-        );
+        const vomdFile = this.findReferencedFile(allFiles, xmlFile, [
+          vomdFileName,
+          `${vomdFileName}.json`,
+        ]);
         if (!vomdFile) {
           if (strictSourceReads) {
             throw new ConflictException(
@@ -179,9 +180,9 @@ export class ItemListParser {
         }
 
         if (parsed.codingSchemeRef) {
-          const vocsFile = allFiles.find(
-            (file) => file.originalName === parsed.codingSchemeRef,
-          );
+          const vocsFile = this.findReferencedFile(allFiles, xmlFile, [
+            parsed.codingSchemeRef,
+          ]);
           if (vocsFile) {
             try {
               const vocsContent = await fs.readFile(vocsFile.filePath, "utf-8");
@@ -298,6 +299,9 @@ export class ItemListParser {
                 ? subIdLabels[explorerRow.subId] || explorerRow.subId
                 : undefined,
               unitId: parsed.unitId,
+              partId: this.partFromUnitPath(
+                xmlFile.relativePath || xmlFile.originalName,
+              ),
               unitLabel: parsed.unitLabel,
               description: item.description || "",
               variableId: sourceVariable,
@@ -330,7 +334,9 @@ export class ItemListParser {
 
     const meanTaskDifficultyByUnit = calculateMeanTaskDifficultyByUnit(items);
     for (const item of items) {
-      item.meanTaskDifficulty = meanTaskDifficultyByUnit.get(item.unitId);
+      item.meanTaskDifficulty = meanTaskDifficultyByUnit.get(
+        item.partId ? `${item.partId}/${item.unitId}` : item.unitId,
+      );
     }
     const columns: MetadataColumn[] = Array.from(columnMap.entries()).map(
       ([id, label]) => ({ id, label }),
@@ -349,6 +355,39 @@ export class ItemListParser {
       parseMs: performance.now() - parseStartedAt,
       cacheable,
     };
+  }
+
+  private findReferencedFile(
+    allFiles: AcpFile[],
+    source: AcpFile,
+    references: string[],
+  ): AcpFile | undefined {
+    const sourceDir = path.posix.dirname(
+      source.relativePath || source.originalName,
+    );
+    for (const reference of references) {
+      const localPath = path.posix.normalize(
+        path.posix.join(sourceDir === "." ? "" : sourceDir, reference),
+      );
+      const local = allFiles.find(
+        (file) => (file.relativePath || file.originalName) === localPath,
+      );
+      if (local) return local;
+    }
+    const basenames = new Set(references.map((entry) => path.posix.basename(entry)));
+    const matches = allFiles.filter((file) =>
+      basenames.has(path.posix.basename(file.relativePath || file.originalName)),
+    );
+    return matches.length === 1 ? matches[0] : undefined;
+  }
+
+  private partFromUnitPath(relativePath: string): string | undefined {
+    const segments = relativePath.split("/");
+    const unitsIndex = segments.findIndex(
+      (segment) => segment.toLowerCase() === "units",
+    );
+    const part = unitsIndex >= 0 ? segments[unitsIndex + 1] : undefined;
+    return part ? normalizePartId(part) : undefined;
   }
 
   private buildCacheKey(acpId: string, context: ItemListParseContext): string {

--- a/backend/src/files/relative-path.spec.ts
+++ b/backend/src/files/relative-path.spec.ts
@@ -1,0 +1,26 @@
+import { BadRequestException } from "@nestjs/common";
+import { normalizePartId, normalizeRelativePath } from "./relative-path";
+
+describe("normalizeRelativePath", () => {
+  it.each([
+    "/absolute/unit.xml",
+    "C:/absolute/unit.xml",
+    "../unit.xml",
+    "units/../../unit.xml",
+    "units/",
+    "units/\0unit.xml",
+    "",
+  ])("rejects unsafe path %p", (value) => {
+    expect(() => normalizeRelativePath(value)).toThrow(BadRequestException);
+  });
+
+  it("normalizes separators and harmless dot segments to POSIX paths", () => {
+    expect(normalizeRelativePath("units\\Ma1\\./unit.xml")).toBe(
+      "units/Ma1/unit.xml",
+    );
+  });
+
+  it("uses one canonical slug for assessment part path segments", () => {
+    expect(normalizePartId("Mäthe Teil 1")).toBe("mathe-teil-1");
+  });
+});

--- a/backend/src/files/relative-path.ts
+++ b/backend/src/files/relative-path.ts
@@ -1,0 +1,27 @@
+import { BadRequestException } from "@nestjs/common";
+import * as path from "path";
+
+export function normalizeRelativePath(input: unknown): string {
+  const raw = String(input ?? "").replace(/\\/g, "/").trim();
+  if (!raw || raw.includes("\0") || raw.startsWith("/") || /^[A-Za-z]:\//.test(raw)) {
+    throw new BadRequestException("relativePath must be a non-empty relative POSIX path");
+  }
+  const normalized = path.posix.normalize(raw).replace(/^\.\//, "");
+  if (!normalized || normalized === "." || normalized === ".." || normalized.endsWith("/") || normalized.startsWith("../") || normalized.split("/").includes("..")) {
+    throw new BadRequestException(`Unsafe relativePath: ${raw}`);
+  }
+  return normalized;
+}
+
+export function getUploadRelativePath(file: Express.Multer.File): string {
+  return normalizeRelativePath((file as Express.Multer.File & { relativePath?: string }).relativePath || file.originalname);
+}
+
+export function normalizePartId(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "part";
+}

--- a/backend/src/files/unit-parser.service.spec.ts
+++ b/backend/src/files/unit-parser.service.spec.ts
@@ -217,9 +217,9 @@ describe("UnitParserService", () => {
     expect(units[0].id).toBe("u1");
     expect(units[0].dependencies).toEqual(
       expect.arrayContaining([
-        { id: "u1.voud", type: "UNIT_DEFINITION" },
-        { id: "u1.vocs", type: "CODING_SCHEME" },
-        { id: "u1.vomd", type: "METADATA" },
+        { id: "u1.voud", type: "UNIT_UI_DEFINITION" },
+        { id: "u1.vocs", type: "UNIT_CODING_SCHEME" },
+        { id: "u1.vomd", type: "UNIT_METADATA" },
         { id: "iqb-player-aspect-2.11.6.html", type: "PLAYER" },
       ]),
     );

--- a/backend/src/files/unit-parser.service.ts
+++ b/backend/src/files/unit-parser.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  Optional,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { EntityManager, Repository } from "typeorm";
@@ -15,6 +16,7 @@ import {
 } from "../acp/acp-index.utils";
 import { FileProcessingProgressReporter } from "./file-processing-progress";
 import { normalizeFeatureConfig } from "../acp/feature-config.utils";
+import { AcpIndexService } from "../acp/acp-index.service";
 import { parseItemRowKeyParts } from "../items/item-row-key.util";
 import { ItemRowNumberingService } from "./item-row-numbering.service";
 import { ItemExplorerStateService } from "../item-explorer/item-explorer-state.service";
@@ -114,6 +116,7 @@ export class UnitParserService {
     private readonly itemListParser: ItemListParser,
     private readonly numberedItemListCache: NumberedItemListCache,
     private readonly unitViewResolver: UnitViewResolver,
+    @Optional() private readonly acpIndexService?: AcpIndexService,
   ) {}
 
   /**
@@ -460,8 +463,16 @@ export class UnitParserService {
     });
 
     if (JSON.stringify(acp.acpIndex || {}) !== JSON.stringify(nextIndex)) {
-      acp.acpIndex = nextIndex;
-      await this.acpRepository.save(acp);
+      if (this.acpIndexService) {
+        await this.acpIndexService.saveCandidate(
+          acpId,
+          nextIndex,
+          acp.updatedAt?.toISOString(),
+        );
+      } else {
+        acp.acpIndex = nextIndex;
+        await this.acpRepository.save(acp);
+      }
     }
 
     report.warnings = Array.from(warningSet);
@@ -503,8 +514,16 @@ export class UnitParserService {
       JSON.stringify(acp.acpIndex || {}) !== JSON.stringify(nextIndex);
 
     if (indexUpdated) {
-      acp.acpIndex = nextIndex;
-      await this.acpRepository.save(acp);
+      if (this.acpIndexService) {
+        await this.acpIndexService.saveCandidate(
+          acpId,
+          nextIndex,
+          acp.updatedAt?.toISOString(),
+        );
+      } else {
+        acp.acpIndex = nextIndex;
+        await this.acpRepository.save(acp);
+      }
     }
 
     return {
@@ -990,12 +1009,14 @@ export class UnitParserService {
     unitId: string,
     onDiagnostics?: (diagnostics: ItemExplorerLoadDiagnostics) => void,
     explorerStateSignature: string | Promise<string> = "",
+    partId?: string,
   ): Promise<any> {
     const totalStartedAt = performance.now();
     const result = await this.unitViewResolver.resolve(
       acpId,
       unitId,
       explorerStateSignature,
+      partId,
     );
     onDiagnostics?.({
       cacheStatus: result.cacheStatus,
@@ -1021,7 +1042,7 @@ export class UnitParserService {
     if (parsedUnit.definitionRef) {
       dependencies.push({
         id: parsedUnit.definitionRef,
-        type: "UNIT_DEFINITION",
+        type: "UNIT_UI_DEFINITION",
       });
       if (!fileNameSet.has(parsedUnit.definitionRef)) {
         warningSet.add(
@@ -1033,7 +1054,7 @@ export class UnitParserService {
     if (parsedUnit.codingSchemeRef) {
       dependencies.push({
         id: parsedUnit.codingSchemeRef,
-        type: "CODING_SCHEME",
+        type: "UNIT_CODING_SCHEME",
       });
       if (!fileNameSet.has(parsedUnit.codingSchemeRef)) {
         warningSet.add(
@@ -1049,7 +1070,7 @@ export class UnitParserService {
           ? `${parsedUnit.metadataRef}.json`
           : parsedUnit.metadataRef;
 
-      dependencies.push({ id: metadataFileName, type: "METADATA" });
+      dependencies.push({ id: metadataFileName, type: "UNIT_METADATA" });
       if (!fileNameSet.has(metadataFileName)) {
         warningSet.add(
           `Unit "${parsedUnit.unitId}" referenziert fehlende Metadaten: ${parsedUnit.metadataRef}`,
@@ -1103,6 +1124,9 @@ export class UnitParserService {
 
     const type = typeof dep?.type === "string" ? dep.type : "FILE";
     const fileBackedTypes = new Set([
+      "UNIT_UI_DEFINITION",
+      "UNIT_CODING_SCHEME",
+      "UNIT_METADATA",
       "UNIT_DEFINITION",
       "CODING_SCHEME",
       "METADATA",

--- a/backend/src/files/unit-parser.types.ts
+++ b/backend/src/files/unit-parser.types.ts
@@ -35,6 +35,7 @@ export interface VomdItemData {
   subId?: string;
   subIdDisplay?: string;
   unitId: string;
+  partId?: string;
   unitLabel: string;
   description: string;
   variableId: string;

--- a/backend/src/files/unit-view.resolver.spec.ts
+++ b/backend/src/files/unit-view.resolver.spec.ts
@@ -69,4 +69,45 @@ describe("UnitViewResolver", () => {
     );
     expect(fs.readFile).toHaveBeenCalledTimes(3);
   });
+
+  it("resolves a unit by the same slug used for its part path", async () => {
+    const files = [
+      {
+        id: "file-mathe",
+        acpId: "acp-1",
+        originalName: "u1.xml",
+        relativePath: "units/Mäthe Teil 1/u1.xml",
+        filePath: "/tmp/mathe-u1.xml",
+      },
+      {
+        id: "file-sprache",
+        acpId: "acp-1",
+        originalName: "u1.xml",
+        relativePath: "units/Sprache/u1.xml",
+        filePath: "/tmp/sprache-u1.xml",
+      },
+    ] as AcpFile[];
+    const fileCatalogCache = {
+      get: jest.fn(async () => ({
+        files,
+        signature: "revision",
+        cacheStatus: "hit" as const,
+        sourceReadMs: 0,
+        fileSignatureMs: 0,
+      })),
+    } as unknown as FileCatalogCache;
+    (fs.readFile as jest.Mock).mockResolvedValue(`<Unit>
+      <Id>u1</Id><Label>Mathe</Label><DefinitionRef player="">u1.voud</DefinitionRef>
+    </Unit>`);
+
+    const result = await new UnitViewResolver(fileCatalogCache).resolve(
+      "acp-1",
+      "u1",
+      "",
+      "mathe-teil-1",
+    );
+
+    expect(result.value).toEqual(expect.objectContaining({ id: "u1" }));
+    expect(fs.readFile).toHaveBeenCalledWith("/tmp/mathe-u1.xml", "utf-8");
+  });
 });

--- a/backend/src/files/unit-view.resolver.ts
+++ b/backend/src/files/unit-view.resolver.ts
@@ -1,10 +1,12 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { ConflictException, Injectable, Logger } from "@nestjs/common";
 import * as fs from "fs/promises";
 import { createHash } from "crypto";
 import { performance } from "perf_hooks";
+import * as path from "path";
 import { AcpFile } from "../database/entities";
 import { AsyncCacheStatus, AsyncLruCache } from "./async-lru-cache";
 import { FileCatalogCache, FileCatalogResult } from "./file-catalog.cache";
+import { normalizePartId } from "./relative-path";
 import { findPlayerFile, parseUnitXml } from "./unit-file-parsing";
 
 interface UnitViewCacheValue {
@@ -34,17 +36,18 @@ export class UnitViewResolver {
     acpId: string,
     unitId: string,
     explorerStateSignature: string | Promise<string> = "",
+    partId?: string,
   ): Promise<UnitViewResolution> {
     const [catalog, resolvedExplorerStateSignature] = await Promise.all([
       this.fileCatalogCache.get(acpId),
       Promise.resolve(explorerStateSignature),
     ]);
-    const cacheKey = `${acpId}:${unitId}:${this.hashCanonicalValue({
+    const cacheKey = `${acpId}:${partId || "legacy"}:${unitId}:${this.hashCanonicalValue({
       files: catalog.signature,
       explorerState: resolvedExplorerStateSignature,
     })}`;
     const { value, status } = await this.cache.getOrLoad(cacheKey, () =>
-      this.build(acpId, unitId, catalog.files),
+      this.build(acpId, unitId, catalog.files, partId),
     );
     return {
       value: structuredClone(value.value),
@@ -62,11 +65,28 @@ export class UnitViewResolver {
     acpId: string,
     unitId: string,
     allFiles: AcpFile[],
+    partId?: string,
   ): Promise<UnitViewCacheValue> {
     const parseStartedAt = performance.now();
-    const xmlFile = allFiles.find(
+    const matchingXmlFiles = allFiles.filter(
       (file) => file.originalName.replace(/\.xml$/i, "") === unitId,
     );
+    if (!partId && matchingXmlFiles.length > 1) {
+      throw new ConflictException({
+        message: `Unit ${unitId} exists in multiple assessment parts`,
+        possibleParts: matchingXmlFiles
+          .map((file) => this.partFromUnitPath(file.relativePath || file.originalName))
+          .filter(Boolean),
+      });
+    }
+    const xmlFile = partId
+      ? matchingXmlFiles.find((file) =>
+          this.partFromUnitPath(file.relativePath || file.originalName) ===
+            normalizePartId(partId),
+        )
+      : matchingXmlFiles.length === 1
+        ? matchingXmlFiles[0]
+        : undefined;
     if (!xmlFile) {
       return { value: null, parseMs: performance.now() - parseStartedAt };
     }
@@ -81,6 +101,7 @@ export class UnitViewResolver {
     }
 
     const dependencies: any[] = [];
+    const unitDirectory = path.posix.dirname(xmlFile.relativePath || xmlFile.originalName);
     const playerFileName = findPlayerFile(
       parsed.playerRef,
       allFiles.map((file) => file.originalName),
@@ -105,6 +126,7 @@ export class UnitViewResolver {
       parsed.definitionRef,
       "UNIT_DEFINITION",
       acpId,
+      unitDirectory,
     );
     this.addDependency(
       dependencies,
@@ -112,14 +134,12 @@ export class UnitViewResolver {
       parsed.codingSchemeRef,
       "CODING_SCHEME",
       acpId,
+      unitDirectory,
     );
 
     if (parsed.metadataRef) {
-      const metadataFile = allFiles.find(
-        (file) =>
-          file.originalName === parsed.metadataRef ||
-          file.originalName === `${parsed.metadataRef}.json`,
-      );
+      const metadataFile = this.findDependencyFile(allFiles, parsed.metadataRef, unitDirectory) ||
+        this.findDependencyFile(allFiles, `${parsed.metadataRef}.json`, unitDirectory);
       if (metadataFile) {
         dependencies.push({
           type: "METADATA",
@@ -147,11 +167,10 @@ export class UnitViewResolver {
     originalName: string | undefined,
     type: string,
     acpId: string,
+    unitDirectory: string,
   ): void {
     if (!originalName) return;
-    const file = allFiles.find(
-      (candidate) => candidate.originalName === originalName,
-    );
+    const file = this.findDependencyFile(allFiles, originalName, unitDirectory);
     if (!file) return;
     dependencies.push({
       type,
@@ -159,6 +178,32 @@ export class UnitViewResolver {
       downloadUrl: `/api/acp/${acpId}/files/${file.id}/download`,
       fileId: file.id,
     });
+  }
+
+  private findDependencyFile(
+    allFiles: AcpFile[],
+    originalName: string,
+    unitDirectory: string,
+  ): AcpFile | undefined {
+    const relativePath = path.posix.normalize(
+      path.posix.join(unitDirectory === "." ? "" : unitDirectory, originalName),
+    );
+    const local = allFiles.find(
+      (candidate) => (candidate.relativePath || candidate.originalName) === relativePath,
+    );
+    if (local) return local;
+    const matches = allFiles.filter((candidate) => candidate.originalName === originalName);
+    return matches.length === 1 ? matches[0] : undefined;
+  }
+
+  private partFromUnitPath(relativePath: string): string {
+    const segments = relativePath.split("/");
+    const unitsIndex = segments.findIndex(
+      (segment) => segment.toLowerCase() === "units",
+    );
+    return unitsIndex >= 0 && segments[unitsIndex + 1]
+      ? normalizePartId(segments[unitsIndex + 1])
+      : "";
   }
 
   private hashCanonicalValue(value: unknown): string {

--- a/backend/src/items/mean-task-difficulty.ts
+++ b/backend/src/items/mean-task-difficulty.ts
@@ -1,5 +1,6 @@
 export interface ItemDifficultyValue {
   unitId: string;
+  partId?: string;
   empiricalDifficulty?: number;
 }
 
@@ -16,10 +17,11 @@ export function calculateMeanTaskDifficultyByUnit(
       continue;
     }
 
-    const total = totals.get(item.unitId) || { sum: 0, count: 0 };
+    const unitKey = item.partId ? `${item.partId}/${item.unitId}` : item.unitId;
+    const total = totals.get(unitKey) || { sum: 0, count: 0 };
     total.sum += item.empiricalDifficulty;
     total.count += 1;
-    totals.set(item.unitId, total);
+    totals.set(unitKey, total);
   }
 
   return new Map(

--- a/backend/src/snapshots/snapshots.service.spec.ts
+++ b/backend/src/snapshots/snapshots.service.spec.ts
@@ -244,7 +244,10 @@ describe("SnapshotsService", () => {
       await service.restore("snap-1");
       expect(acpRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          acpIndex: snapshotWithFiles.acpIndexSnapshot,
+          acpIndex: {
+            ...snapshotWithFiles.acpIndexSnapshot,
+            status: "IN_DEVELOPMENT",
+          },
         }),
       );
       expect(fileRepo.delete).toHaveBeenCalledWith({

--- a/backend/src/snapshots/snapshots.service.ts
+++ b/backend/src/snapshots/snapshots.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { LessThan, Repository } from "typeorm";
 import { ConfigService } from "@nestjs/config";
+import { ModuleRef } from "@nestjs/core";
 import * as fs from "fs/promises";
 import * as path from "path";
 import {
@@ -26,6 +27,7 @@ export class SnapshotsService {
     @InjectRepository(AcpFile)
     private readonly fileRepository: Repository<AcpFile>,
     private readonly configService: ConfigService,
+    private readonly moduleRef: ModuleRef,
   ) {
     this.storagePath = this.configService.get<string>(
       "FILE_STORAGE_PATH",
@@ -129,6 +131,7 @@ export class SnapshotsService {
           snapshotId: savedSnapshot.id,
           filePath: snapshotFilePath,
           originalName: file.originalName,
+          relativePath: file.relativePath || file.originalName,
           checksum: file.checksum,
           fileSize: file.fileSize,
         }),
@@ -150,10 +153,6 @@ export class SnapshotsService {
       throw new NotFoundException("ACP not found");
     }
 
-    // Restore ACP-Index
-    acp.acpIndex = { ...snapshot.acpIndexSnapshot };
-    await this.acpRepository.save(acp);
-
     // Resolve all file data first; only mutate DB state after all files
     // are restorable to avoid partial restores.
     const restoredFiles: AcpFile[] = [];
@@ -169,18 +168,47 @@ export class SnapshotsService {
             acpId: acp.id,
             filePath,
             originalName: sf.originalName,
+            relativePath: sf.relativePath || sf.originalName,
             fileSize: fileSize ?? sf.fileSize,
             checksum: sf.checksum,
           }),
         );
       }
     }
+    const restoredIndex = {
+      ...snapshot.acpIndexSnapshot,
+      status: "IN_DEVELOPMENT",
+    };
+    let restoredAcp: Acp;
+    let indexService: any;
+    try {
+      const { AcpIndexService } = require("../acp/acp-index.service");
+      indexService = this.moduleRef.get(AcpIndexService, {
+        strict: false,
+      });
+      restoredAcp = await indexService.saveCandidate(
+        acp.id,
+        restoredIndex,
+        acp.updatedAt.toISOString(),
+      );
+    } catch (error) {
+      if (error?.constructor?.name !== "UnknownElementException") throw error;
+      acp.acpIndex = restoredIndex;
+      restoredAcp = await this.acpRepository.save(acp);
+    }
+
     await this.fileRepository.delete({ acpId: snapshot.acpId });
     if (restoredFiles.length) {
       await this.fileRepository.save(restoredFiles);
     }
+    if (indexService) {
+      await indexService.validateStoredIndex(acp.id, {
+        external: false,
+        persist: true,
+      });
+    }
 
-    return acp;
+    return restoredAcp;
   }
 
   private async resolveRestoredFilePath(

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -276,6 +276,21 @@ export class ViewsController {
     return this.viewsService.getUnitViewData(acpId, unitId);
   }
 
+  @Get("acp/:acpId/parts/:partId/units/:unitId")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({ summary: "Get unit view data scoped to an assessment part" })
+  async getUnitInPart(
+    @UuidParam("acpId") acpId: string,
+    @Param("partId") partId: string,
+    @Param("unitId") unitId: string,
+    @Request() req: any,
+  ) {
+    if (!(await this.canUseFeature(acpId, req, "enableUnitView", true))) {
+      throw new ForbiddenException("Unit view is not enabled for this ACP");
+    }
+    return this.viewsService.getUnitViewData(acpId, unitId, partId);
+  }
+
   @Get("acp/:acpId/items")
   @UseGuards(AcpAccessGuard)
   @ApiOperation({ summary: "Get item list for an ACP" })

--- a/backend/src/views/views.service.ts
+++ b/backend/src/views/views.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   UnauthorizedException,
 } from "@nestjs/common";
@@ -15,6 +16,8 @@ import {
 } from "../database/entities";
 import {
   findUnitInIndex,
+  findUnitInPart,
+  findUnitsInIndex,
   getAssessmentParts,
   getIndexUnits,
   toRuntimeAcpIndex,
@@ -187,16 +190,25 @@ export class ViewsService {
     const index = toRuntimeAcpIndex(acp.acpIndex);
 
     // Extract units from ACP-Index
-    const units = getIndexUnits(index).map((u: any) => ({
-      id: u.id,
-      name: u.name,
-      description: u.description,
-    }));
+    const assessmentParts = getAssessmentParts(index);
+    const units = assessmentParts.length
+      ? assessmentParts.flatMap((part: any) =>
+          (Array.isArray(part?.units) ? part.units : []).map((unit: any) => ({
+            id: unit.id,
+            partId: part.id,
+            name: unit.name,
+            description: unit.description,
+          })),
+        )
+      : getIndexUnits(index).map((unit: any) => ({
+          id: unit.id,
+          name: unit.name,
+          description: unit.description,
+        }));
 
     // Sequence model: one sequence equals one booklet module.
     const sequenceMap = new Map<string, any>();
-    const parts = getAssessmentParts(index);
-    for (const part of parts) {
+    for (const part of assessmentParts) {
       const modulesById = new Map<string, any>();
       for (const module of part.bookletModules || []) {
         if (!module?.id || typeof module.id !== "string") continue;
@@ -250,18 +262,27 @@ export class ViewsService {
   async getAcpIndex(acpId: string): Promise<Record<string, unknown> | null> {
     const acp = await this.acpRepository.findOne({ where: { id: acpId } });
     if (!acp) return null;
-    return toRuntimeAcpIndex(acp.acpIndex);
+    return acp.acpIndex;
   }
 
   /**
    * Get unit view data including player reference.
    */
-  async getUnitViewData(acpId: string, unitId: string): Promise<any> {
+  async getUnitViewData(acpId: string, unitId: string, partId?: string): Promise<any> {
     const acp = await this.acpRepository.findOne({ where: { id: acpId } });
     if (!acp) return null;
 
     const index = toRuntimeAcpIndex(acp.acpIndex);
-    const unit = findUnitInIndex(index, unitId);
+    const matches = findUnitsInIndex(index, unitId);
+    if (!partId && matches.length > 1) {
+      throw new ConflictException({
+        message: `Unit ${unitId} exists in multiple assessment parts`,
+        possibleParts: matches.map((entry) => entry.partId),
+      });
+    }
+    const unit = partId
+      ? findUnitInPart(index, partId, unitId)
+      : matches[0]?.unit || findUnitInIndex(index, unitId);
     if (!unit) return null;
 
     // Resolve file references
@@ -269,7 +290,7 @@ export class ViewsService {
     const fileRefs: any[] = [];
     for (const dep of dependencies) {
       const file = await this.fileRepository.findOne({
-        where: { acpId, originalName: dep.id },
+        where: { acpId, relativePath: dep.id },
       });
       if (file) {
         fileRefs.push({
@@ -283,6 +304,7 @@ export class ViewsService {
 
     return {
       id: unit.id,
+      ...(partId || matches[0]?.partId ? { partId: partId || matches[0]?.partId } : {}),
       name: unit.name,
       description: unit.description,
       lang: unit.lang,

--- a/frontend/src/app/acp-manager/dashboard/dashboard.component.ts
+++ b/frontend/src/app/acp-manager/dashboard/dashboard.component.ts
@@ -46,6 +46,10 @@ import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog.c
       }
 
       <div class="grid">
+        <a [routerLink]="['/manage', acp.id, 'index']" class="card link-card">
+          <h3>ACP-Index 0.5</h3>
+          <p>Validieren, migrieren, erzeugen und veröffentlichen</p>
+        </a>
         <a [routerLink]="['/manage', acp.id, 'files']" class="card link-card">
           <h3>📁 Dateien</h3>
           <p>Dateien hochladen, herunterladen und validieren</p>
@@ -244,11 +248,12 @@ export class DashboardComponent implements OnInit {
     reader.onload = () => {
       try {
         const data = JSON.parse(reader.result as string);
-        this.api.importAcpIndex(this.acp!.id, data).subscribe({
+        this.api.importAcpIndex(this.acp!.id, data, this.acp!.updatedAt).subscribe({
           next: (idx) => {
             this.acp!.acpIndex = idx;
             this.error = '';
             this.indexSuccessMessage = 'ACP-Index wurde importiert.';
+            this.refreshAcp();
           },
         });
       } catch {
@@ -275,18 +280,24 @@ export class DashboardComponent implements OnInit {
     this.deleteIndexError = '';
     this.indexSuccessMessage = '';
 
-    this.api.deleteAcpIndex(this.acp.id).subscribe({
+    this.api.deleteAcpIndex(this.acp.id, this.acp.updatedAt).subscribe({
       next: (idx) => {
         this.acp!.acpIndex = idx;
         this.indexSuccessMessage = 'ACP-Index wurde auf den Standardzustand zurückgesetzt.';
         this.deletingIndex = false;
         this.showDeleteIndexDialog = false;
+        this.refreshAcp();
       },
       error: (err) => {
         this.deletingIndex = false;
         this.deleteIndexError = err?.error?.message || 'Fehler beim Löschen des ACP-Index.';
       },
     });
+  }
+
+  private refreshAcp() {
+    if (!this.acp) return;
+    this.api.getAcp(this.acp.id).subscribe((acp) => (this.acp = acp));
   }
 
   assignRole() {

--- a/frontend/src/app/acp-manager/files/files.component.ts
+++ b/frontend/src/app/acp-manager/files/files.component.ts
@@ -1,7 +1,7 @@
 import { HttpErrorResponse, HttpEventType } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { filter, firstValueFrom, map, tap } from 'rxjs';
 import {
   AcpFile,
@@ -34,6 +34,7 @@ type DeleteDialogMode = 'single' | 'selected' | 'all';
   standalone: true,
   imports: [
     FormsModule,
+    RouterLink,
     AcpManagerContextComponent,
     ConfirmDialogComponent,
     FilePreviewPanelComponent,
@@ -160,9 +161,14 @@ type DeleteDialogMode = 'single' | 'selected' | 'all';
 
     @if (lastSyncReport) {
       <div class="alert alert-info">
-        Index-Sync: {{ lastSyncReport.unitsAdded }} Units hinzugefügt,
-        {{ lastSyncReport.unitsUpdated }} Units aktualisiert, {{ lastSyncReport.itemsAdded }} Items
-        hinzugefügt, {{ lastSyncReport.itemsUpdated }} Items aktualisiert.
+        @if (lastSyncReport.requiresConfirmation) {
+          Der ACP-Index wurde nicht verändert. Prüfen und übernehmen Sie die Generatorvorschau im
+          <a [routerLink]="['/manage', acpId, 'index']">ACP-Index-Editor</a>.
+        } @else {
+          Index-Sync: {{ lastSyncReport.unitsAdded }} Units hinzugefügt,
+          {{ lastSyncReport.unitsUpdated }} Units aktualisiert, {{ lastSyncReport.itemsAdded }} Items
+          hinzugefügt, {{ lastSyncReport.itemsUpdated }} Items aktualisiert.
+        }
         @if (lastSyncReport.warnings?.length) {
           <div style="margin-top:6px">
             Warnungen:

--- a/frontend/src/app/acp-manager/index/acp-index-manager.component.ts
+++ b/frontend/src/app/acp-manager/index/acp-index-manager.component.ts
@@ -1,0 +1,256 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
+import {
+  Acp,
+  AcpIndexGenerationPreview,
+  AcpIndexMigrationPreview,
+  AcpIndexValidationReport,
+} from '../../core/models/api.models';
+import { ApiService } from '../../core/services/api.service';
+import { AcpManagerContextComponent } from '../shared/acp-manager-context.component';
+
+@Component({
+  selector: 'app-acp-index-manager',
+  standalone: true,
+  imports: [CommonModule, FormsModule, AcpManagerContextComponent],
+  template: `
+    <app-acp-manager-context />
+    <div class="page-header"><h1>ACP-Index 0.5</h1></div>
+    @if (acp?.acpIndexValidationStatus) {
+      <div class="alert" [class.alert-warning]="acp?.acpIndexValidationStatus === 'LEGACY_NONCONFORMANT'">
+        Bestandsstatus: {{ acp?.acpIndexValidationStatus }} · Schema: {{ acp?.acpIndexSchemaId || 'unbekannt' }}
+      </div>
+    }
+    @if (message) { <div class="alert alert-success">{{ message }}</div> }
+    @if (error) { <div class="alert alert-error">{{ error }}</div> }
+
+    <div class="card">
+      <h3>Header und Metadaten</h3>
+      <div class="form-grid">
+        <label>Paket-ID<input [(ngModel)]="header.packageId" disabled /></label>
+        <label>Version<input [(ngModel)]="header.version" placeholder="1.0.0" /></label>
+        <label>Name (de)<input [(ngModel)]="header.nameDe" /></label>
+        <label>Beschreibung (de)<input [(ngModel)]="header.descriptionDe" /></label>
+        <label>Maintainer<input [(ngModel)]="header.maintainerName" /></label>
+        <label>Maintainer-URL<input [(ngModel)]="header.maintainerUrl" /></label>
+      </div>
+      <label>Metadaten (metadata-values@3.0 JSON)
+        <textarea [(ngModel)]="metadataJson" rows="8"></textarea>
+      </label>
+      <div class="toolbar">
+        <button class="btn btn-primary" (click)="saveHeader()" [disabled]="busy">Speichern</button>
+        <button class="btn btn-outline" (click)="validate()" [disabled]="busy">Validieren</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>Konformität und Veröffentlichung</h3>
+      @if (validation) {
+        <p>
+          Schema: <strong>{{ validation.valid ? 'gültig' : 'ungültig' }}</strong> ·
+          Veröffentlichung: <strong>{{ validation.publishable ? 'möglich' : 'blockiert' }}</strong>
+        </p>
+        @for (issue of validation.issues; track issue.code + issue.path) {
+          <div class="issue" [class.error]="issue.severity === 'error'">
+            <code>{{ issue.path }}</code> — {{ issue.message }}
+          </div>
+        }
+        @for (check of validation.externalChecks; track check.url) {
+          <div class="issue"><code>{{ check.url }}</code> — {{ check.status }}</div>
+        }
+      }
+      <div class="toolbar">
+        @if (isReleased) {
+          <button class="btn btn-outline" (click)="reopen()" [disabled]="busy">Wieder öffnen</button>
+        } @else {
+          <button class="btn btn-primary" (click)="publish('RELEASED_PUBLIC')" [disabled]="busy">Öffentlich veröffentlichen</button>
+          <button class="btn btn-outline" (click)="publish('RELEASED_CONFIDENTIAL')" [disabled]="busy">Vertraulich veröffentlichen</button>
+        }
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>Legacy-Migration</h3>
+      <div class="toolbar">
+        <button class="btn btn-outline" (click)="previewMigration()" [disabled]="busy">Migration prüfen</button>
+        <button class="btn btn-primary" (click)="applyMigration()" [disabled]="busy || !migration?.validation?.valid">Migration übernehmen</button>
+      </div>
+      @if (migration) {
+        @for (change of migration.changes; track change.path + change.message) {
+          <div class="issue"><code>{{ change.path }}</code> — {{ change.message }}</div>
+        }
+        @for (issue of migration.unresolved; track issue.code + issue.path) {
+          <div class="issue error"><code>{{ issue.path }}</code> — {{ issue.message }}</div>
+        }
+      }
+    </div>
+
+    <div class="card">
+      <h3>Index aus Dateien erzeugen</h3>
+      <div class="toolbar">
+        <button class="btn btn-outline" (click)="previewGeneration()" [disabled]="busy">Vorschau erzeugen</button>
+        <button class="btn btn-primary" (click)="applyGeneration()" [disabled]="busy || !generation?.canApply">Übernehmen</button>
+      </div>
+      @if (generation) {
+        @for (path of generation.unassignedUnitPaths; track path) {
+          <div class="assignment">
+            <code>{{ path }}</code>
+            <input [(ngModel)]="partAssignments[path]" placeholder="Part-ID" />
+            <label><input type="checkbox" [(ngModel)]="omitted[path]" /> bewusst auslassen</label>
+          </div>
+        }
+        @for (booklet of generation.ambiguousBooklets; track booklet.path) {
+          <div class="assignment">
+            <code>{{ booklet.path }}</code>
+            <select [(ngModel)]="partAssignments[booklet.path]">
+              <option value="">Part wählen</option>
+              @for (part of booklet.possibleParts; track part) { <option [value]="part">{{ part }}</option> }
+            </select>
+          </div>
+        }
+        @for (warning of generation.warnings; track warning) { <div class="issue">{{ warning }}</div> }
+        <details><summary>JSON-Diff ({{ generation.diff.length }} Änderungen)</summary><pre>{{ generation.diff | json }}</pre></details>
+      }
+    </div>
+
+    <div class="card">
+      <h3>Komplexe Struktur als validiertes JSON</h3>
+      <p>Assessment-Parts, Skalen und Coding-Parameter können hier vollständig importiert werden.</p>
+      <textarea [(ngModel)]="fullIndexJson" rows="18"></textarea>
+      <button class="btn btn-primary" (click)="saveFullJson()" [disabled]="busy">JSON validieren und speichern</button>
+    </div>
+  `,
+  styles: [`
+    .form-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:12px; }
+    label { display:flex; flex-direction:column; gap:5px; font-size:.85rem; }
+    input, textarea, select { width:100%; padding:8px; border:1px solid var(--color-border); border-radius:var(--radius); }
+    textarea { font-family:monospace; }
+    .card { margin-bottom:18px; }
+    .toolbar { display:flex; flex-wrap:wrap; gap:8px; margin-top:12px; }
+    .issue { padding:7px 9px; margin:5px 0; background:var(--color-bg); border-left:3px solid #d7a11e; }
+    .issue.error { border-left-color:#b42318; }
+    .assignment { display:grid; grid-template-columns:minmax(250px,1fr) minmax(140px,240px) auto; gap:10px; align-items:center; margin:8px 0; }
+    .assignment label { flex-direction:row; align-items:center; }
+    .assignment label input { width:auto; }
+    pre { max-height:320px; overflow:auto; background:var(--color-bg); padding:12px; }
+  `],
+})
+export class AcpIndexManagerComponent implements OnInit {
+  acpId = '';
+  acp: Acp | null = null;
+  busy = false;
+  error = '';
+  message = '';
+  validation: AcpIndexValidationReport | null = null;
+  migration: AcpIndexMigrationPreview | null = null;
+  generation: AcpIndexGenerationPreview | null = null;
+  partAssignments: Record<string, string> = {};
+  omitted: Record<string, boolean> = {};
+  metadataJson = '';
+  fullIndexJson = '';
+  header = {
+    packageId: '', version: '', nameDe: '', descriptionDe: '', maintainerName: '', maintainerUrl: '',
+  };
+
+  get isReleased() {
+    return ['RELEASED_PUBLIC', 'RELEASED_CONFIDENTIAL'].includes(String(this.acp?.acpIndex?.['status'] || ''));
+  }
+
+  constructor(private route: ActivatedRoute, private api: ApiService) {}
+
+  ngOnInit() {
+    this.acpId = this.route.snapshot.paramMap.get('acpId') || '';
+    this.load();
+  }
+
+  load() {
+    this.api.getAcp(this.acpId).subscribe({
+      next: (acp) => {
+        this.acp = acp;
+        const index = acp.acpIndex || {};
+        this.header = {
+          packageId: acp.packageId,
+          version: index['version'] || '',
+          nameDe: this.localized(index['name'], 'de'),
+          descriptionDe: this.localized(index['description'], 'de'),
+          maintainerName: index['maintainerName'] || '',
+          maintainerUrl: index['maintainerUrl'] || '',
+        };
+        this.metadataJson = index['metadata'] ? JSON.stringify(index['metadata'], null, 2) : '';
+        this.fullIndexJson = JSON.stringify(index, null, 2);
+      },
+      error: (error) => this.fail(error),
+    });
+  }
+
+  saveHeader() {
+    if (!this.acp) return;
+    try {
+      const index = { ...this.acp.acpIndex };
+      index['version'] = this.header.version;
+      index['name'] = this.upsertLocalized(index['name'], 'de', this.header.nameDe);
+      if (this.header.descriptionDe) index['description'] = this.upsertLocalized(index['description'], 'de', this.header.descriptionDe);
+      else delete index['description'];
+      this.assignOptional(index, 'maintainerName', this.header.maintainerName);
+      this.assignOptional(index, 'maintainerUrl', this.header.maintainerUrl);
+      if (this.metadataJson.trim()) index['metadata'] = JSON.parse(this.metadataJson);
+      else delete index['metadata'];
+      this.saveIndex(index, 'Header gespeichert.');
+    } catch (error) { this.fail(error); }
+  }
+
+  saveFullJson() {
+    try { this.saveIndex(JSON.parse(this.fullIndexJson), 'Index gespeichert.'); }
+    catch (error) { this.fail(error); }
+  }
+
+  validate() { this.run(this.api.validateAcpIndex(this.acpId), (report) => { this.validation = report; }); }
+  previewMigration() { this.run(this.api.previewAcpIndexMigration(this.acpId), (preview) => { this.migration = preview; }); }
+  applyMigration() {
+    if (!this.migration) return;
+    this.run(this.api.migrateAcpIndex(this.acpId, this.migration.sourceUpdatedAt), () => { this.message = 'Migration übernommen und Snapshot erstellt.'; this.load(); });
+  }
+  previewGeneration() {
+    const omittedUnitPaths = Object.entries(this.omitted).filter(([, value]) => value).map(([path]) => path);
+    this.run(this.api.previewIndexGeneration(this.acpId, { partAssignments: this.partAssignments, omittedUnitPaths }), (preview) => { this.generation = preview; this.partAssignments = { ...preview.assignments, ...this.partAssignments }; });
+  }
+  applyGeneration() {
+    if (!this.generation) return;
+    const omittedUnitPaths = Object.entries(this.omitted).filter(([, value]) => value).map(([path]) => path);
+    this.run(this.api.applyIndexGeneration(this.acpId, {
+      sourceRevision: this.generation.sourceRevision,
+      expectedUpdatedAt: this.generation.sourceUpdatedAt,
+      partAssignments: this.partAssignments,
+      omittedUnitPaths,
+    }), () => { this.message = 'Index erzeugt und Snapshot erstellt.'; this.load(); });
+  }
+  publish(status: 'RELEASED_PUBLIC' | 'RELEASED_CONFIDENTIAL') {
+    if (!this.acp) return;
+    this.run(this.api.publishAcpIndex(this.acpId, status, this.acp.updatedAt), () => { this.message = 'ACP veröffentlicht.'; this.load(); });
+  }
+  reopen() {
+    if (!this.acp) return;
+    this.run(this.api.reopenAcpIndex(this.acpId, this.acp.updatedAt), () => { this.message = 'ACP wieder geöffnet; Snapshot wurde erstellt.'; this.load(); });
+  }
+
+  private saveIndex(index: Record<string, any>, message: string) {
+    if (!this.acp) return;
+    this.run(this.api.updateAcpIndex(this.acpId, index, this.acp.updatedAt), () => { this.message = message; this.load(); });
+  }
+  private run<T>(request: Observable<T>, success: (value: T) => void) {
+    this.busy = true; this.error = ''; this.message = '';
+    request.subscribe({ next: (value: T) => { this.busy = false; success(value); }, error: (error: unknown) => { this.busy = false; this.fail(error); } });
+  }
+  private fail(error: any) { this.error = error?.error?.message || error?.message || String(error); }
+  private localized(value: any, lang: string) { return Array.isArray(value) ? value.find((entry) => entry?.lang === lang)?.value || '' : ''; }
+  private upsertLocalized(value: any, lang: string, text: string) {
+    const entries = Array.isArray(value) ? [...value] : [];
+    const index = entries.findIndex((entry) => entry?.lang === lang);
+    if (index >= 0) entries[index] = { lang, value: text }; else entries.push({ lang, value: text });
+    return entries;
+  }
+  private assignOptional(target: Record<string, any>, key: string, value: string) { if (value.trim()) target[key] = value.trim(); else delete target[key]; }
+}

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -80,6 +80,13 @@ export const routes: Routes = [
           import('./acp-manager/files/files.component').then((m) => m.FilesComponent),
       },
       {
+        path: 'index',
+        loadComponent: () =>
+          import('./acp-manager/index/acp-index-manager.component').then(
+            (m) => m.AcpIndexManagerComponent,
+          ),
+      },
+      {
         path: 'snapshots',
         loadComponent: () =>
           import('./acp-manager/snapshots/snapshots.component').then((m) => m.SnapshotsComponent),
@@ -118,6 +125,11 @@ export const routes: Routes = [
       },
       {
         path: 'unit/:unitId',
+        loadComponent: () =>
+          import('./views/unit-view/unit-view.component').then((m) => m.UnitViewComponent),
+      },
+      {
+        path: 'part/:partId/unit/:unitId',
         loadComponent: () =>
           import('./views/unit-view/unit-view.component').then((m) => m.UnitViewComponent),
       },

--- a/frontend/src/app/core/models/api.models.ts
+++ b/frontend/src/app/core/models/api.models.ts
@@ -79,6 +79,13 @@ export interface Acp {
   name: string;
   description?: string;
   acpIndex: Record<string, any>;
+  acpIndexSchemaId?: string;
+  acpIndexValidationStatus?:
+    | 'UNKNOWN'
+    | 'CONFORMANT'
+    | 'CONFORMANT_WITH_ISSUES'
+    | 'LEGACY_NONCONFORMANT';
+  acpIndexValidationReport?: AcpIndexValidationReport;
   settings: Record<string, any>;
   createdAt: string;
   updatedAt: string;
@@ -89,6 +96,7 @@ export interface AcpFile {
   acpId: string;
   filePath: string;
   originalName: string;
+  relativePath: string;
   fileType?: string;
   fileSize: number;
   checksum?: string;
@@ -102,6 +110,48 @@ export interface IndexSyncReport {
   itemsAdded: number;
   itemsUpdated: number;
   warnings: string[];
+}
+
+export interface AcpIndexValidationIssue {
+  code: string;
+  scope: 'schema' | 'semantic' | 'vocabulary' | 'file';
+  severity: 'error' | 'warning' | 'info';
+  path: string;
+  message: string;
+}
+
+export interface AcpIndexValidationReport {
+  schemaId: 'acp-index@0.5';
+  valid: boolean;
+  publishable: boolean;
+  checkedAt: string;
+  issues: AcpIndexValidationIssue[];
+  externalChecks: Array<{
+    url: string;
+    status: 'valid' | 'invalid' | 'cached' | 'unavailable';
+    checkedAt?: string;
+  }>;
+}
+
+export interface AcpIndexGenerationPreview {
+  candidateIndex: Record<string, any>;
+  validation: AcpIndexValidationReport;
+  sourceRevision: string;
+  sourceUpdatedAt: string;
+  assignments: Record<string, string>;
+  unassignedUnitPaths: string[];
+  ambiguousBooklets: Array<{ path: string; possibleParts: string[] }>;
+  warnings: string[];
+  diff: Array<{ operation: 'add' | 'remove' | 'replace'; path: string }>;
+  canApply: boolean;
+}
+
+export interface AcpIndexMigrationPreview {
+  candidateIndex: Record<string, any>;
+  changes: Array<{ path: string; message: string }>;
+  unresolved: AcpIndexValidationIssue[];
+  validation: AcpIndexValidationReport;
+  sourceUpdatedAt: string;
 }
 
 export type FileUploadConflictStrategy = 'reject' | 'overwrite' | 'keep-both';
@@ -430,6 +480,7 @@ export interface PublicAcp {
 
 export interface UnitViewData {
   id: string;
+  partId?: string;
   name: string;
   description?: string;
   lang?: string;

--- a/frontend/src/app/core/services/api.service.spec.ts
+++ b/frontend/src/app/core/services/api.service.spec.ts
@@ -612,32 +612,40 @@ describe('ApiService', () => {
       const indexData = { entries: [{ id: '1' }] };
       httpClientMock.put.mockReturnValue(of(indexData));
 
-      service.updateAcpIndex('acp1', indexData).subscribe((result) => {
+      service.updateAcpIndex('acp1', indexData, '2026-01-01T00:00:00.000Z').subscribe((result) => {
         expect(result).toEqual(indexData);
       });
 
-      expect(httpClientMock.put).toHaveBeenCalledWith('/api/acp/acp1/index', indexData);
+      expect(httpClientMock.put).toHaveBeenCalledWith(
+        '/api/acp/acp1/index?expectedUpdatedAt=2026-01-01T00%3A00%3A00.000Z',
+        indexData,
+      );
     });
 
     it('should import ACP index', () => {
       const importData = { entries: [{ id: '1' }] };
       httpClientMock.post.mockReturnValue(of(importData));
 
-      service.importAcpIndex('acp1', importData).subscribe((result) => {
+      service.importAcpIndex('acp1', importData, '2026-01-01T00:00:00.000Z').subscribe((result) => {
         expect(result).toEqual(importData);
       });
 
-      expect(httpClientMock.post).toHaveBeenCalledWith('/api/acp/acp1/index/import', importData);
+      expect(httpClientMock.post).toHaveBeenCalledWith(
+        '/api/acp/acp1/index/import?expectedUpdatedAt=2026-01-01T00%3A00%3A00.000Z',
+        importData,
+      );
     });
 
     it('should delete ACP index', () => {
       httpClientMock.delete.mockReturnValue(of({}));
 
-      service.deleteAcpIndex('acp1').subscribe((result) => {
+      service.deleteAcpIndex('acp1', '2026-01-01T00:00:00.000Z').subscribe((result) => {
         expect(result).toEqual({});
       });
 
-      expect(httpClientMock.delete).toHaveBeenCalledWith('/api/acp/acp1/index');
+      expect(httpClientMock.delete).toHaveBeenCalledWith(
+        '/api/acp/acp1/index?expectedUpdatedAt=2026-01-01T00%3A00%3A00.000Z',
+      );
     });
 
     it('should build index export URL with auth token', () => {

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -32,6 +32,9 @@ import {
   ItemCollectionsPayload,
   ItemExplorerPerspective,
   SimpleItemListEntry,
+  AcpIndexValidationReport,
+  AcpIndexMigrationPreview,
+  AcpIndexGenerationPreview,
 } from '../models/api.models';
 
 @Injectable({ providedIn: 'root' })
@@ -160,14 +163,67 @@ export class ApiService {
   getAcpIndex(id: string): Observable<any> {
     return this.http.get(`${this.API}/acp/${id}/index`);
   }
-  updateAcpIndex(id: string, data: any): Observable<any> {
-    return this.http.put(`${this.API}/acp/${id}/index`, data);
+  updateAcpIndex(id: string, data: any, expectedUpdatedAt: string): Observable<any> {
+    return this.http.put(
+      `${this.API}/acp/${id}/index?expectedUpdatedAt=${encodeURIComponent(expectedUpdatedAt)}`,
+      data,
+    );
   }
-  importAcpIndex(id: string, data: any): Observable<any> {
-    return this.http.post(`${this.API}/acp/${id}/index/import`, data);
+  importAcpIndex(id: string, data: any, expectedUpdatedAt: string): Observable<any> {
+    return this.http.post(
+      `${this.API}/acp/${id}/index/import?expectedUpdatedAt=${encodeURIComponent(expectedUpdatedAt)}`,
+      data,
+    );
   }
-  deleteAcpIndex(id: string): Observable<any> {
-    return this.http.delete(`${this.API}/acp/${id}/index`);
+  deleteAcpIndex(id: string, expectedUpdatedAt: string): Observable<any> {
+    return this.http.delete(
+      `${this.API}/acp/${id}/index?expectedUpdatedAt=${encodeURIComponent(expectedUpdatedAt)}`,
+    );
+  }
+  validateAcpIndex(id: string): Observable<AcpIndexValidationReport> {
+    return this.http.post<AcpIndexValidationReport>(`${this.API}/acp/${id}/index/validate`, {});
+  }
+  previewAcpIndexMigration(id: string): Observable<AcpIndexMigrationPreview> {
+    return this.http.post<AcpIndexMigrationPreview>(`${this.API}/acp/${id}/index/migration-preview`, {});
+  }
+  migrateAcpIndex(id: string, expectedUpdatedAt: string): Observable<Acp> {
+    return this.http.post<Acp>(`${this.API}/acp/${id}/index/migrate`, { expectedUpdatedAt });
+  }
+  publishAcpIndex(
+    id: string,
+    status: 'RELEASED_PUBLIC' | 'RELEASED_CONFIDENTIAL',
+    expectedUpdatedAt: string,
+  ): Observable<Acp> {
+    return this.http.post<Acp>(`${this.API}/acp/${id}/index/publish`, {
+      status,
+      expectedUpdatedAt,
+    });
+  }
+  reopenAcpIndex(id: string, expectedUpdatedAt: string): Observable<Acp> {
+    return this.http.post<Acp>(`${this.API}/acp/${id}/index/reopen`, { expectedUpdatedAt });
+  }
+  previewIndexGeneration(
+    acpId: string,
+    options: { partAssignments?: Record<string, string>; omittedUnitPaths?: string[] } = {},
+  ): Observable<AcpIndexGenerationPreview> {
+    return this.http.post<AcpIndexGenerationPreview>(
+      `${this.API}/files/${acpId}/index-generation/preview`,
+      options,
+    );
+  }
+  applyIndexGeneration(
+    acpId: string,
+    input: {
+      sourceRevision: string;
+      expectedUpdatedAt: string;
+      partAssignments?: Record<string, string>;
+      omittedUnitPaths?: string[];
+    },
+  ): Observable<{ index: Record<string, any>; validation: AcpIndexValidationReport }> {
+    return this.http.post<{ index: Record<string, any>; validation: AcpIndexValidationReport }>(
+      `${this.API}/files/${acpId}/index-generation/apply`,
+      input,
+    );
   }
 
   // ACP Roles
@@ -343,10 +399,13 @@ export class ApiService {
   getFileUnitView(
     acpId: string,
     unitId: string,
-    options?: { perspective?: ItemExplorerPerspective },
+    options?: { perspective?: ItemExplorerPerspective; partId?: string },
   ): Observable<any> {
     const query = this.buildPerspectiveQuery(options?.perspective);
-    return this.http.get(`${this.API}/acp/${acpId}/files/unit-view/${unitId}${query}`);
+    const route = options?.partId
+      ? `${this.API}/acp/${acpId}/files/unit-view/${encodeURIComponent(options.partId)}/${encodeURIComponent(unitId)}`
+      : `${this.API}/acp/${acpId}/files/unit-view/${encodeURIComponent(unitId)}`;
+    return this.http.get(`${route}${query}`);
   }
 
   getIndexExportUrl(id: string): string {
@@ -423,8 +482,11 @@ export class ApiService {
   getViewUnits(acpId: string): Observable<any[]> {
     return this.http.get<any[]>(`${this.API}/view/acp/${acpId}/units`);
   }
-  getViewUnit(acpId: string, unitId: string): Observable<UnitViewData> {
-    return this.http.get<UnitViewData>(`${this.API}/view/acp/${acpId}/units/${unitId}`);
+  getViewUnit(acpId: string, unitId: string, partId?: string): Observable<UnitViewData> {
+    const url = partId
+      ? `${this.API}/view/acp/${acpId}/parts/${encodeURIComponent(partId)}/units/${encodeURIComponent(unitId)}`
+      : `${this.API}/view/acp/${acpId}/units/${encodeURIComponent(unitId)}`;
+    return this.http.get<UnitViewData>(url);
   }
   getViewItems(acpId: string): Observable<SimpleItemListEntry[]> {
     return this.http.get<SimpleItemListEntry[]>(`${this.API}/view/acp/${acpId}/items`);

--- a/frontend/src/app/views/item-explorer/item-explorer-preview-coordinator.service.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer-preview-coordinator.service.ts
@@ -129,7 +129,14 @@ export class ItemExplorerPreviewCoordinator implements OnDestroy {
     );
     const assets$ = request.reuseUnit
       ? of(null)
-      : this.loader.load(request.acpId, request.perspective, request.item.unitId);
+      : request.item.partId
+        ? this.loader.load(
+            request.acpId,
+            request.perspective,
+            request.item.unitId,
+            request.item.partId,
+          )
+        : this.loader.load(request.acpId, request.perspective, request.item.unitId);
 
     return forkJoin({ assets: assets$, responseState: responseState$ }).pipe(
       map(({ assets, responseState }) => {

--- a/frontend/src/app/views/item-explorer/item-explorer-preview-loader.service.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer-preview-loader.service.ts
@@ -48,8 +48,9 @@ export class ItemExplorerPreviewLoader {
     acpId: string,
     perspective: ItemExplorerPerspective,
     unitId: string,
+    partId?: string,
   ): Observable<ItemExplorerPreviewAssets> {
-    const key = `${acpId}:${perspective}:${unitId}`;
+    const key = `${acpId}:${perspective}:${partId || "legacy"}:${unitId}`;
     const cached = this.unitCache.get(key);
     if (cached) {
       const cacheStatus = cached.settled ? 'hit' : 'coalesced';
@@ -74,6 +75,7 @@ export class ItemExplorerPreviewLoader {
     entry.observable = this.api
       .getFileUnitView(acpId, unitId, {
         perspective,
+        ...(partId ? { partId } : {}),
       })
       .pipe(
         tap({

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.ts
@@ -3840,7 +3840,10 @@ export class ItemExplorerFacade implements OnDestroy {
   }
 
   downloadUnit() {
-    const url = `/api/acp/${this.acpId}/files?unitId=${this.selectedItem?.unitId}&format=zip`;
+    const partQuery = this.selectedItem?.partId
+      ? `&partId=${encodeURIComponent(this.selectedItem.partId)}`
+      : '';
+    const url = `/api/acp/${this.acpId}/files?unitId=${encodeURIComponent(this.selectedItem?.unitId || '')}${partQuery}&format=zip`;
     window.open(this.api.appendAuthToken(url), '_blank');
   }
 

--- a/frontend/src/app/views/item-explorer/item-explorer.models.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.models.ts
@@ -24,6 +24,7 @@ export interface ExplorerItem {
   subId?: string;
   subIdDisplay?: string;
   unitId: string;
+  partId?: string;
   unitLabel: string;
   description: string;
   variableId: string;

--- a/frontend/src/app/views/unit-view/unit-list.component.ts
+++ b/frontend/src/app/views/unit-view/unit-list.component.ts
@@ -25,14 +25,14 @@ import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/bre
           </tr>
         </thead>
         <tbody>
-          @for (unit of units; track unit.id) {
+          @for (unit of units; track (unit.partId || 'legacy') + '/' + unit.id) {
             <tr>
               <td>
                 <code>{{ unit.id }}</code>
               </td>
               <td>{{ unit.name }}</td>
               <td>
-                <a [routerLink]="['/view', acpId, 'unit', unit.id]" class="btn btn-sm btn-primary"
+                <a [routerLink]="unit.partId ? ['/view', acpId, 'part', unit.partId, 'unit', unit.id] : ['/view', acpId, 'unit', unit.id]" class="btn btn-sm btn-primary"
                   >Ansehen</a
                 >
               </td>

--- a/frontend/src/app/views/unit-view/unit-view.component.ts
+++ b/frontend/src/app/views/unit-view/unit-view.component.ts
@@ -458,6 +458,7 @@ export class UnitViewComponent implements OnInit, OnDestroy {
 
   acpId = '';
   unitId = '';
+  partId = '';
   unit: UnitViewData | null = null;
   playerSrcDoc: any = null;
   breadcrumbs: BreadcrumbItem[] = [];
@@ -503,6 +504,7 @@ export class UnitViewComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.acpId = this.route.snapshot.paramMap.get('acpId') || '';
     this.unitId = this.route.snapshot.paramMap.get('unitId') || '';
+    this.partId = this.route.snapshot.paramMap.get('partId') || '';
 
     this.onWindowResize();
     window.addEventListener('resize', this.resizeHandler);
@@ -529,7 +531,7 @@ export class UnitViewComponent implements OnInit, OnDestroy {
       else if (this.featureConfig.showRichText) this.activeTab = 'richtext';
     });
 
-    this.api.getViewUnit(this.acpId, this.unitId).subscribe((u) => {
+    this.api.getViewUnit(this.acpId, this.unitId, this.partId || undefined).subscribe((u) => {
       this.unit = u;
       this.breadcrumbs = [
         { label: 'Assessment Content Pool', route: ['/'] },


### PR DESCRIPTION
## Summary

- Vendor and validate the ACP index 0.5, unit 0.5, scale 0.2, and metadata-values 3.0 schemas through a central service.
- Preserve normalized relative file paths and generate assessment parts, units, modules, and instruments through a preview/snapshot/apply workflow.
- Add migration, publication, reopening, external vocabulary caching, and semantic/file validation workflows.
- Introduce part-scoped unit routes and an ACP index management UI.
- Address review findings around transactional overwrites, preservation of existing parts, complete document references, cache failures, SSRF-safe resource loading, revision guards, and consistent part slugs.

## Why

The existing implementation could transport an ACP index, but it did not reliably enforce the published schema or provide complete semantic, vocabulary, file, migration, and generation workflows.

## Behavioral impact

- New and changed indexes must be structurally schema-conformant.
- Semantic, file, and vocabulary errors remain permitted during development but block publication.
- Released ACPs must be reopened before modification.
- Index update, import, and delete operations require an `expectedUpdatedAt` revision guard.
- Unit resolution is scoped by assessment part; ambiguous legacy routes return a conflict.

## Rollout

Run the backend database migrations before deploying:

```sh
cd backend
npm run migration:run
```

## Validation

- Backend lint and build
- Backend: 60 suites, 687 tests
- Backend production dependency audit: 0 vulnerabilities
- Frontend lint and build
- Frontend: 39 files, 464 tests
- `git diff --check`
- StarS fixture: 462 files; 72 Ma1 units; 80 Sp1 units; 9 shared IDs; one instrument and module per booklet; missing `rahmenhandlung_end` correctly blocks publication

## Review note

The automated review helper could not run because TruffleHog is unavailable in the environment. A manual closeout review was completed and its actionable findings were implemented.
