### PR TITLE
Clarify Item Explorer numbering and personal selection lists

### DIFF
--- a/backend/src/acp/feature-config.utils.spec.ts
+++ b/backend/src/acp/feature-config.utils.spec.ts
@@ -116,4 +116,26 @@ describe("normalizeFeatureConfig", () => {
       },
     });
   });
+
+  it("keeps reference-number visibility opt-in for existing ACPs", () => {
+    expect(
+      normalizeFeatureConfig({
+        metadataColumns: {
+          visible: [],
+          order: [],
+          referenceNumberVisible: true,
+        },
+      }),
+    ).toMatchObject({
+      metadataColumns: {
+        visible: [],
+        order: [],
+        referenceNumberVisible: true,
+      },
+    });
+
+    expect(normalizeFeatureConfig({ enableItemList: true })).not.toHaveProperty(
+      "metadataColumns.referenceNumberVisible",
+    );
+  });
 });

--- a/backend/src/acp/feature-config.utils.ts
+++ b/backend/src/acp/feature-config.utils.ts
@@ -3,6 +3,7 @@ type UnknownRecord = Record<string, unknown>;
 interface MetadataColumnsConfig {
   visible: string[];
   order: string[];
+  referenceNumberVisible?: boolean;
 }
 
 function asRecord(value: unknown): UnknownRecord {
@@ -62,13 +63,16 @@ function normalizeMetadataColumns(
   const metadataColumns = asRecord(metadataColumnsRaw);
   const visible = asStringArray(metadataColumns.visible);
   const order = asStringArray(metadataColumns.order);
+  const referenceNumberVisible =
+    metadataColumns.referenceNumberVisible === true;
 
-  if (visible.length || order.length) {
+  if (visible.length || order.length || referenceNumberVisible) {
     const normalizedVisible = visible.length ? visible : order;
     const normalizedOrder = order.length ? order : normalizedVisible;
     return {
       visible: normalizedVisible,
       order: normalizedOrder,
+      ...(referenceNumberVisible ? { referenceNumberVisible: true } : {}),
     };
   }
 

--- a/backend/src/item-collections/item-collection.models.ts
+++ b/backend/src/item-collections/item-collection.models.ts
@@ -7,9 +7,12 @@ export interface StoredItemCollection {
   updatedAt: string;
 }
 
+export type ItemCollectionViewMode = "all" | "active";
+
 export interface ItemCollectionState {
   collections: StoredItemCollection[];
   activeCollectionId: string | null;
+  collectionViewMode: ItemCollectionViewMode;
 }
 
 export interface ItemCollectionSummary {
@@ -31,5 +34,6 @@ export interface ItemCollectionView extends StoredItemCollection {
 
 export interface ItemCollectionsPayload {
   activeCollectionId: string | null;
+  collectionViewMode: ItemCollectionViewMode;
   collections: ItemCollectionView[];
 }

--- a/backend/src/item-collections/item-collection.store.spec.ts
+++ b/backend/src/item-collections/item-collection.store.spec.ts
@@ -81,6 +81,7 @@ describe("ItemCollectionStore", () => {
           },
         ],
         activeCollectionId: "collection-1",
+        collectionViewMode: "active",
       }),
     );
 
@@ -95,12 +96,13 @@ describe("ItemCollectionStore", () => {
     });
     expect(manager.query).toHaveBeenCalledWith(
       expect.stringMatching(
-        /UPDATE "acp_item_preferences"[\s\S]*jsonb_typeof\("preferences"\) = 'object'[\s\S]*ELSE '\{\}'::jsonb[\s\S]*'\{collections\}'[\s\S]*'\{activeCollectionId\}'/,
+        /UPDATE "acp_item_preferences"[\s\S]*jsonb_typeof\("preferences"\) = 'object'[\s\S]*ELSE '\{\}'::jsonb[\s\S]*'\{collections\}'[\s\S]*'\{activeCollectionId\}'[\s\S]*'\{collectionViewMode\}'/,
       ),
       [
         "preference-1",
         expect.stringContaining('"collection-1"'),
         JSON.stringify("collection-1"),
+        JSON.stringify("active"),
         null,
       ],
     );
@@ -119,7 +121,11 @@ describe("ItemCollectionStore", () => {
       false,
       (preferences) => {
         expect(preferences).toEqual({});
-        return { collections: [], activeCollectionId: null };
+        return {
+          collections: [],
+          activeCollectionId: null,
+          collectionViewMode: "all",
+        };
       },
     );
 
@@ -140,7 +146,11 @@ describe("ItemCollectionStore", () => {
         credentialUsername: "reader-a",
       },
       true,
-      () => ({ collections: [], activeCollectionId: null }),
+      () => ({
+        collections: [],
+        activeCollectionId: null,
+        collectionViewMode: "all",
+      }),
     );
 
     expect(manager.query).toHaveBeenNthCalledWith(
@@ -159,6 +169,7 @@ describe("ItemCollectionStore", () => {
       store.mutate("acp-1", { kind: "user", userId: "user-1" }, false, () => ({
         collections: [],
         activeCollectionId: null,
+        collectionViewMode: "all",
       })),
     ).rejects.toThrow(NotFoundException);
     expect(manager.query).not.toHaveBeenCalled();

--- a/backend/src/item-collections/item-collection.store.ts
+++ b/backend/src/item-collections/item-collection.store.ts
@@ -52,21 +52,26 @@ export class ItemCollectionStore {
             UPDATE "acp_item_preferences"
             SET "preferences" = jsonb_set(
                   jsonb_set(
-                    CASE
-                      WHEN jsonb_typeof("preferences") = 'object'
-                        THEN "preferences"
-                      ELSE '{}'::jsonb
-                    END,
-                    '{collections}',
-                    $2::jsonb,
+                    jsonb_set(
+                      CASE
+                        WHEN jsonb_typeof("preferences") = 'object'
+                          THEN "preferences"
+                        ELSE '{}'::jsonb
+                      END,
+                      '{collections}',
+                      $2::jsonb,
+                      true
+                    ),
+                    '{activeCollectionId}',
+                    $3::jsonb,
                     true
                   ),
-                  '{activeCollectionId}',
-                  $3::jsonb,
+                  '{collectionViewMode}',
+                  $4::jsonb,
                   true
                 ),
                 "credential_username" = CASE
-                  WHEN $4::varchar IS NOT NULL THEN $4::varchar
+                  WHEN $5::varchar IS NOT NULL THEN $5::varchar
                   ELSE "credential_username"
                 END,
                 "updated_at" = now()
@@ -76,6 +81,7 @@ export class ItemCollectionStore {
             record.id,
             JSON.stringify(state.collections),
             JSON.stringify(state.activeCollectionId),
+            JSON.stringify(state.collectionViewMode),
             identity.kind === "credential"
               ? identity.credentialUsername || null
               : null,

--- a/backend/src/item-collections/item-collections.service.spec.ts
+++ b/backend/src/item-collections/item-collections.service.spec.ts
@@ -89,6 +89,104 @@ describe("ItemCollectionsService", () => {
       missingStimulusTimeUnitCount: 0,
       complete: false,
     });
+    expect(result.collectionViewMode).toBe("all");
+  });
+
+  it("defaults missing or invalid collection view modes to all", async () => {
+    const basePreferences = {
+      activeCollectionId: "collection-1",
+      collections: [
+        {
+          id: "collection-1",
+          name: "Auswahl A",
+          rowKeys: [],
+          version: 1,
+          createdAt: "2026-07-01T10:00:00.000Z",
+          updatedAt: "2026-07-01T10:00:00.000Z",
+        },
+      ],
+    };
+    store.readPreferences.mockResolvedValue(basePreferences);
+    await expect(service.getItemCollections("acp-1", owner)).resolves.toEqual(
+      expect.objectContaining({ collectionViewMode: "all" }),
+    );
+
+    store.readPreferences.mockResolvedValue({
+      ...basePreferences,
+      collectionViewMode: "invalid",
+    });
+    await expect(service.getItemCollections("acp-1", owner)).resolves.toEqual(
+      expect.objectContaining({ collectionViewMode: "all" }),
+    );
+  });
+
+  it("falls back to all when the stored active collection no longer exists", async () => {
+    store.readPreferences.mockResolvedValue({
+      activeCollectionId: "deleted-collection",
+      collectionViewMode: "active",
+      collections: [
+        {
+          id: "collection-1",
+          name: "Auswahl A",
+          rowKeys: [],
+          version: 1,
+          createdAt: "2026-07-01T10:00:00.000Z",
+          updatedAt: "2026-07-01T10:00:00.000Z",
+        },
+      ],
+    });
+
+    await expect(service.getItemCollections("acp-1", owner)).resolves.toEqual(
+      expect.objectContaining({
+        activeCollectionId: "collection-1",
+        collectionViewMode: "all",
+      }),
+    );
+  });
+
+  it("persists active view mode and resets it when no active list remains", async () => {
+    const preferences: Record<string, unknown> = {
+      activeCollectionId: "collection-1",
+      collectionViewMode: "all",
+      collections: [
+        {
+          id: "collection-1",
+          name: "Auswahl A",
+          rowKeys: [],
+          version: 1,
+          createdAt: "2026-07-01T10:00:00.000Z",
+          updatedAt: "2026-07-01T10:00:00.000Z",
+        },
+      ],
+    };
+    store.mutate.mockImplementation(async (...args: any[]) => {
+      const state = args[3](preferences);
+      preferences.collections = state.collections;
+      preferences.activeCollectionId = state.activeCollectionId;
+      preferences.collectionViewMode = state.collectionViewMode;
+      return state;
+    });
+
+    const activated = await service.activateItemCollection(
+      "acp-1",
+      owner,
+      "collection-1",
+      false,
+      "active",
+    );
+    expect(activated.collectionViewMode).toBe("active");
+
+    const deleted = await service.deleteItemCollection(
+      "acp-1",
+      owner,
+      "collection-1",
+    );
+    expect(deleted).toEqual(
+      expect.objectContaining({
+        activeCollectionId: null,
+        collectionViewMode: "all",
+      }),
+    );
   });
 
   it("checks the base version inside the store mutation", async () => {

--- a/backend/src/item-collections/item-collections.service.ts
+++ b/backend/src/item-collections/item-collections.service.ts
@@ -18,6 +18,7 @@ import {
 import {
   ItemCollectionState,
   ItemCollectionSummary,
+  ItemCollectionViewMode,
   ItemCollectionsPayload,
   StoredItemCollection,
 } from "./item-collection.models";
@@ -51,7 +52,7 @@ export class ItemCollectionsService {
     rawName?: string,
     canEditExplorerState = false,
   ): Promise<ItemCollectionsPayload> {
-    const name = this.normalizeName(rawName || "Meine Kollektion");
+    const name = this.normalizeName(rawName || "Meine Auswahlliste");
     const now = new Date().toISOString();
     const collection: StoredItemCollection = {
       id: uuidv4(),
@@ -152,6 +153,7 @@ export class ItemCollectionsService {
     identity: StablePreferenceIdentity,
     collectionId: string | null,
     canEditExplorerState = false,
+    collectionViewMode?: ItemCollectionViewMode,
   ): Promise<ItemCollectionsPayload> {
     const state = await this.mutateState(
       acpId,
@@ -167,6 +169,13 @@ export class ItemCollectionsService {
           throw new NotFoundException("Item collection not found");
         }
         lockedState.activeCollectionId = collectionId;
+        if (collectionViewMode) {
+          lockedState.collectionViewMode = collectionId
+            ? collectionViewMode
+            : "all";
+        } else if (!collectionId) {
+          lockedState.collectionViewMode = "all";
+        }
       },
     );
     return this.resolveViews(acpId, state, canEditExplorerState);
@@ -192,6 +201,9 @@ export class ItemCollectionsService {
         lockedState.collections = collections;
         if (lockedState.activeCollectionId === collectionId) {
           lockedState.activeCollectionId = collections[0]?.id || null;
+        }
+        if (!lockedState.activeCollectionId) {
+          lockedState.collectionViewMode = "all";
         }
       },
     );
@@ -317,13 +329,21 @@ export class ItemCollectionsService {
     const requestedActiveId = String(
       preferences.activeCollectionId || "",
     ).trim();
+    const hasRequestedActiveCollection = collections.some(
+      (collection) => collection.id === requestedActiveId,
+    );
+    const activeCollectionId = hasRequestedActiveCollection
+      ? requestedActiveId
+      : collections[0]?.id || null;
+    const requestedViewMode: ItemCollectionViewMode =
+      preferences.collectionViewMode === "active" ? "active" : "all";
     return {
       collections,
-      activeCollectionId: collections.some(
-        (collection) => collection.id === requestedActiveId,
-      )
-        ? requestedActiveId
-        : collections[0]?.id || null,
+      activeCollectionId,
+      collectionViewMode:
+        hasRequestedActiveCollection && activeCollectionId
+          ? requestedViewMode
+          : "all",
     };
   }
 
@@ -383,6 +403,7 @@ export class ItemCollectionsService {
     );
     return {
       activeCollectionId: state.activeCollectionId,
+      collectionViewMode: state.collectionViewMode,
       collections: state.collections.map((collection) => {
         const unavailableRowKeys = collection.rowKeys.filter(
           (rowKey) => !itemsByRowKey.has(rowKey),

--- a/backend/src/item-explorer/item-explorer-state.service.ts
+++ b/backend/src/item-explorer/item-explorer-state.service.ts
@@ -24,6 +24,7 @@ export interface ExplorerActor {
 export interface ExplorerMetadataColumns {
   visible: string[];
   order: string[];
+  referenceNumberVisible?: boolean;
 }
 
 export interface ExplorerSharedStatePayload {
@@ -651,6 +652,9 @@ export class ItemExplorerStateService {
     const metadataColumns: ExplorerMetadataColumns = {
       visible: visible.length ? visible : order,
       order: order.length ? order : visible,
+      ...(rawMetadataColumns.referenceNumberVisible === true
+        ? { referenceNumberVisible: true }
+        : {}),
     };
 
     const itemProperties = this.normalizeItemProperties(acp.itemProperties);
@@ -706,10 +710,17 @@ export class ItemExplorerStateService {
     const visible = this.asStringArray(state.metadataColumns?.visible);
     const order = this.asStringArray(state.metadataColumns?.order);
 
-    if (visible.length || order.length) {
+    if (
+      visible.length ||
+      order.length ||
+      state.metadataColumns.referenceNumberVisible
+    ) {
       normalizedFeatureConfig.metadataColumns = {
         visible: visible.length ? visible : order,
         order: order.length ? order : visible,
+        ...(state.metadataColumns.referenceNumberVisible
+          ? { referenceNumberVisible: true }
+          : {}),
       };
     } else {
       delete normalizedFeatureConfig.metadataColumns;
@@ -773,6 +784,9 @@ export class ItemExplorerStateService {
       metadataColumns: {
         visible: visible.length ? visible : order,
         order: order.length ? order : visible,
+        ...(metadataColumnsRaw.referenceNumberVisible === true
+          ? { referenceNumberVisible: true }
+          : {}),
       },
       itemOrder: this.asStringArray(payload.itemOrder),
       itemProperties: this.normalizeItemProperties(payload.itemProperties),
@@ -789,6 +803,9 @@ export class ItemExplorerStateService {
       metadataColumns: {
         visible: [...current.metadataColumns.visible],
         order: [...current.metadataColumns.order],
+        ...(current.metadataColumns.referenceNumberVisible
+          ? { referenceNumberVisible: true }
+          : {}),
       },
       itemOrder: [...current.itemOrder],
       itemProperties: this.normalizeItemProperties(current.itemProperties),
@@ -811,6 +828,9 @@ export class ItemExplorerStateService {
       merged.metadataColumns = {
         visible: visible.length ? visible : order,
         order: order.length ? order : visible,
+        ...(patch.metadataColumns.referenceNumberVisible === true
+          ? { referenceNumberVisible: true }
+          : {}),
       };
     }
 

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -146,7 +146,7 @@ class ExportAllPersonalItemDataDto {
 }
 
 class CreateItemCollectionDto {
-  @ApiPropertyOptional({ example: "Meine Kollektion" })
+  @ApiPropertyOptional({ example: "Meine Auswahlliste" })
   @IsOptional()
   @IsString()
   name?: string;
@@ -186,6 +186,11 @@ class ActivateItemCollectionDto {
   @IsOptional()
   @IsString()
   collectionId?: string | null;
+
+  @ApiPropertyOptional({ enum: ["all", "active"] })
+  @IsOptional()
+  @IsIn(["all", "active"])
+  collectionViewMode?: "all" | "active";
 
   @ApiPropertyOptional({ enum: ["editor", "read-only"] })
   @IsOptional()
@@ -508,7 +513,9 @@ export class ViewsController {
 
   @Put("acp/:acpId/items/collections/active")
   @UseGuards(AcpAccessGuard)
-  @ApiOperation({ summary: "Persist the active personal item collection" })
+  @ApiOperation({
+    summary: "Persist the active personal item collection and list view mode",
+  })
   async activateItemCollection(
     @UuidParam("acpId") acpId: string,
     @Body() dto: ActivateItemCollectionDto,
@@ -520,6 +527,7 @@ export class ViewsController {
       this.requireCollectionIdentity(req),
       dto.collectionId || null,
       this.isEditorPerspective(req, dto.perspective),
+      dto.collectionViewMode,
     );
   }
 

--- a/backend/test/browser-e2e/seed.ts
+++ b/backend/test/browser-e2e/seed.ts
@@ -106,6 +106,7 @@ async function seed(): Promise<void> {
           enableItemListSort: true,
           enableItemClick: true,
           persistUserPreferences: true,
+          enableItemCollections: true,
         },
       }),
     );

--- a/frontend/e2e/item-list-preferences.spec.ts
+++ b/frontend/e2e/item-list-preferences.spec.ts
@@ -281,3 +281,123 @@ test('reconciles mean filters across clear, reimport, reload and credential relo
 
   await managerContext.close();
 });
+
+test('keeps positions gapless and persists the personal selection view across perspectives', async ({
+  page,
+  request,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 1100 });
+  const login = await request.post('/api/auth/login', {
+    data: { username: MANAGER_USERNAME, password: MANAGER_PASSWORD },
+  });
+  expect(login.ok()).toBeTruthy();
+  const token = (await login.json()).accessToken as string;
+  await page.addInitScript((accessToken) => {
+    localStorage.setItem('cp_token', accessToken);
+    localStorage.setItem('cp_auth_type', 'local');
+  }, token);
+
+  await page.goto(`/view/${ACP_ID}/item-explorer`);
+  await expect(page.getByRole('columnheader', { name: 'Pos.' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: /Referenz-Nr/ })).toBeHidden();
+  await expect(page.locator('tbody tr td.number-col')).toHaveText(['1', '2']);
+
+  await page.getByRole('button', { name: /Referenznummern neu vergeben/ }).click();
+  await expect(page.getByRole('heading', { name: 'Referenznummern neu vergeben' })).toBeVisible();
+  await expect(page.getByText(/Alle 2 Zeilen des vollständigen Itembestands/)).toBeVisible();
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/item-list/renumber') &&
+        response.ok(),
+    ),
+    page.getByRole('button', { name: 'Referenznummern neu vergeben', exact: true }).last().click(),
+  ]);
+  await expect(page.getByText(/2 Referenznummern im vollständigen Itembestand/)).toBeVisible();
+
+  await page.getByRole('button', { name: /Spalten verwalten/ }).click();
+  await page.getByLabel(/Referenz-Nr/).check();
+  await page
+    .getByRole('button', { name: /Speichern/ })
+    .last()
+    .click();
+  await expect(page.getByRole('columnheader', { name: /Referenz-Nr/ })).toBeVisible();
+  await expect(page.locator('tbody tr td.number-col').nth(0)).toHaveText('1');
+  await expect(page.locator('tbody tr td.number-col').nth(2)).toHaveText('2');
+
+  const tableScroll = page.locator('.table-scroll');
+  await tableScroll.evaluate((element) => {
+    element.scrollLeft = element.scrollWidth;
+  });
+  const [positionBox, referenceBox, itemIdBox] = await Promise.all([
+    page.getByRole('columnheader', { name: 'Pos.' }).boundingBox(),
+    page.getByRole('columnheader', { name: /Referenz-Nr/ }).boundingBox(),
+    page.getByRole('columnheader', { name: /Item-ID/ }).boundingBox(),
+  ]);
+  expect(positionBox).not.toBeNull();
+  expect(referenceBox).not.toBeNull();
+  expect(itemIdBox).not.toBeNull();
+  expect(positionBox!.x + positionBox!.width).toBeLessThanOrEqual(referenceBox!.x + 1);
+  expect(referenceBox!.x + referenceBox!.width).toBeLessThanOrEqual(itemIdBox!.x + 1);
+
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().endsWith('/items/collections') &&
+        response.ok(),
+    ),
+    page.getByRole('button', { name: 'Neu', exact: true }).click(),
+  ]);
+  await expect(page.getByRole('button', { name: 'Nur Auswahlliste (0)' })).toBeEnabled();
+
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PATCH' &&
+        response.url().includes('/items/collections/') &&
+        response.ok(),
+    ),
+    page
+      .getByRole('checkbox', { name: /in Auswahlliste auswählen/ })
+      .first()
+      .check(),
+  ]);
+  const activeOnlyButton = page.getByRole('button', { name: 'Nur Auswahlliste (1)' });
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        response.url().endsWith('/items/collections/active') &&
+        response.ok(),
+    ),
+    activeOnlyButton.click(),
+  ]);
+  await expect(page.locator('tbody tr')).toHaveCount(1);
+
+  await page.reload();
+  await expect(page.getByRole('button', { name: 'Nur Auswahlliste (1)' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  await expect(page.locator('tbody tr')).toHaveCount(1);
+
+  await page.getByRole('button', { name: 'READ ONLY-Vorschau' }).click();
+  await expect(page.getByRole('button', { name: 'Bearbeitungsansicht' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Nur Auswahlliste (1)' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  await expect(page.locator('tbody tr')).toHaveCount(1);
+
+  await page.getByRole('button', { name: 'Alle Items' }).click();
+  await expect(page.locator('tbody tr')).toHaveCount(2);
+
+  await page.getByRole('button', { name: 'Bearbeitungsansicht' }).click();
+  const discardButton = page.getByRole('button', { name: /Verwerfen/ }).first();
+  await expect(discardButton).toBeEnabled();
+  await discardButton.click();
+  await page.getByRole('button', { name: 'Änderungen verwerfen', exact: true }).click();
+  await expect(page.getByRole('columnheader', { name: /Referenz-Nr/ })).toBeHidden();
+});

--- a/frontend/src/app/acp-manager/access-config/access-config.component.ts
+++ b/frontend/src/app/acp-manager/access-config/access-config.component.ts
@@ -500,7 +500,7 @@ import { AcpManagerContextComponent } from '../shared/acp-manager-context.compon
         </label>
         <label class="feature-toggle">
           <input type="checkbox" [(ngModel)]="featureConfig[enableItemCollectionsKey]" />
-          <span>Persönliche Item-Kollektionen aktivieren</span>
+          <span>Persönliche Item-Auswahllisten aktivieren</span>
         </label>
         @if (featureConfig[enablePersonalItemDataKey]) {
           <div class="indent-section personal-data-config">

--- a/frontend/src/app/core/models/api.models.ts
+++ b/frontend/src/app/core/models/api.models.ts
@@ -488,12 +488,14 @@ export interface ItemCollection {
 
 export interface ItemCollectionsPayload {
   activeCollectionId: string | null;
+  collectionViewMode: 'all' | 'active';
   collections: ItemCollection[];
 }
 
 export interface ItemExplorerMetadataColumns {
   visible?: string[];
   order?: string[];
+  referenceNumberVisible?: boolean;
 }
 
 export interface ItemExplorerSharedState {

--- a/frontend/src/app/core/services/api.service.spec.ts
+++ b/frontend/src/app/core/services/api.service.spec.ts
@@ -952,6 +952,28 @@ describe('ApiService', () => {
       );
     });
 
+    it('should persist the active personal item list view mode', () => {
+      const payload = {
+        activeCollectionId: 'collection-1',
+        collectionViewMode: 'active' as const,
+        collections: [],
+      };
+      httpClientMock.put.mockReturnValue(of(payload));
+
+      service
+        .activateItemCollection('acp1', 'collection-1', 'read-only', 'active')
+        .subscribe((result) => expect(result).toEqual(payload));
+
+      expect(httpClientMock.put).toHaveBeenCalledWith(
+        '/api/view/acp/acp1/items/collections/active',
+        {
+          collectionId: 'collection-1',
+          perspective: 'read-only',
+          collectionViewMode: 'active',
+        },
+      );
+    });
+
     it('should get view sequences', () => {
       httpClientMock.get.mockReturnValue(of([]));
 

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -643,10 +643,11 @@ export class ApiService {
     acpId: string,
     collectionId: string | null,
     perspective: ItemExplorerPerspective,
+    collectionViewMode?: 'all' | 'active',
   ): Observable<ItemCollectionsPayload> {
     return this.http.put<ItemCollectionsPayload>(
       `${this.API}/view/acp/${acpId}/items/collections/active`,
-      { collectionId, perspective },
+      { collectionId, perspective, collectionViewMode },
     );
   }
 

--- a/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.css
+++ b/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.css
@@ -1,3 +1,17 @@
 :host {
   display: contents;
 }
+.collection-label {
+  font-size: 0.85rem;
+}
+.collection-view-toggle {
+  display: inline-flex;
+  align-items: center;
+}
+.collection-view-toggle .btn:first-child {
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+.collection-view-toggle .btn:last-child {
+  margin-left: -1px;
+  border-radius: 0 var(--radius) var(--radius) 0;
+}

--- a/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.html
+++ b/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.html
@@ -1,28 +1,51 @@
 @if (vm.enableItemCollections) {
   <div class="collection-bar">
     @if (vm.collectionLoadState === 'loading') {
-      <span>Kollektionen werden geladen …</span>
+      <span>Persönliche Auswahllisten werden geladen …</span>
     } @else if (vm.collectionLoadState === 'error') {
       <span class="personal-data-error">{{ vm.collectionError }}</span>
       <button class="btn btn-outline btn-sm" (click)="vm.loadItemCollections()">
         Erneut laden
       </button>
     } @else {
+      <strong class="collection-label">Persönliche Auswahlliste</strong>
       <select
         class="tag-input collection-select"
-        aria-label="Aktive Kollektion auswählen"
+        aria-label="Aktive persönliche Auswahlliste auswählen"
         [ngModel]="vm.activeCollectionId"
         (ngModelChange)="vm.activateCollection($event)"
         [disabled]="vm.collectionBusy || vm.itemCollections.length === 0"
       >
         @if (vm.itemCollections.length === 0) {
-          <option [ngValue]="null">Noch keine Kollektion</option>
+          <option [ngValue]="null">Noch keine Auswahlliste</option>
         }
         @for (collection of vm.itemCollections; track collection.id) {
           <option [value]="collection.id">{{ collection.name }}</option>
         }
       </select>
       <button class="btn btn-outline btn-sm" (click)="vm.createCollection()">Neu</button>
+      <div class="collection-view-toggle" role="group" aria-label="Angezeigte Items">
+        <button
+          class="btn btn-outline btn-sm"
+          type="button"
+          [class.btn-primary]="vm.collectionViewMode === 'all'"
+          [attr.aria-pressed]="vm.collectionViewMode === 'all'"
+          [disabled]="vm.collectionBusy"
+          (click)="vm.setCollectionViewMode('all')"
+        >
+          Alle Items
+        </button>
+        <button
+          class="btn btn-outline btn-sm"
+          type="button"
+          [class.btn-primary]="vm.collectionViewMode === 'active'"
+          [attr.aria-pressed]="vm.collectionViewMode === 'active'"
+          [disabled]="!vm.activeItemCollection || vm.collectionBusy"
+          (click)="vm.setCollectionViewMode('active')"
+        >
+          Nur Auswahlliste ({{ vm.activeItemCollection?.rowKeys?.length || 0 }})
+        </button>
+      </div>
       <button
         class="btn btn-outline btn-sm"
         [disabled]="!vm.activeItemCollection || vm.collectionBusy"
@@ -71,7 +94,7 @@
             CSV exportieren
           </button>
           <button class="btn btn-danger btn-sm" (click)="vm.deleteActiveCollection()">
-            Kollektion löschen
+            Auswahlliste löschen
           </button>
         </div>
       </div>

--- a/frontend/src/app/views/item-explorer/components/column-manager-dialog/item-explorer-column-manager-dialog.component.css
+++ b/frontend/src/app/views/item-explorer/components/column-manager-dialog/item-explorer-column-manager-dialog.component.css
@@ -8,6 +8,36 @@
 .column-manager-toolbar .search-container {
   flex: 1;
 }
+.base-column-settings {
+  margin-bottom: 18px;
+}
+.base-column-settings h3,
+.overlay-content > h3 {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+}
+.base-column-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  cursor: pointer;
+}
+.base-column-option input {
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+}
+.base-column-option span,
+.base-column-option small {
+  display: block;
+}
+.base-column-option small {
+  margin-top: 3px;
+  color: var(--color-text-secondary);
+}
 .column-grid {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/views/item-explorer/components/column-manager-dialog/item-explorer-column-manager-dialog.component.html
+++ b/frontend/src/app/views/item-explorer/components/column-manager-dialog/item-explorer-column-manager-dialog.component.html
@@ -13,6 +13,25 @@
         <button class="btn btn-sm btn-outline" (click)="vm.closeColumnManager()">✕</button>
       </div>
       <div class="overlay-content">
+        <section class="base-column-settings" aria-labelledby="base-columns-heading">
+          <h3 id="base-columns-heading">Grundspalten</h3>
+          <label class="base-column-option">
+            <input
+              type="checkbox"
+              [checked]="vm.metadataSettings.referenceNumberVisible === true"
+              (change)="vm.toggleReferenceNumberVisibility()"
+            />
+            <span>
+              <strong>Referenz-Nr.</strong>
+              <small
+                >Stabile Nummer im vollständigen Itembestand; bei ausgeblendeten Zeilen sind Lücken
+                sichtbar.</small
+              >
+            </span>
+          </label>
+        </section>
+
+        <h3>Metadatenspalten</h3>
         <div class="column-manager-toolbar">
           <div class="search-container">
             <input
@@ -25,7 +44,10 @@
           <button
             class="btn btn-outline btn-sm"
             (click)="vm.resetToDefault()"
-            [disabled]="!vm.metadataSettings.visible.length"
+            [disabled]="
+              !vm.metadataSettings.visible.length &&
+              vm.metadataSettings.referenceNumberVisible !== true
+            "
           >
             🔄 Standard
           </button>

--- a/frontend/src/app/views/item-explorer/components/header/item-explorer-header.component.css
+++ b/frontend/src/app/views/item-explorer/components/header/item-explorer-header.component.css
@@ -26,6 +26,12 @@
   gap: 16px;
   flex-wrap: wrap;
 }
+.renumber-blocked-hint {
+  width: 100%;
+  color: #8a5a00;
+  font-size: 0.8rem;
+  text-align: right;
+}
 .explorer-status-bar {
   margin-bottom: 12px;
   padding: 10px 14px;
@@ -115,5 +121,9 @@
 
   .status-meta {
     overflow-wrap: anywhere;
+  }
+
+  .renumber-blocked-hint {
+    text-align: left;
   }
 }

--- a/frontend/src/app/views/item-explorer/components/header/item-explorer-header.component.html
+++ b/frontend/src/app/views/item-explorer/components/header/item-explorer-header.component.html
@@ -4,7 +4,7 @@
   </div>
   <div class="header-actions">
     <span class="item-count"
-      >{{ vm.filteredItems.length }} von {{ vm.visibleItemsCount }} Zeilen</span
+      >{{ vm.filteredItems.length }} von {{ vm.totalItemsCount }} Zeilen</span
     >
     <button
       class="btn btn-outline btn-sm"
@@ -89,7 +89,7 @@
         [disabled]="vm.isRenumberingBlocked()"
         [title]="vm.getRenumberingActionTitle()"
       >
-        🔢 Nummerierung neu
+        🔢 Referenznummern neu vergeben
       </button>
       <button
         class="btn btn-outline btn-sm"
@@ -115,6 +115,11 @@
       <button class="btn btn-outline btn-sm" (click)="vm.showHistory()">🕒 Änderungsverlauf</button>
     }
   </div>
+  @if (vm.canEditExplorer && vm.isRenumberingBlocked()) {
+    <div class="renumber-blocked-hint" role="status">
+      {{ vm.getRenumberingBlockedMessage() }}
+    </div>
+  }
 </div>
 
 @if (vm.showReadOnlyPreviewBanner) {
@@ -198,18 +203,29 @@
   </div>
 }
 
+@if (vm.draftSaveSuccessMessage) {
+  <div class="alert alert-info" style="margin-bottom: 12px" aria-live="polite">
+    {{ vm.draftSaveSuccessMessage }}
+  </div>
+}
+
 <app-confirm-dialog
   [open]="vm.showRenumberDialog"
-  title="Nummerierung neu berechnen"
-  message="Alle aktuell vorhandenen Zeilen werden nach Item-ID und Sub-ID neu nummeriert."
+  title="Referenznummern neu vergeben"
+  [message]="
+    'Alle ' +
+    vm.totalItemsCount +
+    ' Zeilen des vollständigen Itembestands werden nach Item-ID und Sub-ID neu nummeriert.'
+  "
   [details]="[
-    'Bisherige Nummernlücken können sich dadurch schließen.',
-    'Die Nummern bleiben anschließend bei Sortierung und Filterung unverändert.',
+    'Auch aktuell ausgeblendete Zeilen werden einbezogen.',
+    'Bisherige Referenznummern ändern sich; Lücken im vollständigen Bestand werden geschlossen.',
+    'Die sichtbare Spalte Pos. bleibt davon unberührt und wird aus der aktuellen Ansicht berechnet.',
   ]"
   [error]="vm.renumberError"
   [busy]="vm.renumberBusy"
-  busyLabel="Nummeriere Zeilen..."
-  confirmLabel="Nummerierung neu"
+  busyLabel="Referenznummern werden vergeben ..."
+  confirmLabel="Referenznummern neu vergeben"
   confirmVariant="primary"
   (confirmed)="vm.confirmRenumber()"
   (cancelled)="vm.closeRenumberDialog()"

--- a/frontend/src/app/views/item-explorer/components/item-explorer-presentational-components.spec.ts
+++ b/frontend/src/app/views/item-explorer/components/item-explorer-presentational-components.spec.ts
@@ -87,6 +87,6 @@ describe('ItemExplorer presentational components', () => {
   });
 
   it('gives the collection selector an accessible name', () => {
-    expect(collectionsTemplate).toContain('aria-label="Aktive Kollektion auswählen"');
+    expect(collectionsTemplate).toContain('aria-label="Aktive persönliche Auswahlliste auswählen"');
   });
 });

--- a/frontend/src/app/views/item-explorer/components/table/item-explorer-table.component.css
+++ b/frontend/src/app/views/item-explorer/components/table/item-explorer-table.component.css
@@ -22,6 +22,23 @@
   gap: 8px;
   flex-wrap: wrap;
 }
+.visibility-summary {
+  display: flex;
+  gap: 8px 16px;
+  flex-wrap: wrap;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+}
+.collection-empty-state {
+  padding: 32px !important;
+  text-align: center !important;
+  color: var(--color-text-secondary);
+}
+.collection-empty-state strong,
+.collection-empty-state span {
+  display: block;
+  margin-bottom: 8px;
+}
 .item-list-loading {
   display: flex;
   align-items: center;
@@ -124,6 +141,12 @@
   background-color: var(--color-surface) !important;
   z-index: 31;
   font-variant-numeric: tabular-nums;
+}
+.reference-number-col {
+  left: 72px;
+}
+.reference-number-col + .sticky-col {
+  left: 144px;
 }
 .explorer-table th.number-col {
   background-color: var(--color-bg) !important;

--- a/frontend/src/app/views/item-explorer/components/table/item-explorer-table.component.html
+++ b/frontend/src/app/views/item-explorer/components/table/item-explorer-table.component.html
@@ -24,6 +24,18 @@
         </button>
       </div>
     }
+    @if (vm.hiddenMissingDifficultyItemsCount > 0 || vm.hiddenExcludedItemsCount > 0) {
+      <div class="visibility-summary" aria-live="polite">
+        @if (vm.hiddenMissingDifficultyItemsCount > 0) {
+          <span
+            >{{ vm.hiddenMissingDifficultyItemsCount }} ohne Itemschwierigkeit ausgeblendet</span
+          >
+        }
+        @if (vm.hiddenExcludedItemsCount > 0) {
+          <span>{{ vm.hiddenExcludedItemsCount }} ausgeschlossene Items ausgeblendet</span>
+        }
+      </div>
+    }
     @if (vm.showExplorerKeyboardHints) {
       <div class="help-text">
         Tastatur: <kbd>/</kbd> Filter, <kbd>↑</kbd>/<kbd>↓</kbd> Auswahl, <kbd>Pos1</kbd>/<kbd
@@ -101,11 +113,20 @@
       <thead>
         <tr>
           @if (vm.enableItemCollections) {
-            <th class="collection-select-col" title="Zur aktiven Kollektion hinzufügen">✓</th>
+            <th class="collection-select-col" title="Zur aktiven Auswahlliste hinzufügen">✓</th>
           }
-          <th (click)="vm.sortBy('rowNumber')" class="sortable number-col">
-            Nr. {{ vm.getSortIndicator('rowNumber') }}
+          <th class="number-col" title="Position in der aktuell gefilterten und sortierten Liste">
+            Pos.
           </th>
+          @if (vm.referenceNumberVisible) {
+            <th
+              (click)="vm.sortBy('rowNumber')"
+              class="sortable number-col reference-number-col"
+              title="Stabile Nummer im vollständigen Itembestand; bei ausgeblendeten Zeilen sind Lücken sichtbar."
+            >
+              Referenz-Nr. {{ vm.getSortIndicator('rowNumber') }}
+            </th>
+          }
           <th (click)="vm.sortBy('itemId')" class="sortable sticky-col">
             Item-ID {{ vm.getSortIndicator('itemId') }}
           </th>
@@ -146,6 +167,9 @@
             <th class="collection-select-col"></th>
           }
           <th class="number-col"></th>
+          @if (vm.referenceNumberVisible) {
+            <th class="number-col reference-number-col"></th>
+          }
           <th class="sticky-col">
             <input
               class="col-filter-input"
@@ -274,11 +298,19 @@
                   [checked]="vm.isItemInActiveCollection(item)"
                   [disabled]="vm.collectionBusy || vm.collectionLoadState !== 'loaded'"
                   (change)="vm.toggleItemInActiveCollection(item)"
-                  [attr.aria-label]="'Item ' + item.itemId + ' in Kollektion auswählen'"
+                  [attr.aria-label]="'Item ' + item.itemId + ' in Auswahlliste auswählen'"
                 />
               </td>
             }
-            <td class="number-col">{{ item.rowNumber }}</td>
+            <td class="number-col">{{ i + 1 }}</td>
+            @if (vm.referenceNumberVisible) {
+              <td
+                class="number-col reference-number-col"
+                title="Stabile Nummer im vollständigen Itembestand"
+              >
+                {{ item.rowNumber }}
+              </td>
+            }
             <td class="sticky-col">
               <div class="item-id-cell">
                 <code
@@ -414,6 +446,25 @@
                 ></textarea>
               </td>
             }
+          </tr>
+        }
+        @if (
+          vm.collectionViewMode === 'active' &&
+          vm.activeItemCollection &&
+          vm.activeItemCollection.rowKeys.length === 0
+        ) {
+          <tr>
+            <td colspan="100" class="collection-empty-state">
+              <strong>Diese Auswahlliste ist noch leer.</strong>
+              <span>Fügen Sie Items hinzu oder zeigen Sie wieder alle Items an.</span>
+              <button
+                class="btn btn-outline btn-sm"
+                type="button"
+                (click)="vm.setCollectionViewMode('all')"
+              >
+                Zu Alle Items wechseln
+              </button>
+            </td>
           </tr>
         }
       </tbody>

--- a/frontend/src/app/views/item-explorer/components/table/item-explorer-table.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/components/table/item-explorer-table.component.spec.ts
@@ -11,6 +11,18 @@ describe('ItemExplorerTableComponent', () => {
     );
   });
 
+  it('renders a gapless view position and an optional stable reference number', () => {
+    expect(template).toContain('<td class="number-col">{{ i + 1 }}</td>');
+    expect(template).toContain('@if (vm.referenceNumberVisible)');
+    expect(template).toContain('Referenz-Nr.');
+    expect(template).toContain('{{ item.rowNumber }}');
+  });
+
+  it('offers a dedicated empty state for an empty active selection list', () => {
+    expect(template).toContain('Diese Auswahlliste ist noch leer.');
+    expect(template).toContain('(click)="vm.setCollectionViewMode(\'all\')"');
+  });
+
   it('owns filter focus and selection scrolling', () => {
     vi.useFakeTimers();
     const feature = {

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
@@ -962,6 +962,109 @@ describe('ItemExplorerFacade', () => {
     ]);
   });
 
+  it('falls back to task sorting when the saved reference-number sort is hidden', () => {
+    const component = createFacade();
+    component.sortField = 'rowNumber';
+    component.sortDir = 'desc';
+    component.metadataSettings.referenceNumberVisible = false;
+    component.items = [
+      {
+        itemId: 'ITEM_2',
+        uuid: 'uuid-2',
+        rowKey: 'uuid-2',
+        rowNumber: 2,
+        unitId: 'UNIT_2',
+        unitLabel: 'Aufgabe B',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1',
+        rowNumber: 9,
+        unitId: 'UNIT_1',
+        unitLabel: 'Aufgabe A',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+    ];
+
+    component.applyFilter(false);
+
+    expect(component.sortField).toBe('unitLabel');
+    expect(component.sortDir).toBe('asc');
+    expect(component.filteredItems.map((item) => item.rowNumber)).toEqual([9, 2]);
+  });
+
+  it('keeps stable reference numbers sortable when their column is visible', () => {
+    const component = createFacade();
+    component.metadataSettings.referenceNumberVisible = true;
+    component.items = [
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1',
+        rowNumber: 8,
+        unitId: 'UNIT_1',
+        unitLabel: 'Aufgabe A',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+      {
+        itemId: 'ITEM_2',
+        uuid: 'uuid-2',
+        rowKey: 'uuid-2',
+        rowNumber: 3,
+        unitId: 'UNIT_2',
+        unitLabel: 'Aufgabe B',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+    ];
+    component.filteredItems = [...component.items];
+
+    component.sortBy('rowNumber');
+
+    expect(component.filteredItems.map((item) => item.rowNumber)).toEqual([3, 8]);
+  });
+
+  it('treats reference-number visibility as an opt-in ACP setting', () => {
+    const component = createFacade();
+
+    expect((component as any).resolveMetadataSettings({}).referenceNumberVisible).toBe(false);
+    expect(
+      (component as any).resolveMetadataSettings({
+        metadataColumns: { referenceNumberVisible: true },
+      }).referenceNumberVisible,
+    ).toBe(true);
+  });
+
+  it('restores column settings when the column manager is cancelled', () => {
+    const component = createFacade();
+    component.metadataSettings = {
+      visible: ['subject'],
+      order: ['subject'],
+      referenceNumberVisible: false,
+    };
+
+    component.openColumnManager();
+    component.toggleReferenceNumberVisibility();
+    expect(component.referenceNumberVisible).toBe(true);
+
+    component.closeColumnManager();
+
+    expect(component.metadataSettings).toEqual({
+      visible: ['subject'],
+      order: ['subject'],
+      referenceNumberVisible: false,
+    });
+  });
+
   it('ignores stale item-list responses after a newer reload completes', () => {
     const firstLoad = new Subject<any>();
     const secondLoad = new Subject<any>();
@@ -1061,7 +1164,9 @@ describe('ItemExplorerFacade', () => {
 
     expect(recalculateItemRowNumbers).toHaveBeenCalledWith('acp-1');
     expect(component.showRenumberDialog).toBe(false);
-    expect(component.numberingSuccessMessage).toBe('Eine Zeile wurde neu nummeriert.');
+    expect(component.numberingSuccessMessage).toBe(
+      'Eine Referenznummer im vollständigen Itembestand wurde neu vergeben. 0 Zeilen werden aktuell angezeigt.',
+    );
     expect(reloadItems).toHaveBeenCalledTimes(1);
   });
 
@@ -1800,7 +1905,7 @@ describe('ItemExplorerFacade', () => {
     expect(component.visibleItemsCount).toBe(2);
   });
 
-  it('keeps the header total on the visible item base when text filters narrow the list', () => {
+  it('keeps the header total on the complete item base when filters narrow the list', () => {
     const component = createFacade();
     component.items = [
       {
@@ -1838,6 +1943,25 @@ describe('ItemExplorerFacade', () => {
 
     expect(component.filteredItems.map((item) => item.uuid)).toEqual(['uuid-1']);
     expect(component.visibleItemsCount).toBe(2);
+    expect(component.totalItemsCount).toBe(3);
+    expect(component.hiddenExcludedItemsCount).toBe(1);
+  });
+
+  it('reports mutually exclusive base-visibility reasons', () => {
+    const component = createFacade();
+    component.showOnlyItemsWithEmpiricalDifficulty = true;
+    component.hasEmpiricalDifficulty = true;
+    component.items = [
+      { uuid: 'excluded-missing', excluded: true },
+      { uuid: 'visible-missing' },
+      { uuid: 'visible', empiricalDifficulty: 0.2 },
+    ] as any;
+
+    expect(component.hiddenExcludedItemsCount).toBe(1);
+    expect(component.hiddenMissingDifficultyItemsCount).toBe(1);
+    expect(component.hiddenExcludedItemsCount + component.hiddenMissingDifficultyItemsCount).toBe(
+      2,
+    );
   });
 
   it('counts only items with empirical difficulty when that visibility rule is active', () => {
@@ -3735,6 +3859,116 @@ describe('ItemExplorerFacade', () => {
     expect(component.activeItemCollection?.version).toBe(2);
   });
 
+  it('persists and applies the active personal selection view after base visibility rules', async () => {
+    const payload = {
+      activeCollectionId: 'collection-1',
+      collectionViewMode: 'active' as const,
+      collections: [
+        {
+          id: 'collection-1',
+          name: 'Auswahl',
+          rowKeys: ['visible', 'excluded'],
+          version: 1,
+          createdAt: '',
+          updatedAt: '',
+          unavailableRowKeys: [],
+          summary: {} as any,
+        },
+      ],
+    };
+    const activateItemCollection = vi.fn().mockReturnValue(of(payload));
+    const component = createFacade({
+      api: { activateItemCollection },
+      authService: { isLoggedIn: true },
+    });
+    component.acpId = 'acp-1';
+    component.items = [
+      {
+        itemId: 'VISIBLE',
+        uuid: 'visible',
+        rowKey: 'visible',
+        unitId: 'UNIT_1',
+        unitLabel: 'Aufgabe A',
+        description: 'Treffer',
+        variableId: '',
+        metadata: {},
+      },
+      {
+        itemId: 'EXCLUDED',
+        uuid: 'excluded',
+        rowKey: 'excluded',
+        unitId: 'UNIT_2',
+        unitLabel: 'Aufgabe B',
+        description: 'Treffer',
+        variableId: '',
+        metadata: {},
+        excluded: true,
+      },
+      {
+        itemId: 'OTHER',
+        uuid: 'other',
+        rowKey: 'other',
+        unitId: 'UNIT_3',
+        unitLabel: 'Aufgabe C',
+        description: 'Treffer',
+        variableId: '',
+        metadata: {},
+      },
+    ];
+    component.itemCollections = payload.collections;
+    component.activeCollectionId = 'collection-1';
+    component.collectionLoadState = 'loaded';
+
+    await component.setCollectionViewMode('active');
+
+    expect(activateItemCollection).toHaveBeenCalledWith(
+      'acp-1',
+      'collection-1',
+      'read-only',
+      'active',
+    );
+    expect(component.filteredItems.map((item) => item.rowKey)).toEqual(['visible']);
+  });
+
+  it('rolls the personal selection view back when persistence fails', async () => {
+    const component = createFacade({
+      api: { activateItemCollection: vi.fn(() => throwError(() => new Error('offline'))) },
+      authService: { isLoggedIn: true },
+    });
+    component.items = [
+      {
+        itemId: 'ITEM',
+        uuid: 'item',
+        rowKey: 'item',
+        unitId: 'UNIT',
+        unitLabel: 'Aufgabe',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+    ];
+    component.itemCollections = [
+      {
+        id: 'collection-1',
+        name: 'Auswahl',
+        rowKeys: [],
+        version: 1,
+        createdAt: '',
+        updatedAt: '',
+        unavailableRowKeys: [],
+        summary: {} as any,
+      },
+    ];
+    component.activeCollectionId = 'collection-1';
+    component.applyFilter(false);
+
+    await component.setCollectionViewMode('active');
+
+    expect(component.collectionViewMode).toBe('all');
+    expect(component.filteredItems).toHaveLength(1);
+    expect(component.collectionError).toContain('konnte nicht gespeichert werden');
+  });
+
   it('keeps the collection conflict visible while reloading the latest version', async () => {
     const freshCollection = {
       id: 'collection-1',
@@ -3766,7 +4000,7 @@ describe('ItemExplorerFacade', () => {
     expect(component.activeItemCollection?.name).toBe('Server-Auswahl');
     expect(component.collectionLoadState).toBe('loaded');
     expect(component.collectionError).toBe(
-      'Die Kollektion wurde parallel geändert und wird neu geladen.',
+      'Die Auswahlliste wurde parallel geändert und wird neu geladen.',
     );
   });
 
@@ -4097,5 +4331,52 @@ describe('ItemExplorerFacade', () => {
       expect.objectContaining({ id: 'collection-b', name: 'User B' }),
     ]);
     expect(component.activeCollectionId).toBe('collection-b');
+  });
+
+  it('immediately removes the previous identity collection filter on logout', () => {
+    let token: string | null = createJwt('user-a');
+    const component = createFacade({
+      authService: { getToken: () => token },
+    });
+    component.enableItemCollections = true;
+    component.items = [
+      {
+        itemId: 'ITEM_1',
+        uuid: 'uuid-1',
+        rowKey: 'uuid-1',
+        unitId: 'UNIT_1',
+        unitLabel: 'Aufgabe A',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+      {
+        itemId: 'ITEM_2',
+        uuid: 'uuid-2',
+        rowKey: 'uuid-2',
+        unitId: 'UNIT_2',
+        unitLabel: 'Aufgabe B',
+        description: '',
+        variableId: '',
+        metadata: {},
+      },
+    ];
+    component.itemCollections = [
+      {
+        id: 'collection-a',
+        name: 'User A',
+        rowKeys: ['uuid-1'],
+      } as any,
+    ];
+    component.activeCollectionId = 'collection-a';
+    component.collectionViewMode = 'active';
+    component.applyFilter(false);
+    expect(component.filteredItems.map((item) => item.rowKey)).toEqual(['uuid-1']);
+
+    token = null;
+    (component as any).syncItemCollectionSession();
+
+    expect(component.collectionViewMode).toBe('all');
+    expect(component.filteredItems.map((item) => item.rowKey)).toEqual(['uuid-1', 'uuid-2']);
   });
 });

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.ts
@@ -199,6 +199,7 @@ export class ItemExplorerFacade implements OnDestroy {
   enableItemCollections = false;
   itemCollections: ItemCollection[] = [];
   activeCollectionId: string | null = null;
+  collectionViewMode: 'all' | 'active' = 'all';
   collectionLoadState: 'idle' | 'loading' | 'loaded' | 'error' = 'idle';
   collectionBusy = false;
   collectionError = '';
@@ -246,7 +247,12 @@ export class ItemExplorerFacade implements OnDestroy {
   perspectiveSwitchBusy = false;
   showColumnManager = false;
   allColumns: MetadataColumn[] = [];
-  metadataSettings: MetadataSettings = { visible: [], order: [] };
+  metadataSettings: MetadataSettings = {
+    visible: [],
+    order: [],
+    referenceNumberVisible: false,
+  };
+  private columnManagerOriginalSettings: MetadataSettings | null = null;
   columnFilterText = '';
   itemOrder: string[] = [];
 
@@ -285,6 +291,8 @@ export class ItemExplorerFacade implements OnDestroy {
   renumberBusy = false;
   renumberError = '';
   numberingSuccessMessage = '';
+  draftSaveSuccessMessage = '';
+  private draftSaveMessageResetTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Leave with pending changes dialog
   showLeaveWithChangesDialog = false;
@@ -443,8 +451,30 @@ export class ItemExplorerFacade implements OnDestroy {
     return this.items.filter((item) => this.isItemExcluded(item)).length;
   }
 
+  get totalItemsCount(): number {
+    return this.items.length;
+  }
+
   get visibleItemsCount(): number {
     return this.items.filter((item) => this.isItemVisibleByBaseRules(item)).length;
+  }
+
+  get hiddenExcludedItemsCount(): number {
+    if (this.showExcludedItems) return 0;
+    return this.items.filter((item) => this.isItemExcluded(item)).length;
+  }
+
+  get hiddenMissingDifficultyItemsCount(): number {
+    if (!this.showOnlyItemsWithEmpiricalDifficulty || !this.hasEmpiricalDifficulty) return 0;
+    return this.items.filter(
+      (item) =>
+        (this.showExcludedItems || !this.isItemExcluded(item)) &&
+        (item.empiricalDifficulty === undefined || item.empiricalDifficulty === null),
+    ).length;
+  }
+
+  get referenceNumberVisible(): boolean {
+    return this.metadataSettings.referenceNumberVisible === true;
   }
 
   get activeItemCollection(): ItemCollection | null {
@@ -1007,6 +1037,10 @@ export class ItemExplorerFacade implements OnDestroy {
       clearTimeout(this.saveStatusResetTimeout);
       this.saveStatusResetTimeout = null;
     }
+    if (this.draftSaveMessageResetTimeout) {
+      clearTimeout(this.draftSaveMessageResetTimeout);
+      this.draftSaveMessageResetTimeout = null;
+    }
     this.personalDataSessionIdentity = null;
     this.collectionSessionIdentity = null;
     this.pendingPersonalRowUpdates.clear();
@@ -1143,7 +1177,7 @@ export class ItemExplorerFacade implements OnDestroy {
         this.collectionLoadState === 'idle'
       ) {
         this.collectionLoadState = 'error';
-        this.collectionError = 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.';
+        this.collectionError = 'Für persönliche Auswahllisten ist eine Anmeldung erforderlich.';
       }
       return;
     }
@@ -1152,15 +1186,17 @@ export class ItemExplorerFacade implements OnDestroy {
     this.collectionSessionIdentity = nextIdentity;
     this.itemCollections = [];
     this.activeCollectionId = null;
+    this.collectionViewMode = 'all';
     this.collectionBusy = false;
     this.collectionError = '';
     this.collectionLoadState = 'idle';
     this.showCollectionDrawer = false;
+    this.applyFilter(false);
     if (nextIdentity) {
       this.loadItemCollections();
     } else if (this.enableItemCollections) {
       this.collectionLoadState = 'error';
-      this.collectionError = 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.';
+      this.collectionError = 'Für persönliche Auswahllisten ist eine Anmeldung erforderlich.';
     }
   }
 
@@ -1187,7 +1223,7 @@ export class ItemExplorerFacade implements OnDestroy {
     const session = this.getItemCollectionSession();
     if (!session.identity) {
       this.collectionLoadState = 'error';
-      this.collectionError = 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.';
+      this.collectionError = 'Für persönliche Auswahllisten ist eine Anmeldung erforderlich.';
       return;
     }
     this.collectionLoadState = 'loading';
@@ -1198,8 +1234,7 @@ export class ItemExplorerFacade implements OnDestroy {
       .subscribe({
         next: (payload) => {
           if (!this.isCurrentItemCollectionSession(session)) return;
-          this.itemCollections = payload.collections || [];
-          this.activeCollectionId = payload.activeCollectionId || null;
+          this.applyItemCollectionsPayload(payload);
           this.collectionLoadState = 'loaded';
           if (!this.itemListLoading && !this.itemListError) {
             this.recalculateCollectionSummaries();
@@ -1210,8 +1245,8 @@ export class ItemExplorerFacade implements OnDestroy {
           this.collectionLoadState = 'error';
           this.collectionError =
             error?.status === 401
-              ? 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.'
-              : 'Kollektionen konnten nicht geladen werden.';
+              ? 'Für persönliche Auswahllisten ist eine Anmeldung erforderlich.'
+              : 'Auswahllisten konnten nicht geladen werden.';
         },
       });
   }
@@ -1220,15 +1255,15 @@ export class ItemExplorerFacade implements OnDestroy {
     if (this.collectionBusy) return null;
     const session = this.getItemCollectionSession();
     if (!session.identity) {
-      this.collectionError = 'Für persönliche Kollektionen ist eine Anmeldung erforderlich.';
+      this.collectionError = 'Für persönliche Auswahllisten ist eine Anmeldung erforderlich.';
       return null;
     }
     this.collectionBusy = true;
     this.collectionError = '';
     const name =
       this.itemCollections.length === 0
-        ? 'Meine Kollektion'
-        : `Kollektion ${this.itemCollections.length + 1}`;
+        ? 'Meine Auswahlliste'
+        : `Auswahlliste ${this.itemCollections.length + 1}`;
     try {
       const payload = await firstValueFrom(
         this.api.createItemCollection(this.acpId, name, this.getPerspectiveForViewerRequests()),
@@ -1238,7 +1273,7 @@ export class ItemExplorerFacade implements OnDestroy {
       return this.activeItemCollection;
     } catch {
       if (!this.isCurrentItemCollectionSession(session)) return null;
-      this.collectionError = 'Die Kollektion konnte nicht erstellt werden.';
+      this.collectionError = 'Die Auswahlliste konnte nicht erstellt werden.';
       return null;
     } finally {
       if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
@@ -1257,13 +1292,14 @@ export class ItemExplorerFacade implements OnDestroy {
           this.acpId,
           collectionId || null,
           this.getPerspectiveForViewerRequests(),
+          this.collectionViewMode,
         ),
       );
       if (!this.isCurrentItemCollectionSession(session)) return;
       this.applyItemCollectionsPayload(payload);
     } catch {
       if (!this.isCurrentItemCollectionSession(session)) return;
-      this.collectionError = 'Die aktive Kollektion konnte nicht gespeichert werden.';
+      this.collectionError = 'Die aktive Auswahlliste konnte nicht gespeichert werden.';
     } finally {
       if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
     }
@@ -1299,7 +1335,7 @@ export class ItemExplorerFacade implements OnDestroy {
   async renameActiveCollection() {
     const collection = this.activeItemCollection;
     if (!collection || this.collectionBusy) return;
-    const name = window.prompt('Name der Kollektion', collection.name)?.trim();
+    const name = window.prompt('Name der Auswahlliste', collection.name)?.trim();
     if (!name || name === collection.name) return;
     await this.persistActiveCollectionUpdate({ name });
   }
@@ -1307,7 +1343,7 @@ export class ItemExplorerFacade implements OnDestroy {
   async deleteActiveCollection() {
     const collection = this.activeItemCollection;
     if (!collection || this.collectionBusy) return;
-    if (!window.confirm(`Kollektion „${collection.name}“ löschen?`)) return;
+    if (!window.confirm(`Auswahlliste „${collection.name}“ löschen?`)) return;
     const session = this.getItemCollectionSession();
     if (!session.identity) return;
     this.collectionBusy = true;
@@ -1325,7 +1361,7 @@ export class ItemExplorerFacade implements OnDestroy {
       if (!this.activeItemCollection) this.showCollectionDrawer = false;
     } catch {
       if (!this.isCurrentItemCollectionSession(session)) return;
-      this.collectionError = 'Die Kollektion konnte nicht gelöscht werden.';
+      this.collectionError = 'Die Auswahlliste konnte nicht gelöscht werden.';
     } finally {
       if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
     }
@@ -1355,7 +1391,7 @@ export class ItemExplorerFacade implements OnDestroy {
       URL.revokeObjectURL(url);
     } catch {
       if (!this.isCurrentItemCollectionSession(session)) return;
-      this.collectionError = 'Die Kollektion konnte nicht exportiert werden.';
+      this.collectionError = 'Die Auswahlliste konnte nicht exportiert werden.';
     } finally {
       if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
     }
@@ -1384,6 +1420,7 @@ export class ItemExplorerFacade implements OnDestroy {
     if (update.name !== undefined) collection.name = update.name;
     if (update.rowKeys !== undefined) collection.rowKeys = [...update.rowKeys];
     this.recalculateCollectionSummaries();
+    this.applyFilter(false);
     this.collectionBusy = true;
     this.collectionError = '';
     try {
@@ -1401,10 +1438,11 @@ export class ItemExplorerFacade implements OnDestroy {
       if (!this.isCurrentItemCollectionSession(session)) return;
       const index = this.itemCollections.findIndex((candidate) => candidate.id === previous.id);
       if (index >= 0) this.itemCollections[index] = previous;
+      this.applyFilter(false);
       this.collectionError =
         error?.status === 409
-          ? 'Die Kollektion wurde parallel geändert und wird neu geladen.'
-          : 'Die Kollektion konnte nicht gespeichert werden.';
+          ? 'Die Auswahlliste wurde parallel geändert und wird neu geladen.'
+          : 'Die Auswahlliste konnte nicht gespeichert werden.';
       if (error?.status === 409) this.loadItemCollections(true);
     } finally {
       if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
@@ -1413,13 +1451,48 @@ export class ItemExplorerFacade implements OnDestroy {
 
   private applyItemCollectionsPayload(payload: {
     activeCollectionId: string | null;
+    collectionViewMode?: 'all' | 'active';
     collections: ItemCollection[];
   }) {
     this.itemCollections = payload.collections || [];
     this.activeCollectionId = payload.activeCollectionId || null;
+    this.collectionViewMode =
+      payload.collectionViewMode === 'active' && this.activeCollectionId ? 'active' : 'all';
     this.collectionLoadState = 'loaded';
     if (!this.itemListLoading && !this.itemListError) {
       this.recalculateCollectionSummaries();
+    }
+    this.applyFilter(false);
+  }
+
+  async setCollectionViewMode(mode: 'all' | 'active') {
+    const nextMode = mode === 'active' && this.activeItemCollection ? 'active' : 'all';
+    if (nextMode === this.collectionViewMode || this.collectionBusy) return;
+    const session = this.getItemCollectionSession();
+    if (!session.identity) return;
+    const previousMode = this.collectionViewMode;
+    this.collectionViewMode = nextMode;
+    this.collectionBusy = true;
+    this.collectionError = '';
+    this.applyFilter(false);
+    try {
+      const payload = await firstValueFrom(
+        this.api.activateItemCollection(
+          this.acpId,
+          this.activeCollectionId,
+          this.getPerspectiveForViewerRequests(),
+          nextMode,
+        ),
+      );
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      this.applyItemCollectionsPayload(payload);
+    } catch {
+      if (!this.isCurrentItemCollectionSession(session)) return;
+      this.collectionViewMode = previousMode;
+      this.applyFilter(false);
+      this.collectionError = 'Die Ansicht der Auswahlliste konnte nicht gespeichert werden.';
+    } finally {
+      if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
     }
   }
 
@@ -1479,9 +1552,17 @@ export class ItemExplorerFacade implements OnDestroy {
   // --- Filtering ---
   applyFilter(shouldPersist = true) {
     const term = this.filterText.toLowerCase();
+    const activeCollectionRowKeys =
+      this.collectionViewMode === 'active' && this.activeItemCollection
+        ? new Set(this.activeItemCollection.rowKeys)
+        : null;
 
     this.filteredItems = this.items.filter((item) => {
       if (!this.isItemVisibleByBaseRules(item)) {
+        return false;
+      }
+
+      if (activeCollectionRowKeys && !activeCollectionRowKeys.has(item.rowKey)) {
         return false;
       }
 
@@ -1704,6 +1785,7 @@ export class ItemExplorerFacade implements OnDestroy {
   }
 
   private applySort(shouldPersist = true) {
+    this.ensureVisibleSortField();
     if (this.sortField === '__manual__') {
       const rank = new Map<string, number>();
       this.itemOrder.forEach((entry, idx) => rank.set(entry, idx));
@@ -1768,6 +1850,13 @@ export class ItemExplorerFacade implements OnDestroy {
     if (shouldPersist) {
       this.saveUiPreferences();
     }
+  }
+
+  private ensureVisibleSortField() {
+    if (this.sortField !== 'rowNumber' || this.referenceNumberVisible) return;
+    this.sortField = DEFAULT_EXPLORER_SORT_FIELD;
+    this.sortIsMeta = false;
+    this.sortDir = DEFAULT_EXPLORER_SORT_DIR;
   }
 
   private compareSortValues(aVal: unknown, bVal: unknown, direction: 'asc' | 'desc'): number {
@@ -1956,10 +2045,11 @@ export class ItemExplorerFacade implements OnDestroy {
           const count = Number(result?.renumberedCount) || 0;
           this.renumberBusy = false;
           this.closeRenumberDialog();
-          this.numberingSuccessMessage =
+          this.numberingSuccessMessage = `${
             count === 1
-              ? 'Eine Zeile wurde neu nummeriert.'
-              : `${count} Zeilen wurden neu nummeriert.`;
+              ? 'Eine Referenznummer im vollständigen Itembestand wurde'
+              : `${count} Referenznummern im vollständigen Itembestand wurden`
+          } neu vergeben. ${this.filteredItems.length} Zeilen werden aktuell angezeigt.`;
           this.reloadItems();
         },
         error: (error) => {
@@ -1987,10 +2077,10 @@ export class ItemExplorerFacade implements OnDestroy {
   getRenumberingActionTitle(): string {
     return this.isRenumberingBlocked()
       ? this.getRenumberingBlockedMessage()
-      : 'Stabile Zeilennummerierung neu berechnen';
+      : 'Referenznummern im vollständigen Itembestand neu vergeben';
   }
 
-  private getRenumberingBlockedMessage(): string {
+  getRenumberingBlockedMessage(): string {
     if (!this.latestExplorerState) {
       return 'Bitte warten Sie, bis der Explorer-Status geladen wurde.';
     }
@@ -2002,7 +2092,7 @@ export class ItemExplorerFacade implements OnDestroy {
     }
     return this.explorerUiStatus === 'SAVING'
       ? 'Bitte warten Sie, bis die Explorer-Änderungen gespeichert wurden.'
-      : 'Bitte speichern oder verwerfen Sie den Entwurf, bevor Sie neu nummerieren.';
+      : 'Bitte speichern oder verwerfen Sie den Entwurf, bevor Sie Referenznummern neu vergeben.';
   }
 
   getSortIndicator(field: string): string {
@@ -4024,6 +4114,9 @@ export class ItemExplorerFacade implements OnDestroy {
 
   saveMetadataSettings() {
     this.columns = this.filterVisibleColumns(this.allColumns);
+    this.ensureVisibleSortField();
+    this.applySort(false);
+    this.columnManagerOriginalSettings = null;
     this.showColumnManager = false;
     this.restoreFocusAfterOverlayClose();
     this.queueDraftPatch(
@@ -4032,6 +4125,7 @@ export class ItemExplorerFacade implements OnDestroy {
         metadataColumns: {
           visible: [...this.metadataSettings.visible],
           order: [...this.metadataSettings.order],
+          referenceNumberVisible: this.referenceNumberVisible,
         },
       },
       true,
@@ -4039,8 +4133,12 @@ export class ItemExplorerFacade implements OnDestroy {
   }
 
   resetToDefault() {
-    this.metadataSettings = { visible: [], order: [] };
+    this.metadataSettings = { visible: [], order: [], referenceNumberVisible: false };
     this.columns = this.filterVisibleColumns(this.allColumns);
+  }
+
+  toggleReferenceNumberVisibility() {
+    this.metadataSettings.referenceNumberVisible = !this.referenceNumberVisible;
   }
 
   private resolveMetadataSettings(featureConfig: Record<string, any>): MetadataSettings {
@@ -4060,6 +4158,7 @@ export class ItemExplorerFacade implements OnDestroy {
       return {
         visible: visible.length ? visible : order,
         order: order.length ? order : visible,
+        referenceNumberVisible: metadataColumns.referenceNumberVisible === true,
       };
     }
 
@@ -4068,7 +4167,7 @@ export class ItemExplorerFacade implements OnDestroy {
       ? legacyColumns.filter((entry: unknown): entry is string => typeof entry === 'string')
       : [];
 
-    return { visible: legacy, order: legacy };
+    return { visible: legacy, order: legacy, referenceNumberVisible: false };
   }
 
   private buildUiPreferences(): Record<string, unknown> {
@@ -4543,6 +4642,15 @@ export class ItemExplorerFacade implements OnDestroy {
       this.applySharedExplorerEnvelope(envelope, true);
       this.reloadItems();
       this.lastDraftOperationError = '';
+      this.draftSaveSuccessMessage =
+        'Entwurf gespeichert. Referenznummern können bei Bedarf separat neu vergeben werden.';
+      if (this.draftSaveMessageResetTimeout) {
+        clearTimeout(this.draftSaveMessageResetTimeout);
+      }
+      this.draftSaveMessageResetTimeout = setTimeout(() => {
+        this.draftSaveMessageResetTimeout = null;
+        this.draftSaveSuccessMessage = '';
+      }, 5000);
       if (!this.showLeaveWithChangesDialog) {
         this.restoreFocusAfterOverlayClose();
       }
@@ -4652,13 +4760,26 @@ export class ItemExplorerFacade implements OnDestroy {
   }
 
   openColumnManager() {
+    if (this.showColumnManager) {
+      return;
+    }
     this.rememberFocusBeforeOverlay();
+    this.columnManagerOriginalSettings = {
+      visible: [...this.metadataSettings.visible],
+      order: [...this.metadataSettings.order],
+      referenceNumberVisible: this.referenceNumberVisible,
+    };
     this.showColumnManager = true;
   }
 
   closeColumnManager() {
     if (!this.showColumnManager) {
       return;
+    }
+    if (this.columnManagerOriginalSettings) {
+      this.metadataSettings = this.columnManagerOriginalSettings;
+      this.columns = this.filterVisibleColumns(this.allColumns);
+      this.columnManagerOriginalSettings = null;
     }
     this.showColumnManager = false;
     this.restoreFocusAfterOverlayClose();
@@ -4992,6 +5113,7 @@ export class ItemExplorerFacade implements OnDestroy {
     this.pendingDraftPatch = this.mergeDraftPatches(this.pendingDraftPatch, patch);
     this.pendingDraftChangeType = changeType;
     this.explorerUiStatus = 'DIRTY';
+    this.draftSaveSuccessMessage = '';
 
     if (this.draftPatchTimeout) {
       clearTimeout(this.draftPatchTimeout);

--- a/frontend/src/app/views/item-explorer/item-explorer.models.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.models.ts
@@ -47,6 +47,7 @@ export type ReadonlyExplorerItem = DeepReadonly<ExplorerItem>;
 export interface MetadataSettings {
   visible: string[];
   order: string[];
+  referenceNumberVisible?: boolean;
 }
 
 export interface PersonalItemTagConfig {

--- a/frontend/src/app/views/item-explorer/item-explorer.view-models.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.view-models.ts
@@ -24,6 +24,7 @@ export type ItemExplorerHeaderViewModel = ReadonlyViewModelSlice<
     | 'confirmDiscardDraftDialog'
     | 'confirmDiscardPersonalItemDataChanges'
     | 'confirmRenumber'
+    | 'draftSaveSuccessMessage'
     | 'discardAndLeave'
     | 'discardDraftDialogBusy'
     | 'discardDraftDialogError'
@@ -36,6 +37,7 @@ export type ItemExplorerHeaderViewModel = ReadonlyViewModelSlice<
     | 'exportPersonalItemDataXlsx'
     | 'filteredItems'
     | 'getRenumberingActionTitle'
+    | 'getRenumberingBlockedMessage'
     | 'hasPendingDraftChanges'
     | 'isFullscreen'
     | 'isReadOnlyPreview'
@@ -75,7 +77,7 @@ export type ItemExplorerHeaderViewModel = ReadonlyViewModelSlice<
     | 'stayOnPage'
     | 'toggleFullscreen'
     | 'toggleReadOnlyPreview'
-    | 'visibleItemsCount'
+    | 'totalItemsCount'
   >
 >;
 
@@ -100,6 +102,8 @@ export type ItemExplorerTableViewModel = ReadonlyViewModelSlice<
     | 'excludedItemsCount'
     | 'filterText'
     | 'filteredItems'
+    | 'hiddenExcludedItemsCount'
+    | 'hiddenMissingDifficultyItemsCount'
     | 'flushPersonalItemDataSave'
     | 'getItemRowId'
     | 'getMetaSortIndicator'
@@ -126,6 +130,7 @@ export type ItemExplorerTableViewModel = ReadonlyViewModelSlice<
     | 'personalItemCategoryValues'
     | 'personalItemData'
     | 'personalItemTagLabel'
+    | 'referenceNumberVisible'
     | 'removeItemTag'
     | 'removePersonalItemTagFromRow'
     | 'retryPersonalItemDataLoad'
@@ -141,6 +146,9 @@ export type ItemExplorerTableViewModel = ReadonlyViewModelSlice<
     | 'showExplorerKeyboardHints'
     | 'showPersonalItemData'
     | 'showPlayerTargetInfo'
+    | 'collectionViewMode'
+    | 'activeItemCollection'
+    | 'setCollectionViewMode'
     | 'sortBy'
     | 'sortByMeta'
     | 'toggleItemInActiveCollection'
@@ -159,6 +167,7 @@ export type ItemExplorerCollectionsViewModel = ReadonlyViewModelSlice<
     | 'collectionBusy'
     | 'collectionError'
     | 'collectionLoadState'
+    | 'collectionViewMode'
     | 'createCollection'
     | 'deleteActiveCollection'
     | 'enableItemCollections'
@@ -169,6 +178,7 @@ export type ItemExplorerCollectionsViewModel = ReadonlyViewModelSlice<
     | 'removeRowFromActiveCollection'
     | 'renameActiveCollection'
     | 'showCollectionDrawer'
+    | 'setCollectionViewMode'
     | 'toggleCollectionDrawer'
   >
 >;
@@ -281,6 +291,7 @@ export type ItemExplorerColumnManagerDialogViewModel = ReadonlyViewModelSlice<
     | 'setColumnFilterText'
     | 'showColumnManager'
     | 'toggleColumnVisibility'
+    | 'toggleReferenceNumberVisibility'
   >
 >;
 


### PR DESCRIPTION
## What changed

- add a gapless visible `Pos.` column and make the stable `Referenz-Nr.` optional
- show complete item counts and mutually exclusive visibility reasons
- clarify the full-inventory reference-number reassignment workflow and blocked-draft messaging
- rename user-facing collections to personal selection lists
- add an explicit `Alle Items | Nur Auswahlliste` mode that also works in read-only preview
- persist the selection-list view mode per identity and ACP in the existing preference JSON
- preserve unrelated personal preference data through atomic JSONB updates
- add regression coverage for identity changes, invalid stored list state, column-dialog cancellation, sticky columns, and cross-perspective persistence

## Why

Stable backend row numbers can legitimately contain gaps when the current view hides rows. Presenting them as a normal sequential table number made the Explorer look incorrectly numbered. READ ONLY was also easy to confuse with a personal selection-list filter because the two concepts were not represented independently.

## User impact

Users now see a clear, gapless table position while stable reference numbers remain available when needed. Personal selection lists can be used as an explicit additional filter in both editor and read-only perspectives, and the selected mode follows the user across reloads and devices.

## Root cause

The UI used one column for both a stable full-inventory identifier and the apparent position in a filtered table. Collection membership existed as personal state, but the table did not have a separately persisted view mode.

## Validation

- backend: 670 tests passed
- frontend: 476 tests passed
- focused browser E2E: passed
- backend and frontend production builds: passed
- `git diff --check`: passed
