### PR TITLE
Wait for restored stack readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to ContentPool are documented in this file. Releases use
   structural validation for database backups.
 - Wait for both restored PostgreSQL services to become healthy before invoking
   `pg_restore`.
+- Wait for the complete restored application stack to become healthy before
+  running release identity and endpoint checks.
 
 ### Breaking changes
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -134,7 +134,8 @@ docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" run --rm --no-deps -T \
   < "${BACKUP_DIR}/uploads.tgz"
 
 docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" config >/dev/null
-docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" up -d
+cp_info "Waiting for the restored application stack to become ready"
+docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" up -d --wait --wait-timeout 180
 
 if [[ "$HEALTH_CHECK" -eq 1 ]]; then
   release="$(cp_env_get .env APPLICATION_VERSION)"

--- a/scripts/test-deployment-scripts.sh
+++ b/scripts/test-deployment-scripts.sh
@@ -10,6 +10,10 @@ grep -q 'up -d --wait --wait-timeout 120' "$ROOT_DIR/scripts/restore.sh" || {
   echo "restore does not wait for both PostgreSQL services" >&2
   exit 1
 }
+grep -q 'up -d --wait --wait-timeout 180' "$ROOT_DIR/scripts/restore.sh" || {
+  echo "restore does not wait for the complete application stack" >&2
+  exit 1
+}
 
 temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/content-pool-script-test.XXXXXX")"
 trap 'rm -rf "$temp_dir"' EXIT


### PR DESCRIPTION
## Summary
- wait for every restored service to become healthy before endpoint and release identity checks
- retain the separate database readiness gate before pg_restore
- add a regression guard and changelog entry

## Verification
- ./scripts/check-release-metadata.sh
- ./scripts/test-deployment-scripts.sh
- ./scripts/test-backup-restore.sh
- git diff --check

## Rehearsal evidence
The isolated RC.4 restore successfully restored both databases, 12 Keycloak users and uploads. Its immediate final health check raced API/nginx startup; repeating it after Docker health convergence passed every endpoint and version check. Production remained healthy.