### PR TITLE
Harden legacy release adoption and rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to ContentPool are documented in this file. Releases use
 - Add manifest-driven, auditable staging and production updates.
 - Refresh pinned runtime bases and remove package-manager tooling from the
   backend runtime image.
+- Preserve adopted legacy Compose project names so managed updates continue to
+  use the existing database and upload volumes.
+- Add checksum-validated local legacy baselines, exact-digest rollback, and
+  structural validation for database backups.
 
 ### Breaking changes
 
@@ -46,6 +50,8 @@ All notable changes to ContentPool are documented in this file. Releases use
 - Add `DEPLOYMENT_ENV`, `COMPOSE_PROJECT_NAME`, `RELEASE_VERSION`, `APPLICATION_VERSION`, `RELEASE_COMMIT`,
   `RELEASE_BUILT_AT`, `CONTENT_POOL_BACKEND_IMAGE`, and
   `CONTENT_POOL_FRONTEND_IMAGE`.
+- Deployment tools accept `--compose-override` and `--base-url` for isolated
+  rehearsals on a shared Docker host.
 
 ### Database migrations
 
@@ -57,6 +63,8 @@ All notable changes to ContentPool are documented in this file. Releases use
 
 - Adopt the currently running image digests before the first managed update.
 - Application rollback never automatically reverts database migrations.
+- Adopted legacy releases can be restored from their checksum-validated local
+  baseline without relying on a historical GitHub release manifest.
 
 [Unreleased]: https://github.com/iqb-berlin/content-pool-next/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/iqb-berlin/content-pool-next/compare/v0.1.3...v0.2.0

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -15,6 +15,7 @@ decision in the release issue or operational change record.
 
 - [ ] Staging uses its own Compose project, data, volumes, domains, and secrets
 - [ ] Managed update created complete database/config/upload backups
+- [ ] Backup checksums, both tar archives, and both PostgreSQL dump catalogs validate
 - [ ] `/api/version` and `/version.json` match the candidate manifest
 - [ ] OIDC login and logout work
 - [ ] ACP create/update, file upload, public/read view, and Item Explorer smoke tests pass
@@ -34,6 +35,7 @@ decision in the release issue or operational change record.
 
 - [ ] `.env` has `DEPLOYMENT_ENV=production`, `DB_SYNCHRONIZE=false`, and `DB_RUN_MIGRATIONS=true`
 - [ ] Full backup and deployment JSON record were created
+- [ ] Adopted Compose project and exact previous image digests are recorded locally
 - [ ] Compose configuration validates and images are pulled by digest
 - [ ] Health, readiness, Keycloak discovery, and version identity pass
 - [ ] Keycloak user count did not decrease

--- a/docs/operations/releases.md
+++ b/docs/operations/releases.md
@@ -62,8 +62,10 @@ make adopt-current RELEASE=v0.1.3 ENVIRONMENT=production MODE=traefik
 ```
 
 The command refuses to continue unless Docker can resolve both running images
-to registry digests. Repeat separately for staging. After adoption, `.env`
-contains full digest references and the normal release commands can be used.
+to registry digests. Repeat separately for staging. Adoption preserves the
+running Compose project, writes full digest references to `.env`, and creates a
+checksum-validated `baselines/vX.Y.Z` runtime snapshot for exact application
+rollback.
 
 ## Rollback and restore
 
@@ -78,6 +80,11 @@ An intentional application rollback is explicit:
 make production-rollback RELEASE=vX.Y.Z MODE=traefik
 ```
 
+For an adopted legacy release without a historical GitHub manifest, the same
+command uses the local baseline. It restores the legacy runtime and adds a
+temporary Compose image override so the exact captured digests are used rather
+than mutable legacy tags. Database migrations are not reverted.
+
 If an incompatible database or filesystem change requires a full recovery,
 perform the documented downtime restore from one complete update backup:
 
@@ -87,8 +94,20 @@ make restore-backup BACKUP=backups/update_YYYYMMDD_HHMMSS MODE=traefik
 
 The restore stops public/application services, restores both PostgreSQL custom
 dumps with `pg_restore`, restores uploads and runtime configuration, restarts
-the stack, and verifies health and release identity. Test this path in an
-isolated environment before the first production release.
+the stack, and verifies health and release identity. Before stopping services,
+it verifies `SHA256SUMS` and both tar archives; before replacing database
+objects, it validates both custom dumps with `pg_restore --list`. Test this path
+in an isolated environment before the first production release.
+
+An isolated stack on a shared Docker host may supply an additional Compose file
+and a non-default health URL:
+
+```bash
+./scripts/update.sh --mode server --environment staging \
+  --release vX.Y.Z-rc.N \
+  --compose-override /absolute/path/rehearsal.yml \
+  --base-url http://127.0.0.1:18080
+```
 
 When `--manifest` points to a local file or private URL, the runtime archive and
 `SHA256SUMS` must be available beside it. The installer verifies the manifest

--- a/scripts/deploy-common.sh
+++ b/scripts/deploy-common.sh
@@ -306,9 +306,13 @@ cp_apply_manifest_env() {
   local manifest="$2"
   local environment="$3"
   local tool="$4"
+  local compose_project
 
   cp_env_set "$env_file" DEPLOYMENT_ENV "$environment"
-  cp_env_set "$env_file" COMPOSE_PROJECT_NAME "content-pool-${environment}"
+  compose_project="$(cp_env_get "$env_file" COMPOSE_PROJECT_NAME)"
+  if [[ -z "$compose_project" ]]; then
+    cp_env_set "$env_file" COMPOSE_PROJECT_NAME "content-pool-${environment}"
+  fi
   cp_env_set "$env_file" RELEASE_VERSION "$(cp_manifest_get "$tool" "$manifest" release)"
   cp_env_set "$env_file" APPLICATION_VERSION "$(cp_manifest_get "$tool" "$manifest" applicationVersion)"
   cp_env_set "$env_file" RELEASE_COMMIT "$(cp_manifest_get "$tool" "$manifest" sourceCommit)"
@@ -338,11 +342,99 @@ PY
 
 cp_set_compose_args() {
   local mode="$1"
+  local override="${2:-}"
   cp_validate_mode "$mode"
   CONTENT_POOL_COMPOSE_ARGS=(-f docker-compose.server.yml)
   if [[ "$mode" == "traefik" ]]; then
     CONTENT_POOL_COMPOSE_ARGS+=(-f docker-compose.traefik.yml)
   fi
+  if [[ -n "$override" ]]; then
+    [[ -f "$override" ]] || cp_die "Compose override not found: $override"
+    CONTENT_POOL_COMPOSE_ARGS+=(-f "$override")
+  fi
+}
+
+cp_compose_container_id() {
+  local service="$1"
+  local container
+  container="$(docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" ps -q "$service" 2>/dev/null | head -n 1)"
+  [[ -n "$container" ]] || return 1
+  printf '%s' "$container"
+}
+
+cp_compose_service_running() {
+  local service="$1"
+  local container state
+  container="$(cp_compose_container_id "$service")" || return 1
+  state="$(docker inspect "$container" --format '{{.State.Running}}' 2>/dev/null)" || return 1
+  [[ "$state" == "true" ]]
+}
+
+cp_sha256_file() {
+  python3 - "$1" <<'PY'
+import hashlib
+import sys
+
+digest = hashlib.sha256()
+with open(sys.argv[1], "rb") as source:
+    for block in iter(lambda: source.read(1024 * 1024), b""):
+        digest.update(block)
+print(digest.hexdigest())
+PY
+}
+
+cp_write_sha256s() {
+  local directory="$1"
+  shift
+  python3 - "$directory" "$@" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+directory = Path(sys.argv[1])
+lines = []
+for name in sys.argv[2:]:
+    path = directory / name
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    lines.append(f"{digest.hexdigest()}  {name}")
+(directory / "SHA256SUMS").write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+}
+
+cp_verify_sha256s() {
+  local directory="$1"
+  python3 - "$directory" <<'PY'
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+directory = Path(sys.argv[1])
+sums = directory / "SHA256SUMS"
+if not sums.is_file():
+    raise SystemExit("SHA256SUMS is missing")
+seen = set()
+for line in sums.read_text(encoding="utf-8").splitlines():
+    match = re.fullmatch(r"([0-9a-f]{64})  ([^/]+)", line)
+    if not match:
+        raise SystemExit(f"invalid checksum line: {line}")
+    expected, name = match.groups()
+    if name == "SHA256SUMS" or name in seen:
+        raise SystemExit(f"invalid checksum target: {name}")
+    seen.add(name)
+    path = directory / name
+    if not path.is_file():
+        raise SystemExit(f"checksummed file is missing: {name}")
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    if digest.hexdigest() != expected:
+        raise SystemExit(f"checksum mismatch: {name}")
+PY
 }
 
 cp_detect_mode() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,8 @@ Options:
   --environment staging|production  Isolated target environment (required)
   --release VERSION                 Release or candidate, for example v0.2.0-rc.1 (required)
   --manifest FILE|URL               Alternate release-manifest.json source
+  --compose-override FILE           Additional Compose file for an isolated deployment
+  --base-url URL                    Public/frontend URL used by server-mode health checks
   --repo OWNER/REPO                 GitHub repository (default: iqb-berlin/content-pool-next)
   --download                        Deprecated compatibility flag; release assets are always used
   --start                           Start the stack after validation
@@ -320,6 +322,8 @@ REPO="$BOOTSTRAP_REPO"
 ENVIRONMENT="${DEPLOYMENT_ENV:-}"
 RELEASE=""
 MANIFEST_SOURCE=""
+COMPOSE_OVERRIDE=""
+BASE_URL=""
 START=0
 NON_INTERACTIVE=0
 FORCE_ENV=0
@@ -365,6 +369,22 @@ while [[ $# -gt 0 ]]; do
       ;;
     --manifest=*)
       MANIFEST_SOURCE="${1#*=}"
+      shift
+      ;;
+    --compose-override)
+      COMPOSE_OVERRIDE="$2"
+      shift 2
+      ;;
+    --compose-override=*)
+      COMPOSE_OVERRIDE="${1#*=}"
+      shift
+      ;;
+    --base-url)
+      BASE_URL="$2"
+      shift 2
+      ;;
+    --base-url=*)
+      BASE_URL="${1#*=}"
       shift
       ;;
     --repo)
@@ -416,6 +436,10 @@ cp_validate_mode "$MODE"
 cp_validate_environment "$ENVIRONMENT"
 [[ -n "$RELEASE" ]] || cp_die "--release vX.Y.Z[-rc.N] is required"
 cp_validate_release_for_environment "$RELEASE" "$ENVIRONMENT"
+if [[ -n "$COMPOSE_OVERRIDE" ]]; then
+  [[ -f "$COMPOSE_OVERRIDE" ]] || cp_die "Compose override not found: $COMPOSE_OVERRIDE"
+  COMPOSE_OVERRIDE="$(cd "$(dirname "$COMPOSE_OVERRIDE")" && pwd -P)/$(basename "$COMPOSE_OVERRIDE")"
+fi
 
 if [[ -z "$TARGET_DIR" ]]; then
   if [[ "$NON_INTERACTIVE" -eq 1 ]] || ! is_tty; then
@@ -470,7 +494,7 @@ fi
 cp_info "Validating Docker Compose configuration"
 (
   cd "$TARGET_DIR"
-  cp_set_compose_args "$MODE"
+  cp_set_compose_args "$MODE" "$COMPOSE_OVERRIDE"
   docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" config >/dev/null
 )
 
@@ -480,14 +504,18 @@ if [[ "$START" -eq 1 ]]; then
   cp_info "Starting and verifying ContentPool (${MODE})"
   (
     cd "$TARGET_DIR"
-    ./scripts/update.sh \
-      --mode "$MODE" \
-      --environment "$ENVIRONMENT" \
-      --release "$RELEASE" \
-      --manifest "${RELEASE_WORK_DIR}/release-manifest.json" \
-      --no-backup \
-      --no-keycloak-user-check \
+    update_args=(
+      --mode "$MODE"
+      --environment "$ENVIRONMENT"
+      --release "$RELEASE"
+      --manifest "${RELEASE_WORK_DIR}/release-manifest.json"
+      --no-backup
+      --no-keycloak-user-check
       --yes
+    )
+    [[ -z "$COMPOSE_OVERRIDE" ]] || update_args+=(--compose-override "$COMPOSE_OVERRIDE")
+    [[ -z "$BASE_URL" ]] || update_args+=(--base-url "$BASE_URL")
+    ./scripts/update.sh "${update_args[@]}"
   )
 fi
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -14,6 +14,8 @@ PostgreSQL databases, and uploads from one update backup.
 Options:
   --from-backup DIR        Backup directory created by update.sh (required)
   --mode server|traefik    Deployment mode (default: backup manifest/.env)
+  --compose-override FILE  Additional Compose file for an isolated restore
+  --base-url URL           Public/frontend URL used by server-mode health checks
   --yes                    Required for non-interactive execution
   --no-health-check        Skip the final stack health check
   -h, --help               Show this help
@@ -22,6 +24,8 @@ USAGE
 
 BACKUP_DIR=""
 MODE=""
+COMPOSE_OVERRIDE=""
+BASE_URL=""
 YES=0
 HEALTH_CHECK=1
 
@@ -31,6 +35,10 @@ while [[ $# -gt 0 ]]; do
     --from-backup=*) BACKUP_DIR="${1#*=}"; shift ;;
     --mode) MODE="$2"; shift 2 ;;
     --mode=*) MODE="${1#*=}"; shift ;;
+    --compose-override) COMPOSE_OVERRIDE="$2"; shift 2 ;;
+    --compose-override=*) COMPOSE_OVERRIDE="${1#*=}"; shift ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --base-url=*) BASE_URL="${1#*=}"; shift ;;
     --yes) YES=1; shift ;;
     --no-health-check) HEALTH_CHECK=0; shift ;;
     -h|--help) usage; exit 0 ;;
@@ -43,7 +51,7 @@ done
 BACKUP_DIR="$(cd "$BACKUP_DIR" && pwd -P)"
 [[ "$BACKUP_DIR" != "/" ]] || cp_die "Refusing to use filesystem root as a backup"
 
-for file in manifest.txt config.tgz content-pool-db.dump keycloak-db.dump uploads.tgz; do
+for file in manifest.txt config.tgz content-pool-db.dump keycloak-db.dump uploads.tgz SHA256SUMS; do
   [[ -f "${BACKUP_DIR}/${file}" ]] || cp_die "Incomplete backup: ${file} is missing"
 done
 
@@ -54,7 +62,8 @@ fi
 cp_validate_mode "$MODE"
 cp_require_docker_compose
 cp_require_cmd python3
-cp_set_compose_args "$MODE"
+cp_set_compose_args "$MODE" "$COMPOSE_OVERRIDE"
+cp_verify_sha256s "$BACKUP_DIR" || cp_die "Backup checksum validation failed"
 cp_validate_tar_archive "${BACKUP_DIR}/config.tgz" || cp_die "Unsafe configuration archive"
 cp_validate_tar_archive "${BACKUP_DIR}/uploads.tgz" || cp_die "Unsafe uploads archive"
 
@@ -70,12 +79,15 @@ docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" stop nginx content-pool-api key
 
 cp_info "Restoring runtime configuration"
 tar -xzf "${BACKUP_DIR}/config.tgz" -C .
-cp_set_compose_args "$MODE"
+cp_set_compose_args "$MODE" "$COMPOSE_OVERRIDE"
 docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" up -d content-pool-db keycloak-db
 
 restore_database() {
-  local container="$1" user="$2" database="$3" dump="$4"
-  cp_info "Restoring ${database} in ${container} with pg_restore"
+  local service="$1" user="$2" database="$3" dump="$4" container
+  container="$(cp_compose_container_id "$service")" || cp_die "Restore service is unavailable: $service"
+  docker exec -i "$container" pg_restore --list < "$dump" >/dev/null || \
+    cp_die "Invalid PostgreSQL custom dump: $dump"
+  cp_info "Restoring ${database} in ${service} with pg_restore"
   docker exec -i "$container" pg_restore \
     --clean --if-exists --no-owner --no-privileges --exit-on-error \
     -U "$user" -d "$database" < "$dump"
@@ -96,7 +108,8 @@ if [[ -n "$expected_keycloak_users" ]]; then
   keycloak_realm="$(awk -F= '$1 == "keycloak_realm" { print $2 }' \
     "${BACKUP_DIR}/manifest.txt" | tail -n 1)"
   keycloak_realm="${keycloak_realm:-iqb}"
-  restored_keycloak_users="$(docker exec -i keycloak-db psql -qAt -v ON_ERROR_STOP=1 \
+  keycloak_db_container="$(cp_compose_container_id keycloak-db)" || cp_die "keycloak-db is unavailable"
+  restored_keycloak_users="$(docker exec -i "$keycloak_db_container" psql -qAt -v ON_ERROR_STOP=1 \
     -v realm_name="$keycloak_realm" \
     -U "$(cp_env_get_default .env KEYCLOAK_DB_USER keycloak)" \
     -d "$(cp_env_get_default .env KEYCLOAK_DB_NAME keycloak)" <<'SQL'
@@ -124,7 +137,10 @@ docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" up -d
 if [[ "$HEALTH_CHECK" -eq 1 ]]; then
   release="$(cp_env_get .env APPLICATION_VERSION)"
   commit="$(cp_env_get .env RELEASE_COMMIT)"
-  if [[ "$MODE" == "traefik" ]]; then
+  if [[ -n "$BASE_URL" ]]; then
+    ./scripts/check-health.sh "$MODE" "$(cp_env_get .env OIDC_PUBLIC_ISSUER_URL)" \
+      "${BASE_URL%/}/api" "${BASE_URL%/}" "$release" "$commit"
+  elif [[ "$MODE" == "traefik" ]]; then
     host="$(cp_env_get .env CONTENT_POOL_HOST)"
     ./scripts/check-health.sh "$MODE" "$(cp_env_get .env OIDC_PUBLIC_ISSUER_URL)" \
       "https://${host}/api" "https://${host}" "$release" "$commit"

--- a/scripts/test-backup-restore.sh
+++ b/scripts/test-backup-restore.sh
@@ -52,6 +52,8 @@ docker exec "$app_container" pg_dump --format=custom -U postgres content_pool \
   >"${temp_dir}/content-pool-db.dump"
 docker exec "$keycloak_container" pg_dump --format=custom -U postgres keycloak \
   >"${temp_dir}/keycloak-db.dump"
+docker exec -i "$app_container" pg_restore --list <"${temp_dir}/content-pool-db.dump" >/dev/null
+docker exec -i "$keycloak_container" pg_restore --list <"${temp_dir}/keycloak-db.dump" >/dev/null
 
 docker exec -i "$app_container" psql -v ON_ERROR_STOP=1 -U postgres -d content_pool \
   -c 'drop table restore_probe'

--- a/scripts/test-deployment-scripts.sh
+++ b/scripts/test-deployment-scripts.sh
@@ -57,6 +57,30 @@ runtime_sha="$(sha256sum "$fixture_dir/runtime.tar.gz" | awk '{print $1}')"
 (
   # shellcheck source=deploy-common.sh
   . "$ROOT_DIR/scripts/deploy-common.sh"
+  cp "$ROOT_DIR/.env.example" "$fixture_dir/legacy.env"
+  cp_env_set "$fixture_dir/legacy.env" COMPOSE_PROJECT_NAME legacy-content-pool
+  cp_apply_manifest_env "$fixture_dir/legacy.env" "$fixture_dir/release-manifest.json" \
+    staging "$ROOT_DIR/scripts/release_manifest.py"
+  test "$(cp_env_get "$fixture_dir/legacy.env" COMPOSE_PROJECT_NAME)" = legacy-content-pool
+
+  cp "$ROOT_DIR/.env.example" "$fixture_dir/fresh.env"
+  cp_apply_manifest_env "$fixture_dir/fresh.env" "$fixture_dir/release-manifest.json" \
+    staging "$ROOT_DIR/scripts/release_manifest.py"
+  test "$(cp_env_get "$fixture_dir/fresh.env" COMPOSE_PROJECT_NAME)" = content-pool-staging
+
+  mkdir -p "$fixture_dir/backup-check"
+  printf 'backup fixture\n' >"$fixture_dir/backup-check/probe.txt"
+  cp_write_sha256s "$fixture_dir/backup-check" probe.txt
+  cp_verify_sha256s "$fixture_dir/backup-check"
+  printf 'corrupt\n' >>"$fixture_dir/backup-check/probe.txt"
+  if cp_verify_sha256s "$fixture_dir/backup-check" >/dev/null 2>&1; then
+    echo "backup checksum verification accepted corrupted data" >&2
+    exit 1
+  fi
+)
+(
+  # shellcheck source=deploy-common.sh
+  . "$ROOT_DIR/scripts/deploy-common.sh"
   cp_prepare_release example/repository v0.2.0-rc.1 staging \
     "$fixture_dir/release-manifest.json" "$fixture_dir/prepared" >/dev/null
   test -f "$fixture_dir/prepared/runtime/probe.txt"
@@ -95,5 +119,69 @@ assert record["status"] == "failed"
 assert record["environment"] == "staging"
 assert record["target"]["release"] == "v0.2.0-rc.1"
 PY
+
+adopt_dir="$temp_dir/adopt"
+mkdir -p "$adopt_dir/scripts"
+cp "$ROOT_DIR/.env.example" "$adopt_dir/.env"
+cp "$ROOT_DIR/scripts/update.sh" "$ROOT_DIR/scripts/deploy-common.sh" "$adopt_dir/scripts/"
+cat > "$temp_dir/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -eu
+if [[ "${1:-}" == compose ]]; then
+  if [[ "${2:-}" == version ]]; then exit 0; fi
+  service="${*: -1}"
+  case "$service" in
+    content-pool-api) printf 'legacy-api-id\n' ;;
+    nginx) printf 'legacy-nginx-id\n' ;;
+  esac
+  exit 0
+fi
+if [[ "${1:-}" == inspect ]]; then
+  container="${2:-}"
+  case "$*" in
+    *State.Running*) printf 'true\n' ;;
+    *com.docker.compose.project*) printf 'legacy-project\n' ;;
+    *.Image*)
+      case "$container" in
+        legacy-api-id) printf 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' ;;
+        legacy-nginx-id) printf 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n' ;;
+      esac
+      ;;
+  esac
+  exit 0
+fi
+if [[ "${1:-}" == image && "${2:-}" == inspect ]]; then
+  case "${3:-}" in
+    sha256:aaaaaaaa*) printf 'ghcr.io/example/backend@sha256:%064d\n' 1 ;;
+    sha256:bbbbbbbb*) printf 'ghcr.io/example/frontend@sha256:%064d\n' 2 ;;
+  esac
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$temp_dir/bin/docker"
+(
+  cd "$adopt_dir"
+  PATH="$temp_dir/bin:$PATH" ./scripts/update.sh \
+    --mode server --environment production --adopt-current v0.1.3 >/dev/null
+  # shellcheck source=deploy-common.sh
+  . ./scripts/deploy-common.sh
+  test "$(cp_env_get .env COMPOSE_PROJECT_NAME)" = legacy-project
+  test "$(cp_env_get .env RELEASE_VERSION)" = v0.1.3
+  cp_verify_sha256s baselines/v0.1.3
+  rollback_plan="$(PATH="$temp_dir/bin:$PATH" ./scripts/update.sh \
+    --mode server --environment production --rollback-to v0.1.3 --dry-run)"
+  grep -q 'Would use local legacy baseline' <<<"$rollback_plan"
+  python3 - baselines/v0.1.3/manifest.json <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+assert data["composeProject"] == "legacy-project"
+assert data["images"]["backend"].endswith("@sha256:" + "0" * 63 + "1")
+assert data["images"]["frontend"].endswith("@sha256:" + "0" * 63 + "2")
+assert data["runtime"]["archive"] == "runtime.tgz"
+PY
+)
 
 echo "Deployment script checks passed"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -23,6 +23,8 @@ Options:
   --manifest FILE|URL               Alternate release-manifest.json source
   --rollback-to VERSION             Explicitly permit a downgrade to VERSION
   --adopt-current VERSION           Pin currently running legacy images as a baseline
+  --compose-override FILE           Additional Compose file for an isolated deployment
+  --base-url URL                    Public/frontend URL used by server-mode health checks
   --backup-dir DIR                  Backup root (default: ./backups)
   --no-backup                       Skip backups (intentional maintenance only)
   --allow-incomplete-backup         Continue if a backup source is not running
@@ -51,6 +53,23 @@ running_image_digest() {
   repo_digest="$(docker image inspect "$image_id" --format '{{range .RepoDigests}}{{println .}}{{end}}' 2>/dev/null | head -n 1)"
   [[ "$repo_digest" =~ @sha256:[0-9a-f]{64}$ ]] || return 1
   printf '%s' "$repo_digest"
+}
+
+running_service_image_digest() {
+  local service="$1" container
+  container="$(cp_compose_container_id "$service")" || return 1
+  running_image_digest "$container"
+}
+
+write_digest_override() {
+  local output="$1" backend="$2" frontend="$3"
+  cat >"$output" <<YAML
+services:
+  content-pool-api:
+    image: ${backend}
+  nginx:
+    image: ${frontend}
+YAML
 }
 
 validate_env_safety() {
@@ -92,23 +111,29 @@ create_backup_dir() {
 }
 
 backup_database() {
-  local container="$1" user="$2" database="$3" output="$4"
-  if cp_has_running_container "$container"; then
-    cp_info "Backing up ${database} from ${container}"
+  local service="$1" user="$2" database="$3" output="$4" container
+  if cp_compose_service_running "$service"; then
+    container="$(cp_compose_container_id "$service")"
+    cp_info "Backing up ${database} from ${service}"
     if ! docker exec "$container" pg_dump --format=custom -U "$user" "$database" > "$output"; then
       command rm -f "$output"
-      cp_die "Database backup failed for ${container}/${database}"
+      cp_die "Database backup failed for ${service}/${database}"
+    fi
+    if ! docker exec -i "$container" pg_restore --list <"$output" >/dev/null; then
+      command rm -f "$output"
+      cp_die "Database backup validation failed for ${service}/${database}"
     fi
   elif [[ "$ALLOW_INCOMPLETE_BACKUP" -eq 0 ]]; then
-    cp_die "Container ${container} is not running; backup would be incomplete"
+    cp_die "Service ${service} is not running; backup would be incomplete"
   else
-    cp_warn "Container ${container} is not running; database backup skipped"
+    cp_warn "Service ${service} is not running; database backup skipped"
   fi
 }
 
 keycloak_user_count() {
-  local user="$1" database="$2" realm="$3" count
-  count="$(docker exec -i keycloak-db psql -qAt -v ON_ERROR_STOP=1 \
+  local user="$1" database="$2" realm="$3" count container
+  container="$(cp_compose_container_id keycloak-db)" || return 1
+  count="$(docker exec -i "$container" psql -qAt -v ON_ERROR_STOP=1 \
     -v realm_name="$realm" -U "$user" -d "$database" <<'SQL'
 select count(*)
 from user_entity u
@@ -123,7 +148,7 @@ SQL
 
 capture_keycloak_users() {
   [[ "$KEYCLOAK_USER_CHECK" -eq 1 ]] || return 0
-  if ! cp_has_running_container keycloak-db; then
+  if ! cp_compose_service_running keycloak-db; then
     [[ "$ALLOW_INCOMPLETE_BACKUP" -eq 1 ]] || cp_die "keycloak-db is not running"
     cp_warn "Keycloak user check skipped because keycloak-db is not running"
     KEYCLOAK_USER_CHECK=0
@@ -136,8 +161,16 @@ capture_keycloak_users() {
   export KEYCLOAK_USERS_BEFORE
 }
 
+write_backup_checksums() {
+  local backup_dir="$1" path backup_files=(manifest.txt)
+  for path in config.tgz content-pool-db.dump keycloak-db.dump uploads.tgz; do
+    [[ -f "${backup_dir}/${path}" ]] && backup_files+=("$path")
+  done
+  cp_write_sha256s "$backup_dir" "${backup_files[@]}"
+}
+
 create_backup() {
-  local backup_dir old_umask paths=() path
+  local backup_dir old_umask paths=() path api_container
   old_umask="$(umask)"
   umask 077
   backup_dir="$(create_backup_dir "$BACKUP_ROOT")"
@@ -154,8 +187,9 @@ create_backup() {
     "$(cp_env_get_default .env KEYCLOAK_DB_USER keycloak)" \
     "$(cp_env_get_default .env KEYCLOAK_DB_NAME keycloak)" \
     "${backup_dir}/keycloak-db.dump"
-  if cp_has_running_container content-pool-api; then
-    docker exec content-pool-api tar -C /app -czf - uploads > "${backup_dir}/uploads.tgz" || \
+  if cp_compose_service_running content-pool-api; then
+    api_container="$(cp_compose_container_id content-pool-api)"
+    docker exec "$api_container" tar -C /app -czf - uploads > "${backup_dir}/uploads.tgz" || \
       cp_die "Upload backup failed"
   elif [[ "$ALLOW_INCOMPLETE_BACKUP" -eq 0 ]]; then
     cp_die "content-pool-api is not running; upload backup would be incomplete"
@@ -170,6 +204,7 @@ create_backup() {
     printf 'keycloak_realm=%s\n' "$KEYCLOAK_REALM"
     printf 'keycloak_users_before=%s\n' "${KEYCLOAK_USERS_BEFORE:-}"
   } > "${backup_dir}/manifest.txt"
+  write_backup_checksums "$backup_dir"
   chmod 700 "$backup_dir"
   find "$backup_dir" -type f -exec chmod 600 {} \;
   umask "$old_umask"
@@ -224,7 +259,11 @@ PY
 run_health_check() {
   local keycloak_url api_url frontend_url content_host
   [[ "$HEALTH_CHECK" -eq 1 ]] || return 0
-  if [[ "$MODE" == "traefik" ]]; then
+  if [[ -n "$BASE_URL" ]]; then
+    keycloak_url="$(cp_env_get .env OIDC_PUBLIC_ISSUER_URL)"
+    api_url="${BASE_URL%/}/api"
+    frontend_url="${BASE_URL%/}"
+  elif [[ "$MODE" == "traefik" ]]; then
     content_host="$(cp_env_get .env CONTENT_POOL_HOST)"
     keycloak_url="$(cp_env_get .env OIDC_PUBLIC_ISSUER_URL)"
     api_url="https://${content_host}/api"
@@ -239,10 +278,14 @@ run_health_check() {
 }
 
 restore_previous_application() {
+  local digest_override
   cp_warn "Restoring previous runtime files and image references; database migrations are not reverted"
   if [[ -n "$LAST_BACKUP_DIR" && -f "${LAST_BACKUP_DIR}/config.tgz" ]]; then
     tar -xzf "${LAST_BACKUP_DIR}/config.tgz" -C .
-    cp_set_compose_args "$MODE"
+    cp_set_compose_args "$MODE" "$COMPOSE_OVERRIDE"
+    digest_override="${LAST_BACKUP_DIR}/rollback-images.yml"
+    write_digest_override "$digest_override" "$PREVIOUS_BACKEND_IMAGE" "$PREVIOUS_FRONTEND_IMAGE"
+    CONTENT_POOL_COMPOSE_ARGS+=(-f "$digest_override")
     if run_compose up -d; then
       cp_warn "Previous application release restarted"
     else
@@ -275,13 +318,16 @@ cleanup_update() {
 }
 
 adopt_current() {
-  local baseline="$1" backend frontend compose_project
+  local baseline="$1" backend frontend compose_project api_container frontend_container
+  local baseline_dir runtime_archive runtime_sha paths=() path
   [[ "$baseline" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || cp_die "--adopt-current requires stable vMAJOR.MINOR.PATCH"
-  cp_has_running_container content-pool-api || cp_die "content-pool-api is not running"
-  cp_has_running_container content-pool-nginx || cp_die "content-pool-nginx is not running"
-  backend="$(running_image_digest content-pool-api)" || cp_die "Cannot resolve running backend RepoDigest"
-  frontend="$(running_image_digest content-pool-nginx)" || cp_die "Cannot resolve running frontend RepoDigest"
-  compose_project="$(docker inspect content-pool-api \
+  cp_compose_service_running content-pool-api || cp_die "content-pool-api is not running"
+  cp_compose_service_running nginx || cp_die "nginx is not running"
+  api_container="$(cp_compose_container_id content-pool-api)"
+  frontend_container="$(cp_compose_container_id nginx)"
+  backend="$(running_image_digest "$api_container")" || cp_die "Cannot resolve running backend RepoDigest"
+  frontend="$(running_image_digest "$frontend_container")" || cp_die "Cannot resolve running frontend RepoDigest"
+  compose_project="$(docker inspect "$api_container" \
     --format '{{index .Config.Labels "com.docker.compose.project"}}' 2>/dev/null)" || \
     cp_die "Cannot determine the legacy Compose project"
   [[ -n "$compose_project" ]] || cp_die "Running backend has no Compose project label"
@@ -293,9 +339,20 @@ adopt_current() {
   cp_env_set .env RELEASE_BUILT_AT 1970-01-01T00:00:00Z
   cp_env_set .env CONTENT_POOL_BACKEND_IMAGE "$backend"
   cp_env_set .env CONTENT_POOL_FRONTEND_IMAGE "$frontend"
-  mkdir -p deployments
-  python3 - "$baseline" "$ENVIRONMENT" "$compose_project" "$backend" "$frontend" > "deployments/baseline-${baseline}.json" <<'PY'
-import json, sys
+
+  baseline_dir="baselines/${baseline}"
+  mkdir -m 700 -p deployments "$baseline_dir"
+  for path in .env .release-manifest.json docker-compose.server.yml docker-compose.traefik.yml nginx.server.conf Makefile keycloak scripts; do
+    [[ -e "$path" ]] && paths+=("$path")
+  done
+  runtime_archive="${baseline_dir}/runtime.tgz"
+  tar -czf "$runtime_archive" "${paths[@]}"
+  runtime_sha="$(cp_sha256_file "$runtime_archive")"
+  python3 - "$baseline" "$ENVIRONMENT" "$compose_project" "$backend" "$frontend" "$runtime_sha" \
+    > "${baseline_dir}/manifest.json" <<'PY'
+import json
+import sys
+
 print(json.dumps({
     "schemaVersion": 1,
     "type": "legacy-baseline",
@@ -303,9 +360,122 @@ print(json.dumps({
     "environment": sys.argv[2],
     "composeProject": sys.argv[3],
     "images": {"backend": sys.argv[4], "frontend": sys.argv[5]},
+    "runtime": {"archive": "runtime.tgz", "sha256": sys.argv[6]},
 }, indent=2))
 PY
+  cp_write_sha256s "$baseline_dir" manifest.json runtime.tgz
+  command cp -f "${baseline_dir}/manifest.json" "deployments/baseline-${baseline}.json"
+  chmod 600 "${baseline_dir}"/* "deployments/baseline-${baseline}.json"
   cp_info "Adopted ${baseline} with immutable running image digests"
+  cp_info "Baseline: ${baseline_dir}"
+}
+
+baseline_get() {
+  local manifest="$1" field="$2"
+  python3 - "$manifest" "$field" <<'PY'
+import json
+import sys
+
+value = json.load(open(sys.argv[1], encoding="utf-8"))
+for part in sys.argv[2].split("."):
+    value = value[part]
+print(value)
+PY
+}
+
+validate_local_baseline() {
+  local baseline="$1" baseline_dir="baselines/${1}" manifest
+  manifest="${baseline_dir}/manifest.json"
+  [[ -f "$manifest" && -f "${baseline_dir}/runtime.tgz" ]] || return 1
+  cp_verify_sha256s "$baseline_dir" || cp_die "Legacy baseline checksum validation failed"
+  cp_validate_tar_archive "${baseline_dir}/runtime.tgz" || cp_die "Unsafe legacy baseline archive"
+  python3 - "$manifest" "$baseline" "$ENVIRONMENT" <<'PY'
+import json
+import re
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+if data.get("schemaVersion") != 1 or data.get("type") != "legacy-baseline":
+    raise SystemExit("invalid legacy baseline schema")
+if data.get("release") != sys.argv[2] or data.get("environment") != sys.argv[3]:
+    raise SystemExit("legacy baseline target mismatch")
+if not data.get("composeProject"):
+    raise SystemExit("legacy baseline compose project is missing")
+images = data.get("images")
+if not isinstance(images, dict) or set(images) != {"backend", "frontend"}:
+    raise SystemExit("legacy baseline images are incomplete")
+for image in images.values():
+    if not isinstance(image, str) or not re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", image):
+        raise SystemExit("legacy baseline image is not digest-pinned")
+runtime = data.get("runtime", {})
+if runtime.get("archive") != "runtime.tgz" or not re.fullmatch(r"[0-9a-f]{64}", str(runtime.get("sha256", ""))):
+    raise SystemExit("invalid legacy baseline runtime metadata")
+PY
+}
+
+rollback_local_baseline() {
+  local baseline="$1" baseline_dir="baselines/${1}" manifest digest_override users_after
+  manifest="${baseline_dir}/manifest.json"
+  validate_local_baseline "$baseline" || cp_die "Local legacy baseline not found: ${baseline}"
+  TARGET_RELEASE="$baseline"
+  TARGET_APPLICATION_VERSION=""
+  TARGET_COMMIT=""
+  TARGET_BACKEND_IMAGE="$(baseline_get "$manifest" images.backend)"
+  TARGET_FRONTEND_IMAGE="$(baseline_get "$manifest" images.frontend)"
+
+  if [[ "$YES" -eq 0 ]] && is_tty; then
+    printf 'Roll back application to local baseline %s? [y/N]: ' "$baseline"
+    read -r answer
+    [[ "$answer" =~ ^([yY]|yes|YES)$ ]] || cp_die "Rollback aborted"
+  fi
+
+  DEPLOYMENT_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  DEPLOYMENT_RECORD=""
+  DEPLOYMENT_ACTIVE=1
+  RELEASE_WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/content-pool-rollback.XXXXXX")"
+  write_deployment_record started
+  trap cleanup_update EXIT
+  capture_keycloak_users
+  if [[ "$BACKUP" -eq 1 ]]; then
+    create_backup
+    export DEPLOY_CHECK_BACKUP=passed
+  else
+    export DEPLOY_CHECK_BACKUP=skipped
+  fi
+
+  tar -xzf "${baseline_dir}/runtime.tgz" -C .
+  cp_set_compose_args "$MODE" "$COMPOSE_OVERRIDE"
+  digest_override="${RELEASE_WORK_DIR}/rollback-images.yml"
+  write_digest_override "$digest_override" "$TARGET_BACKEND_IMAGE" "$TARGET_FRONTEND_IMAGE"
+  CONTENT_POOL_COMPOSE_ARGS+=(-f "$digest_override")
+  run_compose config >/dev/null || fail_deployment "Legacy baseline Compose validation failed"
+  export DEPLOY_CHECK_COMPOSE=passed
+  if [[ "$PULL" -eq 1 ]]; then
+    run_compose pull || fail_deployment "Pulling legacy baseline images failed"
+  fi
+  docker image inspect "$TARGET_BACKEND_IMAGE" >/dev/null 2>&1 || fail_deployment "Legacy backend digest is unavailable"
+  docker image inspect "$TARGET_FRONTEND_IMAGE" >/dev/null 2>&1 || fail_deployment "Legacy frontend digest is unavailable"
+  export DEPLOY_CHECK_IMAGES=passed
+  run_compose up -d || fail_deployment "Starting legacy baseline failed"
+  export DEPLOY_CHECK_START=passed
+  run_health_check || fail_deployment "Legacy baseline health check failed"
+  export DEPLOY_CHECK_HEALTH=$([[ "$HEALTH_CHECK" -eq 1 ]] && printf passed || printf skipped)
+
+  if [[ "$KEYCLOAK_USER_CHECK" -eq 1 ]]; then
+    users_after="$(keycloak_user_count \
+      "$(cp_env_get_default .env KEYCLOAK_DB_USER keycloak)" \
+      "$(cp_env_get_default .env KEYCLOAK_DB_NAME keycloak)" \
+      "$KEYCLOAK_REALM")" || fail_deployment "Could not count Keycloak users after rollback"
+    (( users_after >= KEYCLOAK_USERS_BEFORE )) || fail_deployment "Keycloak user count decreased during rollback"
+    KEYCLOAK_USERS_AFTER="$users_after"
+    export KEYCLOAK_USERS_AFTER DEPLOY_CHECK_KEYCLOAK=passed
+  else
+    export DEPLOY_CHECK_KEYCLOAK=skipped
+  fi
+  write_deployment_record succeeded
+  DEPLOYMENT_ACTIVE=0
+  cp_info "Application rollback complete: ${baseline}; database migrations were not reverted"
+  cp_info "Record: ${DEPLOYMENT_RECORD}"
 }
 
 MODE="${CONTENT_POOL_DEPLOY_MODE:-}"
@@ -314,6 +484,8 @@ RELEASE=""
 ROLLBACK_TO=""
 ADOPT_CURRENT=""
 MANIFEST_SOURCE=""
+COMPOSE_OVERRIDE=""
+BASE_URL=""
 REPO="${CONTENT_POOL_REPO:-$CONTENT_POOL_REPO_DEFAULT}"
 BACKUP_ROOT=backups
 BACKUP=1
@@ -349,6 +521,10 @@ while [[ $# -gt 0 ]]; do
     --adopt-current=*) ADOPT_CURRENT="${1#*=}"; shift ;;
     --manifest) MANIFEST_SOURCE="$2"; shift 2 ;;
     --manifest=*) MANIFEST_SOURCE="${1#*=}"; shift ;;
+    --compose-override) COMPOSE_OVERRIDE="$2"; shift 2 ;;
+    --compose-override=*) COMPOSE_OVERRIDE="${1#*=}"; shift ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --base-url=*) BASE_URL="${1#*=}"; shift ;;
     --repo) REPO="$2"; shift 2 ;;
     --repo=*) REPO="${1#*=}"; shift ;;
     --backup-dir) BACKUP_ROOT="$2"; shift 2 ;;
@@ -378,7 +554,7 @@ cp_validate_mode "$MODE"
 cp_validate_environment "$ENVIRONMENT"
 cp_require_docker_compose
 cp_require_cmd python3
-cp_set_compose_args "$MODE"
+cp_set_compose_args "$MODE" "$COMPOSE_OVERRIDE"
 
 if [[ -n "$ADOPT_CURRENT" ]]; then
   [[ -z "$RELEASE" && -z "$ROLLBACK_TO" ]] || cp_die "--adopt-current cannot be combined with a release"
@@ -388,8 +564,8 @@ if [[ -n "$ADOPT_CURRENT" ]]; then
 fi
 
 PREVIOUS_RELEASE="$(cp_env_get .env RELEASE_VERSION)"
-PREVIOUS_BACKEND_IMAGE="$(running_image_digest content-pool-api 2>/dev/null || cp_env_get .env CONTENT_POOL_BACKEND_IMAGE)"
-PREVIOUS_FRONTEND_IMAGE="$(running_image_digest content-pool-nginx 2>/dev/null || cp_env_get .env CONTENT_POOL_FRONTEND_IMAGE)"
+PREVIOUS_BACKEND_IMAGE="$(running_service_image_digest content-pool-api 2>/dev/null || cp_env_get .env CONTENT_POOL_BACKEND_IMAGE)"
+PREVIOUS_FRONTEND_IMAGE="$(running_service_image_digest nginx 2>/dev/null || cp_env_get .env CONTENT_POOL_FRONTEND_IMAGE)"
 
 if [[ "$BACKUP_ONLY" -eq 1 ]]; then
   capture_keycloak_users
@@ -404,8 +580,17 @@ cp_validate_release_for_environment "$TARGET_RELEASE" "$ENVIRONMENT"
 
 if [[ "$DRY_RUN" -eq 1 ]]; then
   cp_info "Would deploy ${TARGET_RELEASE} to ${ENVIRONMENT} using mode ${MODE}"
-  cp_info "Would use manifest: ${MANIFEST_SOURCE:-GitHub release asset}"
+  if [[ -n "$ROLLBACK_TO" && -f "baselines/${TARGET_RELEASE}/manifest.json" ]]; then
+    cp_info "Would use local legacy baseline: baselines/${TARGET_RELEASE}"
+  else
+    cp_info "Would use manifest: ${MANIFEST_SOURCE:-GitHub release asset}"
+  fi
   cp_info "Would create backup: $([[ "$BACKUP" -eq 1 ]] && printf yes || printf no)"
+  exit 0
+fi
+
+if [[ -n "$ROLLBACK_TO" && -f "baselines/${TARGET_RELEASE}/manifest.json" ]]; then
+  rollback_local_baseline "$TARGET_RELEASE"
   exit 0
 fi
 
@@ -491,6 +676,7 @@ if [[ "$KEYCLOAK_USER_CHECK" -eq 1 ]]; then
   export KEYCLOAK_USERS_AFTER
   if [[ -n "$LAST_BACKUP_DIR" && -f "${LAST_BACKUP_DIR}/manifest.txt" ]]; then
     printf 'keycloak_users_after=%s\n' "$KEYCLOAK_USERS_AFTER" >>"${LAST_BACKUP_DIR}/manifest.txt"
+    write_backup_checksums "$LAST_BACKUP_DIR"
   fi
   export DEPLOY_CHECK_KEYCLOAK=passed
 else


### PR DESCRIPTION
## What changed

- preserve an adopted Compose project across manifest-driven updates
- resolve running containers through Compose services for isolated projects
- create checksum-validated legacy runtime baselines and exact-digest rollback
- checksum deployment backups and validate PostgreSQL custom dumps before restore
- support Compose overrides and alternate health URLs for isolated rehearsals

## Why

The first managed update from the live v0.1.3 installation would otherwise replace the legacy project name content-pool with content-pool-production. That could address empty volumes or collide with the fixed legacy container names. Legacy rollback also needed to retain exact captured image digests instead of mutable tags.

## Validation

- release metadata and manifest unit tests
- deployment shell fixture tests
- PostgreSQL backup/restore drill
- backend lint, formatting, 666 unit tests, and build
- frontend lint, formatting, 465 unit tests, and build
- runtime bundle contents and shell syntax