### PR TITLE
Wait for update stack readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to ContentPool are documented in this file. Releases use
   `pg_restore`.
 - Wait for the complete restored application stack to become healthy before
   running release identity and endpoint checks.
+- Wait for stack health during normal updates, legacy rollback, and automatic
+  application recovery before evaluating deployment health.
 
 ### Breaking changes
 

--- a/scripts/test-deployment-scripts.sh
+++ b/scripts/test-deployment-scripts.sh
@@ -14,6 +14,10 @@ grep -q 'up -d --wait --wait-timeout 180' "$ROOT_DIR/scripts/restore.sh" || {
   echo "restore does not wait for the complete application stack" >&2
   exit 1
 }
+[[ "$(grep -c 'run_compose up -d --wait --wait-timeout 180' "$ROOT_DIR/scripts/update.sh")" -eq 3 ]] || {
+  echo "not every managed update/rollback start waits for stack readiness" >&2
+  exit 1
+}
 
 temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/content-pool-script-test.XXXXXX")"
 trap 'rm -rf "$temp_dir"' EXIT

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -286,7 +286,7 @@ restore_previous_application() {
     digest_override="${LAST_BACKUP_DIR}/rollback-images.yml"
     write_digest_override "$digest_override" "$PREVIOUS_BACKEND_IMAGE" "$PREVIOUS_FRONTEND_IMAGE"
     CONTENT_POOL_COMPOSE_ARGS+=(-f "$digest_override")
-    if run_compose up -d; then
+    if run_compose up -d --wait --wait-timeout 180; then
       cp_warn "Previous application release restarted"
     else
       cp_warn "Previous application restart failed"
@@ -456,7 +456,8 @@ rollback_local_baseline() {
   docker image inspect "$TARGET_BACKEND_IMAGE" >/dev/null 2>&1 || fail_deployment "Legacy backend digest is unavailable"
   docker image inspect "$TARGET_FRONTEND_IMAGE" >/dev/null 2>&1 || fail_deployment "Legacy frontend digest is unavailable"
   export DEPLOY_CHECK_IMAGES=passed
-  run_compose up -d || fail_deployment "Starting legacy baseline failed"
+  run_compose up -d --wait --wait-timeout 180 || \
+    fail_deployment "Starting legacy baseline failed"
   export DEPLOY_CHECK_START=passed
   run_health_check || fail_deployment "Legacy baseline health check failed"
   export DEPLOY_CHECK_HEALTH=$([[ "$HEALTH_CHECK" -eq 1 ]] && printf passed || printf skipped)
@@ -661,7 +662,7 @@ docker image inspect "$TARGET_BACKEND_IMAGE" >/dev/null 2>&1 || \
 docker image inspect "$TARGET_FRONTEND_IMAGE" >/dev/null 2>&1 || \
   fail_deployment "Pulled frontend image does not match the manifest digest"
 export DEPLOY_CHECK_IMAGES=passed
-run_compose up -d || fail_deployment "Starting the release failed"
+run_compose up -d --wait --wait-timeout 180 || fail_deployment "Starting the release failed"
 export DEPLOY_CHECK_START=passed
 run_health_check || fail_deployment "Health or version check failed"
 export DEPLOY_CHECK_HEALTH=$([[ "$HEALTH_CHECK" -eq 1 ]] && printf passed || printf skipped)


### PR DESCRIPTION
## Summary
- wait for stack health after normal updates and exact-digest legacy rollbacks
- wait for stack health while restoring the previous application after a failed attempt
- add a regression guard covering all managed start paths

## Verification
- ./scripts/check-release-metadata.sh
- ./scripts/test-deployment-scripts.sh
- ./scripts/test-backup-restore.sh
- git diff --check

## Rehearsal evidence
An isolated v0.1.3 exact-digest rollback on the migrated RC.5 database recreated the legacy containers successfully, but the health check raced their startup. Automatic recovery returned the RC.5 API to healthy and kept the rehearsal nginx closed; production remained healthy.