### PR TITLE
Wait for restore database readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to ContentPool are documented in this file. Releases use
   use the existing database and upload volumes.
 - Add checksum-validated local legacy baselines, exact-digest rollback, and
   structural validation for database backups.
+- Wait for both restored PostgreSQL services to become healthy before invoking
+  `pg_restore`.
 
 ### Breaking changes
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -80,7 +80,9 @@ docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" stop nginx content-pool-api key
 cp_info "Restoring runtime configuration"
 tar -xzf "${BACKUP_DIR}/config.tgz" -C .
 cp_set_compose_args "$MODE" "$COMPOSE_OVERRIDE"
-docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" up -d content-pool-db keycloak-db
+cp_info "Waiting for both restore databases to become ready"
+docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" up -d --wait --wait-timeout 120 \
+  content-pool-db keycloak-db
 
 restore_database() {
   local service="$1" user="$2" database="$3" dump="$4" container

--- a/scripts/test-deployment-scripts.sh
+++ b/scripts/test-deployment-scripts.sh
@@ -6,6 +6,11 @@ for script in "$ROOT_DIR"/scripts/*.sh; do
   bash -n "$script"
 done
 
+grep -q 'up -d --wait --wait-timeout 120' "$ROOT_DIR/scripts/restore.sh" || {
+  echo "restore does not wait for both PostgreSQL services" >&2
+  exit 1
+}
+
 temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/content-pool-script-test.XXXXXX")"
 trap 'rm -rf "$temp_dir"' EXIT
 mkdir -p "$temp_dir/scripts" "$temp_dir/bin"


### PR DESCRIPTION
## Summary
- wait until both PostgreSQL restore services are healthy before running pg_restore
- add a deployment-script regression guard
- document the restore safety fix

## Verification
- ./scripts/check-release-metadata.sh
- ./scripts/test-deployment-scripts.sh
- ./scripts/test-backup-restore.sh
- git diff --check

## Rehearsal evidence
An isolated restore on iqb-contentpool.de reproduced the pre-readiness race without touching production. Production remained healthy; the retry will use a new RC after this change is merged.