### PR TITLE
Add scalable personal collection details

### DIFF
--- a/backend/src/item-collections/item-collection.models.ts
+++ b/backend/src/item-collections/item-collection.models.ts
@@ -37,3 +37,17 @@ export interface ItemCollectionsPayload {
   collectionViewMode: ItemCollectionViewMode;
   collections: ItemCollectionView[];
 }
+
+export interface ItemCollectionRowsMutation {
+  baseVersion?: unknown;
+  addRowKeys?: unknown;
+  removeRowKeys?: unknown;
+  clear?: unknown;
+}
+
+export interface ItemCollectionRowsMutationResult {
+  collectionId: string;
+  version: number;
+  updatedAt: string;
+  summary: ItemCollectionSummary;
+}

--- a/backend/src/item-collections/item-collections.service.spec.ts
+++ b/backend/src/item-collections/item-collections.service.spec.ts
@@ -251,6 +251,181 @@ describe("ItemCollectionsService", () => {
     ).rejects.toThrow(BadRequestException);
   });
 
+  it("adds deduplicated rows in order and returns a compact mutation result", async () => {
+    const preferences = {
+      collections: [
+        {
+          id: "collection-1",
+          name: "Auswahl",
+          rowKeys: ["uuid-1::1"],
+          version: 1,
+          createdAt: "2026-07-01T10:00:00.000Z",
+          updatedAt: "2026-07-01T10:00:00.000Z",
+        },
+      ],
+      activeCollectionId: "collection-1",
+    };
+    store.mutate.mockImplementation(async (...args: any[]) => {
+      const state = args[3](preferences);
+      preferences.collections = state.collections;
+      return state;
+    });
+    unitParserService.getItemListFromFiles.mockResolvedValue({
+      items: [
+        { rowKey: "uuid-1::1", uuid: "uuid-1", unitId: "unit-1" },
+        { rowKey: "uuid-2::1", uuid: "uuid-2", unitId: "unit-2" },
+      ],
+    });
+
+    const result = await service.mutateItemCollectionRows(
+      "acp-1",
+      owner,
+      "collection-1",
+      { baseVersion: 1, addRowKeys: ["uuid-2::1", "uuid-2::1"] },
+    );
+
+    expect(preferences.collections[0].rowKeys).toEqual([
+      "uuid-1::1",
+      "uuid-2::1",
+    ]);
+    expect(result).toEqual(
+      expect.objectContaining({
+        collectionId: "collection-1",
+        version: 2,
+        summary: expect.objectContaining({ rowCount: 2 }),
+      }),
+    );
+    expect(result).not.toHaveProperty("rowKeys");
+    expect(result).not.toHaveProperty("collections");
+  });
+
+  it("removes unavailable rows, clears collections, and preserves remaining order", async () => {
+    const preferences = {
+      collections: [
+        {
+          id: "collection-1",
+          name: "Auswahl",
+          rowKeys: ["known-a", "removed-row", "known-b"],
+          version: 4,
+          createdAt: "2026-07-01T10:00:00.000Z",
+          updatedAt: "2026-07-01T10:00:00.000Z",
+        },
+      ],
+      activeCollectionId: "collection-1",
+    };
+    store.mutate.mockImplementation(async (...args: any[]) => {
+      const state = args[3](preferences);
+      preferences.collections = state.collections;
+      return state;
+    });
+
+    const removed = await service.mutateItemCollectionRows(
+      "acp-1",
+      owner,
+      "collection-1",
+      { baseVersion: 4, removeRowKeys: ["removed-row"] },
+    );
+    expect(preferences.collections[0].rowKeys).toEqual(["known-a", "known-b"]);
+    expect(removed.version).toBe(5);
+
+    const cleared = await service.mutateItemCollectionRows(
+      "acp-1",
+      owner,
+      "collection-1",
+      { baseVersion: 5, clear: true },
+    );
+    expect(preferences.collections[0].rowKeys).toEqual([]);
+    expect(cleared.version).toBe(6);
+  });
+
+  it("keeps version and timestamp unchanged for no-op row mutations", async () => {
+    const updatedAt = "2026-07-01T10:00:00.000Z";
+    const preferences = {
+      collections: [
+        {
+          id: "collection-1",
+          name: "Auswahl",
+          rowKeys: ["uuid-1::1"],
+          version: 2,
+          createdAt: updatedAt,
+          updatedAt,
+        },
+      ],
+      activeCollectionId: "collection-1",
+    };
+    store.mutate.mockImplementation(async (...args: any[]) =>
+      args[3](preferences),
+    );
+
+    const result = await service.mutateItemCollectionRows(
+      "acp-1",
+      owner,
+      "collection-1",
+      { baseVersion: 2, addRowKeys: ["uuid-1::1"] },
+    );
+
+    expect(result.version).toBe(2);
+    expect(result.updatedAt).toBe(updatedAt);
+  });
+
+  it("rejects invalid row mutations, unknown additions, limits, and conflicts", async () => {
+    const rowKeys = Array.from(
+      { length: 10_000 },
+      (_, index) => `row-${index}`,
+    );
+    const preferences = {
+      collections: [
+        {
+          id: "collection-1",
+          name: "Auswahl",
+          rowKeys,
+          version: 3,
+          createdAt: "2026-07-01T10:00:00.000Z",
+          updatedAt: "2026-07-01T10:00:00.000Z",
+        },
+      ],
+      activeCollectionId: "collection-1",
+    };
+    store.mutate.mockImplementation(async (...args: any[]) =>
+      args[3](preferences),
+    );
+    unitParserService.getItemRowKeysFromFiles.mockResolvedValue(
+      new Set([...rowKeys, "extra-row"]),
+    );
+
+    await expect(
+      service.mutateItemCollectionRows("acp-1", owner, "collection-1", {
+        baseVersion: 3,
+        addRowKeys: [],
+        removeRowKeys: [],
+      }),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      service.mutateItemCollectionRows("acp-1", owner, "collection-1", {
+        baseVersion: 3,
+        clear: false,
+      }),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      service.mutateItemCollectionRows("acp-1", owner, "collection-1", {
+        baseVersion: 3,
+        addRowKeys: ["unknown-row"],
+      }),
+    ).rejects.toThrow("Collections can only add existing item rows");
+    await expect(
+      service.mutateItemCollectionRows("acp-1", owner, "collection-1", {
+        baseVersion: 3,
+        addRowKeys: ["extra-row"],
+      }),
+    ).rejects.toThrow("At most 10000 item rows");
+    await expect(
+      service.mutateItemCollectionRows("acp-1", owner, "collection-1", {
+        baseVersion: 2,
+        removeRowKeys: ["row-1"],
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+
   it("limits collection creation and delegates create-if-missing to the store", async () => {
     const timestamp = "2026-07-01T10:00:00.000Z";
     const preferences = {

--- a/backend/src/item-collections/item-collections.service.ts
+++ b/backend/src/item-collections/item-collections.service.ts
@@ -17,6 +17,8 @@ import {
 } from "../item-explorer/item-export-projection";
 import {
   ItemCollectionState,
+  ItemCollectionRowsMutation,
+  ItemCollectionRowsMutationResult,
   ItemCollectionSummary,
   ItemCollectionViewMode,
   ItemCollectionsPayload,
@@ -146,6 +148,128 @@ export class ItemCollectionsService {
       },
     );
     return this.resolveViews(acpId, state, canEditExplorerState);
+  }
+
+  async mutateItemCollectionRows(
+    acpId: string,
+    identity: StablePreferenceIdentity,
+    collectionId: string,
+    mutation: ItemCollectionRowsMutation,
+    canEditExplorerState = false,
+  ): Promise<ItemCollectionRowsMutationResult> {
+    const actions = [
+      mutation.addRowKeys !== undefined,
+      mutation.removeRowKeys !== undefined,
+      mutation.clear !== undefined,
+    ].filter(Boolean).length;
+    if (
+      actions !== 1 ||
+      (mutation.clear !== undefined && mutation.clear !== true)
+    ) {
+      throw new BadRequestException(
+        "Exactly one collection row mutation is required",
+      );
+    }
+
+    const addRowKeys =
+      mutation.addRowKeys === undefined
+        ? undefined
+        : this.normalizeRowKeys(mutation.addRowKeys);
+    const removeRowKeys =
+      mutation.removeRowKeys === undefined
+        ? undefined
+        : this.normalizeRowKeys(mutation.removeRowKeys);
+    let knownRowKeys: ReadonlySet<string> | undefined;
+    if (addRowKeys !== undefined) {
+      const explorerState =
+        await this.itemExplorerStateService.getStateForViewer(
+          acpId,
+          canEditExplorerState,
+        );
+      knownRowKeys = await this.unitParserService.getItemRowKeysFromFiles(
+        acpId,
+        {
+          itemPropertiesOverride: explorerState.activeState.itemProperties,
+          publishedItemPropertiesOverride:
+            explorerState.publishedState.itemProperties,
+        },
+      );
+    }
+
+    const baseVersion = Number(mutation.baseVersion);
+    const state = await this.mutateState(
+      acpId,
+      identity,
+      false,
+      (lockedState) => {
+        const collection = lockedState.collections.find(
+          (candidate) => candidate.id === collectionId,
+        );
+        if (!collection) {
+          throw new NotFoundException("Item collection not found");
+        }
+        if (
+          !Number.isInteger(baseVersion) ||
+          baseVersion !== collection.version
+        ) {
+          throw new ConflictException(
+            "The item collection changed concurrently",
+          );
+        }
+
+        let nextRowKeys = collection.rowKeys;
+        if (addRowKeys !== undefined && knownRowKeys) {
+          const existing = new Set(collection.rowKeys);
+          const additions = addRowKeys.filter(
+            (rowKey) => !existing.has(rowKey),
+          );
+          const invalidRowKey = additions.find(
+            (rowKey) => !knownRowKeys!.has(rowKey),
+          );
+          if (invalidRowKey) {
+            throw new BadRequestException(
+              "Collections can only add existing item rows",
+            );
+          }
+          if (
+            collection.rowKeys.length + additions.length >
+            MAX_COLLECTION_ROWS
+          ) {
+            throw new BadRequestException(
+              `At most ${MAX_COLLECTION_ROWS} item rows can be stored in a collection`,
+            );
+          }
+          if (additions.length)
+            nextRowKeys = [...collection.rowKeys, ...additions];
+        } else if (removeRowKeys !== undefined) {
+          const removals = new Set(removeRowKeys);
+          nextRowKeys = collection.rowKeys.filter(
+            (rowKey) => !removals.has(rowKey),
+          );
+        } else if (mutation.clear === true && collection.rowKeys.length) {
+          nextRowKeys = [];
+        }
+
+        const changed =
+          nextRowKeys.length !== collection.rowKeys.length ||
+          nextRowKeys.some(
+            (rowKey, index) => rowKey !== collection.rowKeys[index],
+          );
+        if (!changed) return;
+        collection.rowKeys = nextRowKeys;
+        collection.version += 1;
+        collection.updatedAt = new Date().toISOString();
+      },
+    );
+    const collection = state.collections.find(
+      (candidate) => candidate.id === collectionId,
+    );
+    if (!collection) throw new NotFoundException("Item collection not found");
+    return this.resolveRowsMutationResult(
+      acpId,
+      collection,
+      canEditExplorerState,
+    );
   }
 
   async activateItemCollection(
@@ -417,6 +541,34 @@ export class ItemCollectionsService {
           summary: this.calculateSummary(items, collection.rowKeys.length),
         };
       }),
+    };
+  }
+
+  private async resolveRowsMutationResult(
+    acpId: string,
+    collection: StoredItemCollection,
+    canEditExplorerState: boolean,
+  ): Promise<ItemCollectionRowsMutationResult> {
+    const explorerState = await this.itemExplorerStateService.getStateForViewer(
+      acpId,
+      canEditExplorerState,
+    );
+    const itemList = await this.unitParserService.getItemListFromFiles(acpId, {
+      itemPropertiesOverride: explorerState.activeState.itemProperties,
+      publishedItemPropertiesOverride:
+        explorerState.publishedState.itemProperties,
+    });
+    const itemsByRowKey = new Map(
+      itemList.items.map((item) => [item.rowKey, item] as const),
+    );
+    const items = collection.rowKeys
+      .map((rowKey) => itemsByRowKey.get(rowKey))
+      .filter((item): item is VomdItemData => Boolean(item));
+    return {
+      collectionId: collection.id,
+      version: collection.version,
+      updatedAt: collection.updatedAt,
+      summary: this.calculateSummary(items, collection.rowKeys.length),
     };
   }
 

--- a/backend/src/views/views.controller.spec.ts
+++ b/backend/src/views/views.controller.spec.ts
@@ -62,6 +62,12 @@ describe("ViewsController", () => {
         activeCollectionId: "collection-1",
         collections: [],
       }),
+      mutateItemCollectionRows: jest.fn().mockResolvedValue({
+        collectionId: "collection-1",
+        version: 3,
+        updatedAt: "2026-07-22T10:00:00.000Z",
+        summary: { rowCount: 1 },
+      }),
       activateItemCollection: jest.fn().mockResolvedValue({
         activeCollectionId: "collection-1",
         collections: [],
@@ -537,6 +543,12 @@ describe("ViewsController", () => {
       { baseVersion: 2, rowKeys: ["uuid::1"], perspective: "editor" },
       request,
     );
+    await controller.mutateItemCollectionRows(
+      "acp-1",
+      "collection-1",
+      { baseVersion: 2, removeRowKeys: ["uuid::1"], perspective: "editor" },
+      request,
+    );
     const res = { setHeader: jest.fn(), send: jest.fn() } as any;
     await controller.exportItemCollectionCsv(
       "acp-1",
@@ -556,6 +568,15 @@ describe("ViewsController", () => {
       { kind: "user", userId: "user-1" },
       "collection-1",
       expect.objectContaining({ baseVersion: 2, rowKeys: ["uuid::1"] }),
+      true,
+    );
+    expect(
+      itemCollectionsService.mutateItemCollectionRows,
+    ).toHaveBeenCalledWith(
+      "acp-1",
+      { kind: "user", userId: "user-1" },
+      "collection-1",
+      expect.objectContaining({ baseVersion: 2, removeRowKeys: ["uuid::1"] }),
       true,
     );
     expect(itemCollectionsService.exportItemCollectionCsv).toHaveBeenCalledWith(

--- a/backend/src/views/views.controller.ts
+++ b/backend/src/views/views.controller.ts
@@ -25,6 +25,7 @@ import {
 import {
   ArrayMaxSize,
   IsArray,
+  IsBoolean,
   IsIn,
   IsInt,
   IsObject,
@@ -179,6 +180,80 @@ class UpdateItemCollectionDto {
   @IsOptional()
   @IsIn(["editor", "read-only"])
   perspective?: "editor" | "read-only";
+}
+
+class MutateItemCollectionRowsDto {
+  @ApiProperty()
+  @IsInt()
+  @Min(1)
+  baseVersion!: number;
+
+  @ApiPropertyOptional({ type: [String], maxItems: 10_000 })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(10_000)
+  @IsString({ each: true })
+  addRowKeys?: string[];
+
+  @ApiPropertyOptional({ type: [String], maxItems: 10_000 })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(10_000)
+  @IsString({ each: true })
+  removeRowKeys?: string[];
+
+  @ApiPropertyOptional({ enum: [true] })
+  @IsOptional()
+  @IsBoolean()
+  clear?: boolean;
+
+  @ApiPropertyOptional({ enum: ["editor", "read-only"] })
+  @IsOptional()
+  @IsIn(["editor", "read-only"])
+  perspective?: "editor" | "read-only";
+}
+
+class ItemCollectionSummaryDto {
+  @ApiProperty()
+  rowCount!: number;
+
+  @ApiProperty()
+  itemCount!: number;
+
+  @ApiProperty()
+  unitCount!: number;
+
+  @ApiProperty()
+  itemTimeSeconds!: number;
+
+  @ApiProperty()
+  stimulusTimeSeconds!: number;
+
+  @ApiProperty()
+  testTimeSeconds!: number;
+
+  @ApiProperty()
+  missingItemTimeCount!: number;
+
+  @ApiProperty()
+  missingStimulusTimeUnitCount!: number;
+
+  @ApiProperty()
+  complete!: boolean;
+}
+
+class ItemCollectionRowsMutationResultDto {
+  @ApiProperty({ format: "uuid" })
+  collectionId!: string;
+
+  @ApiProperty()
+  version!: number;
+
+  @ApiProperty({ format: "date-time" })
+  updatedAt!: string;
+
+  @ApiProperty({ type: () => ItemCollectionSummaryDto })
+  summary!: ItemCollectionSummaryDto;
 }
 
 class ActivateItemCollectionDto {
@@ -503,6 +578,28 @@ export class ViewsController {
   ) {
     await this.assertItemCollectionsEnabled(acpId, req);
     return this.itemCollectionsService.updateItemCollection(
+      acpId,
+      this.requireCollectionIdentity(req),
+      collectionId,
+      dto,
+      this.isEditorPerspective(req, dto.perspective),
+    );
+  }
+
+  @Patch("acp/:acpId/items/collections/:collectionId/rows")
+  @UseGuards(AcpAccessGuard)
+  @ApiOperation({
+    summary: "Add, remove, or clear personal item collection rows",
+  })
+  @ApiOkResponse({ type: ItemCollectionRowsMutationResultDto })
+  async mutateItemCollectionRows(
+    @UuidParam("acpId") acpId: string,
+    @UuidParam("collectionId") collectionId: string,
+    @Body() dto: MutateItemCollectionRowsDto,
+    @Request() req: any,
+  ) {
+    await this.assertItemCollectionsEnabled(acpId, req);
+    return this.itemCollectionsService.mutateItemCollectionRows(
       acpId,
       this.requireCollectionIdentity(req),
       collectionId,

--- a/frontend/e2e/item-list-preferences.spec.ts
+++ b/frontend/e2e/item-list-preferences.spec.ts
@@ -282,6 +282,103 @@ test('reconciles mean filters across clear, reimport, reload and credential relo
   await managerContext.close();
 });
 
+test('paginates large personal collections and removes selections across pages', async ({
+  page,
+  request,
+}) => {
+  const login = await request.post('/api/auth/login', {
+    data: { username: MANAGER_USERNAME, password: MANAGER_PASSWORD },
+  });
+  expect(login.ok()).toBeTruthy();
+  const token = (await login.json()).accessToken as string;
+  await page.addInitScript((accessToken) => {
+    localStorage.setItem('cp_token', accessToken);
+    localStorage.setItem('cp_auth_type', 'local');
+  }, token);
+
+  const collectionId = '20000000-0000-4000-8000-000000000001';
+  const rowKeys = Array.from({ length: 51 }, (_, index) => `missing-row-${index + 1}`);
+  const summary = {
+    rowCount: rowKeys.length,
+    itemCount: 0,
+    unitCount: 0,
+    itemTimeSeconds: 0,
+    stimulusTimeSeconds: 0,
+    testTimeSeconds: 0,
+    missingItemTimeCount: 0,
+    missingStimulusTimeUnitCount: 0,
+    complete: true,
+  };
+  let removePayload: { removeRowKeys?: string[]; rowKeys?: string[] } | null = null;
+  await page.route(`**/api/view/acp/${ACP_ID}/items/collections**`, async (route) => {
+    const browserRequest = route.request();
+    const pathname = new URL(browserRequest.url()).pathname;
+    if (browserRequest.method() === 'GET' && pathname.endsWith('/items/collections')) {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          activeCollectionId: collectionId,
+          collectionViewMode: 'all',
+          collections: [
+            {
+              id: collectionId,
+              name: 'Große Auswahlliste',
+              rowKeys,
+              version: 1,
+              createdAt: '2026-07-22T10:00:00.000Z',
+              updatedAt: '2026-07-22T10:00:00.000Z',
+              unavailableRowKeys: rowKeys,
+              summary,
+            },
+          ],
+        }),
+      });
+      return;
+    }
+    if (browserRequest.method() === 'PATCH' && pathname.endsWith('/rows')) {
+      removePayload = browserRequest.postDataJSON();
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          collectionId,
+          version: 2,
+          updatedAt: '2026-07-22T10:01:00.000Z',
+          summary: { ...summary, rowCount: 49 },
+        }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto(`/view/${ACP_ID}/item-explorer`);
+  await page.getByRole('button', { name: 'Details', exact: true }).click();
+  const collectionDialog = page.getByRole('dialog', { name: 'Große Auswahlliste' });
+  await expect(collectionDialog.locator('.collection-table tbody tr')).toHaveCount(50);
+
+  await collectionDialog.getByRole('checkbox', { name: 'Eintrag 1 auswählen' }).check();
+  await collectionDialog.getByRole('button', { name: 'Weiter' }).click();
+  await expect(collectionDialog.getByText('Seite 2 von 2')).toBeVisible();
+  await expect(collectionDialog.locator('.collection-table tbody tr')).toHaveCount(1);
+  await collectionDialog.getByRole('checkbox', { name: 'Eintrag 51 auswählen' }).check();
+  await expect(collectionDialog.getByText('2 ausgewählt')).toBeVisible();
+
+  await collectionDialog.getByRole('button', { name: 'Ausgewählte entfernen (2)' }).click();
+  const confirmation = page.locator('.collection-remove-confirmation');
+  await expect(confirmation).toContainText(
+    '2 Einträge aus der Auswahlliste „Große Auswahlliste“ entfernen?',
+  );
+  await confirmation.getByRole('button', { name: 'Entfernen', exact: true }).click();
+
+  await expect.poll(() => removePayload).not.toBeNull();
+  expect(removePayload).toMatchObject({
+    removeRowKeys: ['missing-row-1', 'missing-row-51'],
+  });
+  expect(removePayload?.rowKeys).toBeUndefined();
+  await expect(collectionDialog.getByText('Seite 1 von 1')).toBeVisible();
+  await expect(collectionDialog.locator('.collection-table tbody tr')).toHaveCount(49);
+});
+
 test('keeps positions gapless and persists the personal selection view across perspectives', async ({
   page,
   request,
@@ -365,6 +462,52 @@ test('keeps positions gapless and persists the personal selection view across pe
       .check(),
   ]);
   const activeOnlyButton = page.getByRole('button', { name: 'Nur Auswahlliste (1)' });
+
+  await page.getByRole('button', { name: 'Details', exact: true }).click();
+  const collectionDialog = page.getByRole('dialog', { name: 'Meine Auswahlliste' });
+  await expect(collectionDialog).toBeVisible();
+  const collectionSearch = collectionDialog.getByRole('searchbox', {
+    name: 'Einträge der Auswahlliste durchsuchen',
+  });
+  await expect(collectionSearch).toBeFocused();
+  await collectionSearch.fill('ohne-treffer');
+  await expect(collectionDialog.getByText('Keine passenden Einträge.')).toBeVisible();
+  await collectionSearch.clear();
+  await collectionDialog.getByRole('checkbox', { name: 'Eintrag 1 auswählen' }).check();
+  await collectionDialog.getByRole('button', { name: 'Ausgewählte entfernen (1)' }).click();
+  const [removeResponse] = await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PATCH' &&
+        response.url().endsWith('/rows') &&
+        response.ok(),
+    ),
+    page
+      .locator('.collection-remove-confirmation')
+      .getByRole('button', { name: 'Entfernen', exact: true })
+      .click(),
+  ]);
+  const removePayload = removeResponse.request().postDataJSON();
+  expect(removePayload.removeRowKeys).toHaveLength(1);
+  expect(removePayload.rowKeys).toBeUndefined();
+  await expect(page.getByRole('button', { name: 'Nur Auswahlliste (0)' })).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(collectionDialog).toBeHidden();
+  await expect(page.getByRole('button', { name: 'Details', exact: true })).toBeFocused();
+
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PATCH' &&
+        response.url().endsWith('/rows') &&
+        response.ok(),
+    ),
+    page
+      .getByRole('checkbox', { name: /in Auswahlliste auswählen/ })
+      .first()
+      .check(),
+  ]);
+
   await Promise.all([
     page.waitForResponse(
       (response) =>

--- a/frontend/e2e/item-list-preferences.spec.ts
+++ b/frontend/e2e/item-list-preferences.spec.ts
@@ -356,6 +356,52 @@ test('paginates large personal collections and removes selections across pages',
   const collectionDialog = page.getByRole('dialog', { name: 'Große Auswahlliste' });
   await expect(collectionDialog.locator('.collection-table tbody tr')).toHaveCount(50);
 
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobileLayout = await collectionDialog.evaluate((dialog) => {
+    const containedSelectors = [
+      '.collection-modal-header',
+      '.collection-modal-toolbar',
+      '.collection-modal-actions',
+      '.collection-modal-footer',
+    ];
+    const dialogRect = dialog.getBoundingClientRect();
+    return {
+      dialogLeft: dialogRect.left,
+      dialogRight: dialogRect.right,
+      viewportWidth: window.innerWidth,
+      children: containedSelectors.map((selector) => {
+        const element = dialog.querySelector<HTMLElement>(selector)!;
+        const rect = element.getBoundingClientRect();
+        return {
+          selector,
+          left: rect.left,
+          right: rect.right,
+          scrollWidth: element.scrollWidth,
+          clientWidth: element.clientWidth,
+        };
+      }),
+    };
+  });
+  expect(mobileLayout.dialogLeft).toBeGreaterThanOrEqual(0);
+  expect(mobileLayout.dialogRight).toBeLessThanOrEqual(mobileLayout.viewportWidth);
+  for (const child of mobileLayout.children) {
+    expect(child.left, `${child.selector} starts outside the dialog`).toBeGreaterThanOrEqual(
+      mobileLayout.dialogLeft,
+    );
+    expect(child.right, `${child.selector} ends outside the dialog`).toBeLessThanOrEqual(
+      mobileLayout.dialogRight,
+    );
+    expect(child.scrollWidth, `${child.selector} overflows horizontally`).toBeLessThanOrEqual(
+      child.clientWidth,
+    );
+  }
+  await expect(collectionDialog.getByRole('searchbox')).toBeInViewport();
+  await expect(collectionDialog.getByRole('button', { name: 'CSV exportieren' })).toBeInViewport();
+  await expect(
+    collectionDialog.getByRole('button', { name: 'Auswahlliste löschen' }),
+  ).toBeInViewport();
+  await expect(collectionDialog.getByRole('button', { name: 'Details schließen' })).toBeInViewport();
+
   await collectionDialog.getByRole('checkbox', { name: 'Eintrag 1 auswählen' }).check();
   await collectionDialog.getByRole('button', { name: 'Weiter' }).click();
   await expect(collectionDialog.getByText('Seite 2 von 2')).toBeVisible();
@@ -368,7 +414,12 @@ test('paginates large personal collections and removes selections across pages',
   await expect(confirmation).toContainText(
     '2 Einträge aus der Auswahlliste „Große Auswahlliste“ entfernen?',
   );
-  await confirmation.getByRole('button', { name: 'Entfernen', exact: true }).click();
+  const confirmRemovalButton = confirmation.getByRole('button', {
+    name: 'Entfernen',
+    exact: true,
+  });
+  await expect(confirmRemovalButton).toBeFocused();
+  await confirmRemovalButton.click();
 
   await expect.poll(() => removePayload).not.toBeNull();
   expect(removePayload).toMatchObject({
@@ -526,7 +577,13 @@ test('keeps positions gapless and persists the personal selection view across pe
   );
   await expect(page.locator('tbody tr')).toHaveCount(1);
 
-  await page.getByRole('button', { name: 'READ ONLY-Vorschau' }).click();
+  const editingViewButton = page.getByRole('button', { name: 'Bearbeitungsansicht' });
+  if (await editingViewButton.isVisible()) {
+    await editingViewButton.click();
+  }
+  const readOnlyPreviewButton = page.getByRole('button', { name: 'READ ONLY-Vorschau' });
+  await expect(readOnlyPreviewButton).toBeVisible();
+  await readOnlyPreviewButton.click();
   await expect(page.getByRole('button', { name: 'Bearbeitungsansicht' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Nur Auswahlliste (1)' })).toHaveAttribute(
     'aria-pressed',

--- a/frontend/src/app/core/models/api.models.ts
+++ b/frontend/src/app/core/models/api.models.ts
@@ -492,6 +492,18 @@ export interface ItemCollectionsPayload {
   collections: ItemCollection[];
 }
 
+export type ItemCollectionRowsMutation =
+  | { baseVersion: number; addRowKeys: string[]; perspective: ItemExplorerPerspective }
+  | { baseVersion: number; removeRowKeys: string[]; perspective: ItemExplorerPerspective }
+  | { baseVersion: number; clear: true; perspective: ItemExplorerPerspective };
+
+export interface ItemCollectionRowsMutationResult {
+  collectionId: string;
+  version: number;
+  updatedAt: string;
+  summary: ItemCollectionSummary;
+}
+
 export interface ItemExplorerMetadataColumns {
   visible?: string[];
   order?: string[];

--- a/frontend/src/app/core/services/api.service.spec.ts
+++ b/frontend/src/app/core/services/api.service.spec.ts
@@ -974,6 +974,33 @@ describe('ApiService', () => {
       );
     });
 
+    it('should mutate collection rows without sending the complete collection', () => {
+      const result = {
+        collectionId: 'collection-1',
+        version: 3,
+        updatedAt: '2026-07-22T10:00:00.000Z',
+        summary: { rowCount: 2 },
+      };
+      httpClientMock.patch.mockReturnValue(of(result));
+
+      service
+        .mutateItemCollectionRows('acp1', 'collection-1', {
+          baseVersion: 2,
+          removeRowKeys: ['uuid::1'],
+          perspective: 'read-only',
+        })
+        .subscribe((response) => expect(response).toBe(result));
+
+      expect(httpClientMock.patch).toHaveBeenCalledWith(
+        '/api/view/acp/acp1/items/collections/collection-1/rows',
+        {
+          baseVersion: 2,
+          removeRowKeys: ['uuid::1'],
+          perspective: 'read-only',
+        },
+      );
+    });
+
     it('should get view sequences', () => {
       httpClientMock.get.mockReturnValue(of([]));
 

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -30,6 +30,8 @@ import {
   FilePreviewResponse,
   FileDeletionResponse,
   ItemCollectionsPayload,
+  ItemCollectionRowsMutation,
+  ItemCollectionRowsMutationResult,
   ItemExplorerPerspective,
   SimpleItemListEntry,
   BuildVersion,
@@ -636,6 +638,17 @@ export class ApiService {
     return this.http.patch<ItemCollectionsPayload>(
       `${this.API}/view/acp/${acpId}/items/collections/${encodeURIComponent(collectionId)}`,
       { ...update, perspective },
+    );
+  }
+
+  mutateItemCollectionRows(
+    acpId: string,
+    collectionId: string,
+    mutation: ItemCollectionRowsMutation,
+  ): Observable<ItemCollectionRowsMutationResult> {
+    return this.http.patch<ItemCollectionRowsMutationResult>(
+      `${this.API}/view/acp/${acpId}/items/collections/${encodeURIComponent(collectionId)}/rows`,
+      mutation,
     );
   }
 

--- a/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.css
+++ b/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.css
@@ -15,3 +15,198 @@
   margin-left: -1px;
   border-radius: 0 var(--radius) var(--radius) 0;
 }
+
+.collection-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.collection-modal {
+  display: flex;
+  flex-direction: column;
+  width: min(1100px, 94vw);
+  max-height: 90vh;
+  min-height: min(680px, 90vh);
+  overflow: hidden;
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
+}
+
+.collection-modal-header,
+.collection-modal-toolbar,
+.collection-modal-footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+}
+
+.collection-modal-header {
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.collection-modal-header h2,
+.collection-modal-header p {
+  margin: 0;
+}
+
+.collection-modal-header h2 {
+  font-size: 1.2rem;
+}
+
+.collection-modal-header p {
+  margin-top: 4px;
+  color: var(--color-text-secondary);
+  font-size: 0.84rem;
+}
+
+.collection-close-button {
+  flex: 0 0 auto;
+}
+
+.collection-modal-toolbar {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.collection-modal-toolbar .filter-input {
+  min-width: 0;
+  flex: 1;
+}
+
+.collection-modal-actions,
+.collection-pagination {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.collection-modal-error {
+  margin: 10px 20px 0;
+}
+
+.collection-modal-content {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  scrollbar-gutter: stable;
+}
+
+.collection-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+
+.collection-table th,
+.collection-table td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.collection-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--color-bg);
+  white-space: nowrap;
+}
+
+.collection-check-col {
+  width: 42px;
+  text-align: center !important;
+}
+
+.collection-position-col {
+  width: 64px;
+  text-align: right !important;
+  font-variant-numeric: tabular-nums;
+}
+
+.collection-action-col {
+  width: 1%;
+  text-align: right !important;
+  white-space: nowrap;
+}
+
+.collection-unavailable-row {
+  background: rgba(243, 156, 18, 0.06);
+}
+
+.collection-available {
+  color: #237a43;
+}
+
+.collection-modal-empty {
+  display: flex;
+  min-height: 300px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 6px;
+  padding: 32px;
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.collection-modal-footer {
+  justify-content: space-between;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
+  flex-wrap: wrap;
+}
+
+.collection-result-summary,
+.collection-pagination {
+  color: var(--color-text-secondary);
+  font-size: 0.84rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 700px) {
+  .collection-modal-backdrop {
+    padding: 0;
+  }
+
+  .collection-modal {
+    width: 100vw;
+    height: 100dvh;
+    min-height: 0;
+    max-height: 100dvh;
+    border-radius: 0;
+  }
+
+  .collection-modal-toolbar,
+  .collection-modal-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .collection-modal-actions,
+  .collection-pagination {
+    justify-content: space-between;
+  }
+
+  .collection-table {
+    min-width: 760px;
+  }
+}

--- a/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.css
+++ b/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.css
@@ -28,9 +28,11 @@
 }
 
 .collection-modal {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   width: min(1100px, 94vw);
+  max-width: 100%;
   max-height: 90vh;
   min-height: min(680px, 90vh);
   overflow: hidden;
@@ -58,8 +60,13 @@
   margin: 0;
 }
 
+.collection-modal-header > div {
+  min-width: 0;
+}
+
 .collection-modal-header h2 {
   font-size: 1.2rem;
+  overflow-wrap: anywhere;
 }
 
 .collection-modal-header p {
@@ -199,6 +206,30 @@
   .collection-modal-footer {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .collection-modal-header,
+  .collection-modal-toolbar,
+  .collection-modal-footer {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .collection-modal-toolbar .filter-input {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .collection-modal-actions {
+    display: grid;
+    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .collection-modal-actions .btn {
+    min-width: 0;
+    white-space: normal;
   }
 
   .collection-modal-actions,

--- a/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.html
+++ b/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.html
@@ -270,6 +270,7 @@
     </div>
 
     <app-confirm-dialog
+      #removeConfirmation
       class="collection-remove-confirmation"
       [open]="showRemoveConfirmation"
       title="Einträge entfernen"

--- a/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.html
+++ b/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.html
@@ -61,11 +61,12 @@
         Leeren
       </button>
       <button
+        #detailsTrigger
         class="btn btn-outline btn-sm"
         [disabled]="!vm.activeItemCollection || vm.collectionBusy"
-        (click)="vm.toggleCollectionDrawer()"
+        (click)="openDetails(detailsTrigger)"
       >
-        {{ vm.showCollectionDrawer ? 'Details schließen' : 'Details' }}
+        Details
       </button>
       @if (vm.activeItemCollection; as collection) {
         <span class="collection-summary">
@@ -85,45 +86,202 @@
   @if (vm.collectionError && vm.collectionLoadState !== 'error') {
     <div class="alert alert-error collection-error">{{ vm.collectionError }}</div>
   }
-  @if (vm.showCollectionDrawer && vm.activeItemCollection) {
-    <div class="collection-drawer">
-      <div class="collection-drawer-header">
-        <strong>{{ vm.activeItemCollection.name }}</strong>
-        <div>
-          <button class="btn btn-outline btn-sm" (click)="vm.exportActiveCollection()">
-            CSV exportieren
+  @if (vm.showCollectionDialog && vm.activeItemCollection; as collection) {
+    <div class="collection-modal-backdrop" (click)="closeDetails()">
+      <div
+        #collectionDialog
+        class="collection-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="collection-dialog-title"
+        aria-describedby="collection-dialog-summary"
+        (click)="$event.stopPropagation()"
+      >
+        <header class="collection-modal-header">
+          <div>
+            <h2 id="collection-dialog-title">{{ collection.name }}</h2>
+            <p id="collection-dialog-summary">
+              <strong>{{ vm.formatDuration(collection.summary.testTimeSeconds) }}</strong>
+              · {{ collection.summary.rowCount }} Zeilen · {{ collection.summary.itemCount }} Items
+              · {{ collection.summary.unitCount }} Units
+            </p>
+          </div>
+          <button
+            class="btn btn-outline btn-sm collection-close-button"
+            type="button"
+            aria-label="Details schließen"
+            [disabled]="vm.collectionBusy"
+            (click)="closeDetails()"
+          >
+            ✕
           </button>
-          <button class="btn btn-danger btn-sm" (click)="vm.deleteActiveCollection()">
-            Auswahlliste löschen
-          </button>
+        </header>
+
+        <div class="collection-modal-toolbar">
+          <input
+            #collectionSearch
+            class="filter-input"
+            type="search"
+            [ngModel]="collectionFilterText"
+            (ngModelChange)="setCollectionFilterText($event)"
+            placeholder="🔍 Aufgabe, Item-ID, Sub-ID oder Zeilenschlüssel suchen …"
+            aria-label="Einträge der Auswahlliste durchsuchen"
+          />
+          <div class="collection-modal-actions">
+            <button
+              class="btn btn-outline btn-sm"
+              type="button"
+              [disabled]="vm.collectionBusy"
+              (click)="vm.exportActiveCollection()"
+            >
+              CSV exportieren
+            </button>
+            <button
+              class="btn btn-danger btn-sm"
+              type="button"
+              [disabled]="vm.collectionBusy"
+              (click)="deleteActiveCollection()"
+            >
+              Auswahlliste löschen
+            </button>
+          </div>
         </div>
-      </div>
-      @if (vm.activeCollectionItems.length === 0) {
-        <p class="help-text">Noch keine Items ausgewählt.</p>
-      } @else {
-        <ol class="collection-items">
-          @for (entry of vm.activeCollectionItems; track entry.rowKey) {
-            <li>
-              @if (entry.item) {
-                <span>
-                  {{ entry.item.unitLabel }} · {{ entry.item.itemId }}
-                  @if (entry.item.subIdDisplay || entry.item.subId) {
-                    · {{ entry.item.subIdDisplay || entry.item.subId }}
-                  }
-                </span>
-              } @else {
-                <span class="collection-warning">Nicht verfügbar: {{ entry.rowKey }}</span>
-              }
-              <button
-                class="btn btn-outline btn-sm"
-                (click)="vm.removeRowFromActiveCollection(entry.rowKey)"
-              >
-                Entfernen
-              </button>
-            </li>
+
+        @if (vm.collectionError) {
+          <div class="alert alert-error collection-modal-error" role="alert">
+            {{ vm.collectionError }}
+          </div>
+        }
+
+        <div class="collection-modal-content">
+          @if (vm.activeCollectionItems.length === 0) {
+            <div class="collection-modal-empty">
+              <strong>Noch keine Items ausgewählt.</strong>
+              <span>Fügen Sie Items über die Checkboxen der Itemtabelle hinzu.</span>
+            </div>
+          } @else if (filteredCollectionItems.length === 0) {
+            <div class="collection-modal-empty">
+              <strong>Keine passenden Einträge.</strong>
+              <span>Ändern oder löschen Sie den Suchbegriff.</span>
+            </div>
+          } @else {
+            <table class="collection-table">
+              <thead>
+                <tr>
+                  <th class="collection-check-col">
+                    <input
+                      type="checkbox"
+                      aria-label="Alle Einträge auf dieser Seite auswählen"
+                      [checked]="currentPageFullySelected"
+                      [indeterminate]="currentPagePartiallySelected"
+                      [disabled]="vm.collectionBusy"
+                      (change)="toggleCurrentPage($any($event.target).checked)"
+                    />
+                  </th>
+                  <th class="collection-position-col">Pos.</th>
+                  <th>Aufgabe</th>
+                  <th>Item-ID</th>
+                  <th>Sub-ID</th>
+                  <th>Status</th>
+                  <th class="collection-action-col"><span class="sr-only">Aktion</span></th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (entry of pagedCollectionItems; track entry.rowKey) {
+                  <tr [class.collection-unavailable-row]="!entry.item">
+                    <td class="collection-check-col">
+                      <input
+                        type="checkbox"
+                        [attr.aria-label]="'Eintrag ' + entry.position + ' auswählen'"
+                        [checked]="selectedRowKeys.has(entry.rowKey)"
+                        [disabled]="vm.collectionBusy"
+                        (change)="toggleRowSelection(entry.rowKey, $any($event.target).checked)"
+                      />
+                    </td>
+                    <td class="collection-position-col">{{ entry.position }}</td>
+                    @if (entry.item) {
+                      <td>{{ entry.item.unitLabel }}</td>
+                      <td>
+                        <code>{{ entry.item.itemId }}</code>
+                      </td>
+                      <td>{{ entry.item.subIdDisplay || entry.item.subId || '–' }}</td>
+                      <td><span class="collection-available">Verfügbar</span></td>
+                    } @else {
+                      <td colspan="3">
+                        <code>{{ entry.rowKey }}</code>
+                      </td>
+                      <td><span class="collection-warning">Nicht verfügbar</span></td>
+                    }
+                    <td class="collection-action-col">
+                      <button
+                        class="btn btn-outline btn-sm"
+                        type="button"
+                        [disabled]="vm.collectionBusy"
+                        [attr.aria-label]="'Eintrag ' + entry.position + ' entfernen'"
+                        (click)="removeOne(entry.rowKey)"
+                      >
+                        Entfernen
+                      </button>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
           }
-        </ol>
-      }
+        </div>
+
+        <footer class="collection-modal-footer">
+          <div class="collection-result-summary" aria-live="polite">
+            {{ filteredCollectionItems.length }} Treffer
+            @if (selectedCount > 0) {
+              · {{ selectedCount }} ausgewählt
+            }
+          </div>
+          <div class="collection-pagination" aria-label="Seitennavigation">
+            <button
+              class="btn btn-outline btn-sm"
+              type="button"
+              [disabled]="collectionPage <= 1 || vm.collectionBusy"
+              (click)="previousPage()"
+            >
+              Zurück
+            </button>
+            <span>Seite {{ collectionPage }} von {{ collectionPageCount }}</span>
+            <button
+              class="btn btn-outline btn-sm"
+              type="button"
+              [disabled]="collectionPage >= collectionPageCount || vm.collectionBusy"
+              (click)="nextPage()"
+            >
+              Weiter
+            </button>
+          </div>
+          <button
+            #removeSelectedButton
+            class="btn btn-danger btn-sm"
+            type="button"
+            [disabled]="selectedCount === 0 || vm.collectionBusy"
+            (click)="openRemoveConfirmation()"
+          >
+            Ausgewählte entfernen ({{ selectedCount }})
+          </button>
+        </footer>
+      </div>
     </div>
+
+    <app-confirm-dialog
+      class="collection-remove-confirmation"
+      [open]="showRemoveConfirmation"
+      title="Einträge entfernen"
+      [message]="
+        selectedCount + ' Einträge aus der Auswahlliste „' + collection.name + '“ entfernen?'
+      "
+      confirmLabel="Entfernen"
+      [busy]="vm.collectionBusy"
+      [error]="removeConfirmationError"
+      busyLabel="Wird entfernt …"
+      (confirmed)="confirmRemoveSelected()"
+      (cancelled)="cancelRemoveConfirmation()"
+    />
   }
 }

--- a/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.spec.ts
+++ b/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.spec.ts
@@ -1,0 +1,123 @@
+/// <reference types="vite/client" />
+
+import { ɵresolveComponentResources as resolveComponentResources } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { ItemExplorerFacade } from '../../item-explorer.facade';
+import { ItemExplorerCollectionsComponent } from './item-explorer-collections.component';
+import collectionsTemplate from './item-explorer-collections.component.html?raw';
+import collectionsStyles from './item-explorer-collections.component.css?raw';
+
+describe('ItemExplorerCollectionsComponent', () => {
+  beforeAll(async () => {
+    await resolveComponentResources((url) => {
+      if (url.endsWith('item-explorer-collections.component.html')) {
+        return Promise.resolve(collectionsTemplate);
+      }
+      if (url.endsWith('item-explorer-collections.component.css')) {
+        return Promise.resolve(collectionsStyles);
+      }
+      return Promise.reject(new Error(`Unexpected component resource: ${url}`));
+    });
+  });
+
+  afterAll(() => TestBed.resetTestingModule());
+
+  it('renders no more than 50 collection rows for 10,000 entries', async () => {
+    const entries = Array.from({ length: 10_000 }, (_, index) => ({
+      rowKey: `row-${index}`,
+      position: index + 1,
+      item: {
+        unitLabel: `Aufgabe ${index}`,
+        itemId: `item-${index}`,
+        subId: String(index),
+      },
+    }));
+    const summary = {
+      rowCount: entries.length,
+      itemCount: entries.length,
+      unitCount: entries.length,
+      itemTimeSeconds: 0,
+      stimulusTimeSeconds: 0,
+      testTimeSeconds: 0,
+      missingItemTimeCount: entries.length,
+      missingStimulusTimeUnitCount: entries.length,
+      complete: false,
+    };
+    const collection = {
+      id: 'collection-1',
+      name: 'Große Auswahlliste',
+      rowKeys: entries.map((entry) => entry.rowKey),
+      version: 1,
+      createdAt: '',
+      updatedAt: '',
+      unavailableRowKeys: [],
+      summary,
+    };
+    const noop = vi.fn();
+    const vm = {
+      enableItemCollections: true,
+      collectionLoadState: 'loaded',
+      collectionBusy: false,
+      collectionError: '',
+      collectionViewMode: 'all',
+      activeCollectionId: collection.id,
+      activeItemCollection: collection,
+      activeCollectionItems: entries,
+      itemCollections: [collection],
+      showCollectionDialog: true,
+      activateCollection: noop,
+      clearActiveCollection: noop,
+      closeCollectionDialog: noop,
+      createCollection: noop,
+      deleteActiveCollection: noop,
+      exportActiveCollection: noop,
+      formatDuration: () => '0:00',
+      loadItemCollections: noop,
+      openCollectionDialog: noop,
+      removeRowFromActiveCollection: noop,
+      removeRowsFromActiveCollection: noop,
+      renameActiveCollection: noop,
+      setCollectionViewMode: noop,
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ItemExplorerCollectionsComponent],
+      providers: [{ provide: ItemExplorerFacade, useValue: { collectionsViewModel: vm } }],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(ItemExplorerCollectionsComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('.collection-table tbody tr')).toHaveLength(50);
+  });
+
+  it('resets selection on collection changes and isolates removal errors', async () => {
+    const vm = {
+      activeItemCollection: { id: 'collection-1' },
+      activeCollectionItems: [{ rowKey: 'shared-row', position: 1, item: null }],
+      collectionBusy: false,
+      collectionError: 'Ein vorheriger Export ist fehlgeschlagen.',
+      removeRowsFromActiveCollection: vi.fn().mockImplementation(async () => {
+        vm.collectionError = 'Die Auswahlliste konnte nicht gespeichert werden.';
+        return false;
+      }),
+    } as any;
+    const component = new ItemExplorerCollectionsComponent({ collectionsViewModel: vm } as any);
+    component.ngDoCheck();
+    component.toggleRowSelection('shared-row', true);
+
+    component.openRemoveConfirmation();
+    expect(component.removeConfirmationError).toBe('');
+    await component.confirmRemoveSelected();
+    expect(component.removeConfirmationError).toBe(
+      'Die Auswahlliste konnte nicht gespeichert werden.',
+    );
+
+    vm.activeItemCollection = { id: 'collection-2' };
+    component.ngDoCheck();
+
+    expect(component.selectedCount).toBe(0);
+    expect(component.showRemoveConfirmation).toBe(false);
+    expect(component.removeConfirmationError).toBe('');
+  });
+});

--- a/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.ts
+++ b/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.ts
@@ -26,6 +26,8 @@ export class ItemExplorerCollectionsComponent implements DoCheck {
   @ViewChild('collectionDialog') private collectionDialog?: ElementRef<HTMLElement>;
   @ViewChild('collectionSearch') private collectionSearch?: ElementRef<HTMLInputElement>;
   @ViewChild('removeSelectedButton') private removeSelectedButton?: ElementRef<HTMLButtonElement>;
+  @ViewChild('removeConfirmation', { read: ElementRef })
+  private removeConfirmation?: ElementRef<HTMLElement>;
 
   private detailsTrigger: HTMLElement | null = null;
   private collectionIdSource: string | null = null;
@@ -109,7 +111,7 @@ export class ItemExplorerCollectionsComponent implements DoCheck {
     this.detailsTrigger = trigger;
     this.resetDialogState();
     this.vm.openCollectionDialog();
-    setTimeout(() => this.collectionSearch?.nativeElement.focus());
+    this.focusCollectionSearch();
   }
 
   closeDetails(): void {
@@ -157,7 +159,7 @@ export class ItemExplorerCollectionsComponent implements DoCheck {
     if (!this.selectedCount || this.vm.collectionBusy) return;
     this.removeConfirmationError = '';
     this.showRemoveConfirmation = true;
-    setTimeout(() => this.getConfirmationDialog()?.querySelector<HTMLElement>('button')?.focus());
+    this.focusRemoveConfirmation();
   }
 
   cancelRemoveConfirmation(): void {
@@ -174,7 +176,7 @@ export class ItemExplorerCollectionsComponent implements DoCheck {
       this.selectedRowKeys.clear();
       this.showRemoveConfirmation = false;
       this.filteredSource = null;
-      setTimeout(() => this.collectionSearch?.nativeElement.focus());
+      this.focusCollectionSearch();
     } else {
       this.removeConfirmationError =
         this.vm.collectionError || 'Die ausgewählten Einträge konnten nicht entfernt werden.';
@@ -244,7 +246,29 @@ export class ItemExplorerCollectionsComponent implements DoCheck {
   }
 
   private getConfirmationDialog(): HTMLElement | null {
-    return document.querySelector('.collection-remove-confirmation .dialog');
+    return this.removeConfirmation?.nativeElement.querySelector('.dialog') || null;
+  }
+
+  private focusRemoveConfirmation(attempt = 0): void {
+    setTimeout(() => {
+      const button = this.getConfirmationDialog()?.querySelector<HTMLElement>('button');
+      if (button) {
+        button.focus();
+      } else if (attempt < 2 && this.showRemoveConfirmation) {
+        this.focusRemoveConfirmation(attempt + 1);
+      }
+    });
+  }
+
+  private focusCollectionSearch(attempt = 0): void {
+    setTimeout(() => {
+      const search = this.collectionSearch?.nativeElement;
+      if (search) {
+        search.focus();
+      } else if (attempt < 2 && this.vm.showCollectionDialog) {
+        this.focusCollectionSearch(attempt + 1);
+      }
+    });
   }
 
   private getFocusableElements(container: HTMLElement): HTMLElement[] {

--- a/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.ts
+++ b/frontend/src/app/views/item-explorer/components/collections/item-explorer-collections.component.ts
@@ -1,20 +1,257 @@
-import { Component, Inject } from '@angular/core';
+import { Component, DoCheck, ElementRef, HostListener, Inject, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ItemExplorerFacade } from '../../item-explorer.facade';
 import { ItemExplorerCollectionsViewModel } from '../../item-explorer.view-models';
+import { ConfirmDialogComponent } from '../../../../shared/components/confirm-dialog.component';
+
+type CollectionEntry = ItemExplorerCollectionsViewModel['activeCollectionItems'][number];
 
 @Component({
   selector: 'app-item-explorer-collections',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ConfirmDialogComponent],
   templateUrl: './item-explorer-collections.component.html',
   styleUrl: './item-explorer-collections.component.css',
 })
-export class ItemExplorerCollectionsComponent {
+export class ItemExplorerCollectionsComponent implements DoCheck {
   readonly vm: ItemExplorerCollectionsViewModel;
+  readonly pageSize = 50;
+  collectionFilterText = '';
+  collectionPage = 1;
+  selectedRowKeys = new Set<string>();
+  showRemoveConfirmation = false;
+  removeConfirmationError = '';
+
+  @ViewChild('collectionDialog') private collectionDialog?: ElementRef<HTMLElement>;
+  @ViewChild('collectionSearch') private collectionSearch?: ElementRef<HTMLInputElement>;
+  @ViewChild('removeSelectedButton') private removeSelectedButton?: ElementRef<HTMLButtonElement>;
+
+  private detailsTrigger: HTMLElement | null = null;
+  private collectionIdSource: string | null = null;
+  private filteredSource: readonly CollectionEntry[] | null = null;
+  private filteredTerm = '';
+  private filteredCache: readonly CollectionEntry[] = [];
+  private pagedSource: readonly CollectionEntry[] | null = null;
+  private pagedPage = 0;
+  private pagedCache: readonly CollectionEntry[] = [];
 
   constructor(@Inject(ItemExplorerFacade) facade: ItemExplorerFacade) {
     this.vm = facade.collectionsViewModel;
+  }
+
+  ngDoCheck(): void {
+    const collectionId = this.vm.activeItemCollection?.id || null;
+    if (this.collectionIdSource === collectionId) return;
+    this.collectionIdSource = collectionId;
+    this.resetCollectionSelection();
+    this.filteredSource = null;
+    this.pagedSource = null;
+  }
+
+  get filteredCollectionItems(): readonly CollectionEntry[] {
+    const source = this.vm.activeCollectionItems;
+    const term = this.collectionFilterText.trim().toLocaleLowerCase();
+    if (this.filteredSource !== source || this.filteredTerm !== term) {
+      this.filteredSource = source;
+      this.filteredTerm = term;
+      this.filteredCache = term
+        ? source.filter((entry) => {
+            const item = entry.item;
+            return [
+              entry.rowKey,
+              item?.unitLabel,
+              item?.itemId,
+              item?.subIdDisplay,
+              item?.subId,
+            ].some((value) => value?.toLocaleLowerCase().includes(term));
+          })
+        : source;
+      this.pruneSelection(source);
+      this.clampPage();
+      this.pagedSource = null;
+    }
+    return this.filteredCache;
+  }
+
+  get collectionPageCount(): number {
+    return Math.max(1, Math.ceil(this.filteredCollectionItems.length / this.pageSize));
+  }
+
+  get pagedCollectionItems(): readonly CollectionEntry[] {
+    const filtered = this.filteredCollectionItems;
+    if (this.pagedSource !== filtered || this.pagedPage !== this.collectionPage) {
+      const start = (this.collectionPage - 1) * this.pageSize;
+      this.pagedSource = filtered;
+      this.pagedPage = this.collectionPage;
+      this.pagedCache = filtered.slice(start, start + this.pageSize);
+    }
+    return this.pagedCache;
+  }
+
+  get selectedCount(): number {
+    return this.selectedRowKeys.size;
+  }
+
+  get currentPageFullySelected(): boolean {
+    const page = this.pagedCollectionItems;
+    return page.length > 0 && page.every((entry) => this.selectedRowKeys.has(entry.rowKey));
+  }
+
+  get currentPagePartiallySelected(): boolean {
+    const selectedOnPage = this.pagedCollectionItems.filter((entry) =>
+      this.selectedRowKeys.has(entry.rowKey),
+    ).length;
+    return selectedOnPage > 0 && selectedOnPage < this.pagedCollectionItems.length;
+  }
+
+  openDetails(trigger: HTMLElement): void {
+    this.detailsTrigger = trigger;
+    this.resetDialogState();
+    this.vm.openCollectionDialog();
+    setTimeout(() => this.collectionSearch?.nativeElement.focus());
+  }
+
+  closeDetails(): void {
+    if (this.vm.collectionBusy) return;
+    this.vm.closeCollectionDialog();
+    this.resetDialogState();
+    setTimeout(() => this.detailsTrigger?.focus());
+  }
+
+  setCollectionFilterText(value: string): void {
+    this.collectionFilterText = value;
+    this.collectionPage = 1;
+    this.selectedRowKeys.clear();
+    this.filteredSource = null;
+  }
+
+  previousPage(): void {
+    if (this.collectionPage > 1) this.collectionPage -= 1;
+  }
+
+  nextPage(): void {
+    if (this.collectionPage < this.collectionPageCount) this.collectionPage += 1;
+  }
+
+  toggleRowSelection(rowKey: string, selected: boolean): void {
+    if (selected) this.selectedRowKeys.add(rowKey);
+    else this.selectedRowKeys.delete(rowKey);
+  }
+
+  toggleCurrentPage(selected: boolean): void {
+    for (const entry of this.pagedCollectionItems) {
+      if (selected) this.selectedRowKeys.add(entry.rowKey);
+      else this.selectedRowKeys.delete(entry.rowKey);
+    }
+  }
+
+  async removeOne(rowKey: string): Promise<void> {
+    if (await this.vm.removeRowFromActiveCollection(rowKey)) {
+      this.selectedRowKeys.delete(rowKey);
+      this.filteredSource = null;
+    }
+  }
+
+  openRemoveConfirmation(): void {
+    if (!this.selectedCount || this.vm.collectionBusy) return;
+    this.removeConfirmationError = '';
+    this.showRemoveConfirmation = true;
+    setTimeout(() => this.getConfirmationDialog()?.querySelector<HTMLElement>('button')?.focus());
+  }
+
+  cancelRemoveConfirmation(): void {
+    if (this.vm.collectionBusy) return;
+    this.showRemoveConfirmation = false;
+    this.removeConfirmationError = '';
+    setTimeout(() => this.removeSelectedButton?.nativeElement.focus());
+  }
+
+  async confirmRemoveSelected(): Promise<void> {
+    const rowKeys = [...this.selectedRowKeys];
+    this.removeConfirmationError = '';
+    if (await this.vm.removeRowsFromActiveCollection(rowKeys)) {
+      this.selectedRowKeys.clear();
+      this.showRemoveConfirmation = false;
+      this.filteredSource = null;
+      setTimeout(() => this.collectionSearch?.nativeElement.focus());
+    } else {
+      this.removeConfirmationError =
+        this.vm.collectionError || 'Die ausgewählten Einträge konnten nicht entfernt werden.';
+    }
+  }
+
+  async deleteActiveCollection(): Promise<void> {
+    await this.vm.deleteActiveCollection();
+    if (!this.vm.showCollectionDialog) {
+      this.resetDialogState();
+      setTimeout(() => this.detailsTrigger?.focus());
+    }
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  onDocumentKeydown(event: KeyboardEvent): void {
+    if (!this.vm.showCollectionDialog) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (this.showRemoveConfirmation) this.cancelRemoveConfirmation();
+      else this.closeDetails();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const container = this.showRemoveConfirmation
+      ? this.getConfirmationDialog()
+      : this.collectionDialog?.nativeElement;
+    if (!container) return;
+    const focusable = this.getFocusableElements(container);
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  private resetDialogState(): void {
+    this.collectionFilterText = '';
+    this.collectionPage = 1;
+    this.collectionIdSource = this.vm.activeItemCollection?.id || null;
+    this.resetCollectionSelection();
+    this.filteredSource = null;
+    this.pagedSource = null;
+  }
+
+  private resetCollectionSelection(): void {
+    this.selectedRowKeys.clear();
+    this.showRemoveConfirmation = false;
+    this.removeConfirmationError = '';
+  }
+
+  private clampPage(): void {
+    const pageCount = Math.max(1, Math.ceil(this.filteredCache.length / this.pageSize));
+    this.collectionPage = Math.min(Math.max(1, this.collectionPage), pageCount);
+  }
+
+  private pruneSelection(source: readonly CollectionEntry[]): void {
+    const available = new Set(source.map((entry) => entry.rowKey));
+    for (const rowKey of this.selectedRowKeys) {
+      if (!available.has(rowKey)) this.selectedRowKeys.delete(rowKey);
+    }
+  }
+
+  private getConfirmationDialog(): HTMLElement | null {
+    return document.querySelector('.collection-remove-confirmation .dialog');
+  }
+
+  private getFocusableElements(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+      container.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((element) => !element.hasAttribute('hidden'));
   }
 }

--- a/frontend/src/app/views/item-explorer/components/item-explorer-presentational-components.spec.ts
+++ b/frontend/src/app/views/item-explorer/components/item-explorer-presentational-components.spec.ts
@@ -74,7 +74,7 @@ describe('ItemExplorer presentational components', () => {
     ['header fullscreen', headerTemplate, '(click)="vm.toggleFullscreen()"'],
     ['header save', headerTemplate, '(click)="vm.openSavePreviewDialog()"'],
     ['collections create', collectionsTemplate, '(click)="vm.createCollection()"'],
-    ['collections delete', collectionsTemplate, '(click)="vm.deleteActiveCollection()"'],
+    ['collections delete', collectionsTemplate, '(click)="deleteActiveCollection()"'],
     ['coding close', codingTemplate, '(click)="vm.closeCodingOverlay()"'],
     ['metadata close', metadataTemplate, '(click)="vm.setMetadataDrawerOpen(false)"'],
     ['upload close', uploadTemplate, '(click)="vm.closeUploadReport(true)"'],
@@ -88,5 +88,38 @@ describe('ItemExplorer presentational components', () => {
 
   it('gives the collection selector an accessible name', () => {
     expect(collectionsTemplate).toContain('aria-label="Aktive persönliche Auswahlliste auswählen"');
+  });
+
+  it('renders collection details as an accessible paginated modal', () => {
+    expect(collectionsTemplate).toContain('role="dialog"');
+    expect(collectionsTemplate).toContain('aria-modal="true"');
+    expect(collectionsTemplate).toContain('pagedCollectionItems');
+    expect(collectionsTemplate).toContain('Alle Einträge auf dieser Seite auswählen');
+    expect(collectionsTemplate).toContain('[error]="removeConfirmationError"');
+  });
+
+  it('filters and paginates large collections without exposing more than 50 rows', () => {
+    const entries = Array.from({ length: 10_000 }, (_, index) => ({
+      rowKey: `row-${index}`,
+      position: index + 1,
+      item: {
+        unitLabel: `Aufgabe ${index}`,
+        itemId: `item-${index}`,
+        subId: String(index),
+      },
+    }));
+    const vm = { activeCollectionItems: entries };
+    const component = new ItemExplorerCollectionsComponent({ collectionsViewModel: vm } as any);
+
+    expect(component.pagedCollectionItems).toHaveLength(50);
+    component.nextPage();
+    expect(component.pagedCollectionItems[0].position).toBe(51);
+
+    component.toggleCurrentPage(true);
+    expect(component.selectedCount).toBe(50);
+    component.setCollectionFilterText('item-9999');
+    expect(component.selectedCount).toBe(0);
+    expect(component.filteredCollectionItems.map((entry) => entry.rowKey)).toEqual(['row-9999']);
+    expect(component.collectionPage).toBe(1);
   });
 });

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.spec.ts
@@ -3793,34 +3793,27 @@ describe('ItemExplorerFacade', () => {
   });
 
   it('persists selection changes against the active collection version', async () => {
-    const response = {
-      activeCollectionId: 'collection-1',
-      collections: [
-        {
-          id: 'collection-1',
-          name: 'Auswahl',
-          rowKeys: ['uuid-1'],
-          version: 2,
-          createdAt: '',
-          updatedAt: '',
-          unavailableRowKeys: [],
-          summary: {
-            rowCount: 1,
-            itemCount: 1,
-            unitCount: 1,
-            itemTimeSeconds: 10,
-            stimulusTimeSeconds: 5,
-            testTimeSeconds: 15,
-            missingItemTimeCount: 0,
-            missingStimulusTimeUnitCount: 0,
-            complete: true,
-          },
-        },
-      ],
+    const summary = {
+      rowCount: 1,
+      itemCount: 1,
+      unitCount: 1,
+      itemTimeSeconds: 10,
+      stimulusTimeSeconds: 5,
+      testTimeSeconds: 15,
+      missingItemTimeCount: 0,
+      missingStimulusTimeUnitCount: 0,
+      complete: true,
     };
-    const updateItemCollection = vi.fn().mockReturnValue(of(response));
+    const mutateItemCollectionRows = vi.fn().mockReturnValue(
+      of({
+        collectionId: 'collection-1',
+        version: 2,
+        updatedAt: '2026-07-22T10:00:00.000Z',
+        summary,
+      }),
+    );
     const component = createFacade({
-      api: { updateItemCollection },
+      api: { mutateItemCollectionRows },
       authService: { isLoggedIn: true },
     });
     const item = {
@@ -3839,10 +3832,14 @@ describe('ItemExplorerFacade', () => {
     component.items = [item];
     component.itemCollections = [
       {
-        ...response.collections[0],
+        id: 'collection-1',
+        name: 'Auswahl',
         rowKeys: [],
         version: 1,
-        summary: { ...response.collections[0].summary, rowCount: 0 },
+        createdAt: '',
+        updatedAt: '',
+        unavailableRowKeys: [],
+        summary: { ...summary, rowCount: 0 },
       },
     ];
     component.activeCollectionId = 'collection-1';
@@ -3850,13 +3847,105 @@ describe('ItemExplorerFacade', () => {
 
     await component.toggleItemInActiveCollection(item);
 
-    expect(updateItemCollection).toHaveBeenCalledWith(
-      'acp-1',
-      'collection-1',
-      { baseVersion: 1, rowKeys: ['uuid-1'] },
-      'read-only',
-    );
+    expect(mutateItemCollectionRows).toHaveBeenCalledWith('acp-1', 'collection-1', {
+      baseVersion: 1,
+      addRowKeys: ['uuid-1'],
+      perspective: 'read-only',
+    });
     expect(component.activeItemCollection?.version).toBe(2);
+    expect(component.activeItemCollection?.rowKeys).toEqual(['uuid-1']);
+  });
+
+  it('caches collection item lookups and membership sets until their sources change', () => {
+    const component = createFacade();
+    const item = {
+      itemId: 'item-1',
+      uuid: 'uuid-1',
+      rowKey: 'uuid-1',
+      unitId: 'unit-1',
+      unitLabel: 'Aufgabe 1',
+      description: '',
+      variableId: 'v1',
+      metadata: {},
+    };
+    component.items = [item];
+    component.itemCollections = [
+      {
+        id: 'collection-1',
+        name: 'Auswahl',
+        rowKeys: ['uuid-1'],
+        version: 1,
+        createdAt: '',
+        updatedAt: '',
+        unavailableRowKeys: [],
+        summary: {} as any,
+      },
+    ];
+    component.activeCollectionId = 'collection-1';
+
+    const firstEntries = component.activeCollectionItems;
+    expect(component.activeCollectionItems).toBe(firstEntries);
+    expect(component.isItemInActiveCollection(item)).toBe(true);
+
+    component.activeItemCollection!.rowKeys = [];
+    expect(component.activeCollectionItems).not.toBe(firstEntries);
+    expect(component.isItemInActiveCollection(item)).toBe(false);
+  });
+
+  it('rolls back failed batch removals and sends clear as a compact mutation', async () => {
+    const summary = {
+      rowCount: 2,
+      itemCount: 2,
+      unitCount: 1,
+      itemTimeSeconds: 0,
+      stimulusTimeSeconds: 0,
+      testTimeSeconds: 0,
+      missingItemTimeCount: 2,
+      missingStimulusTimeUnitCount: 1,
+      complete: false,
+    };
+    const mutateItemCollectionRows = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => ({ status: 500 })))
+      .mockReturnValueOnce(
+        of({
+          collectionId: 'collection-1',
+          version: 2,
+          updatedAt: '2026-07-22T10:00:00.000Z',
+          summary: { ...summary, rowCount: 0, itemCount: 0, unitCount: 0 },
+        }),
+      );
+    const component = createFacade({
+      api: { mutateItemCollectionRows },
+      authService: { isLoggedIn: true },
+    });
+    component.acpId = 'acp-1';
+    component.itemCollections = [
+      {
+        id: 'collection-1',
+        name: 'Auswahl',
+        rowKeys: ['row-1', 'row-2'],
+        version: 1,
+        createdAt: '',
+        updatedAt: '',
+        unavailableRowKeys: ['row-2'],
+        summary,
+      },
+    ];
+    component.activeCollectionId = 'collection-1';
+
+    await expect(component.removeRowsFromActiveCollection(['row-1', 'row-2'])).resolves.toBe(false);
+    expect(component.activeItemCollection?.rowKeys).toEqual(['row-1', 'row-2']);
+    expect(component.activeItemCollection?.unavailableRowKeys).toEqual(['row-2']);
+    expect(component.collectionError).toContain('konnte nicht gespeichert werden');
+
+    await expect(component.clearActiveCollection()).resolves.toBe(true);
+    expect(mutateItemCollectionRows).toHaveBeenLastCalledWith('acp-1', 'collection-1', {
+      baseVersion: 1,
+      clear: true,
+      perspective: 'read-only',
+    });
+    expect(component.activeItemCollection?.rowKeys).toEqual([]);
   });
 
   it('persists and applies the active personal selection view after base visibility rules', async () => {

--- a/frontend/src/app/views/item-explorer/item-explorer.facade.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.facade.ts
@@ -203,9 +203,20 @@ export class ItemExplorerFacade implements OnDestroy {
   collectionLoadState: 'idle' | 'loading' | 'loaded' | 'error' = 'idle';
   collectionBusy = false;
   collectionError = '';
-  showCollectionDrawer = false;
+  showCollectionDialog = false;
   private collectionSessionIdentity: string | null = null;
   private collectionSessionVersion = 0;
+  private collectionItemMapSource: ExplorerItem[] | null = null;
+  private collectionItemMap = new Map<string, ExplorerItem>();
+  private collectionItemsCacheSource: string[] | null = null;
+  private collectionItemsCacheItemSource: ExplorerItem[] | null = null;
+  private collectionItemsCache: Array<{
+    rowKey: string;
+    position: number;
+    item: ExplorerItem | null;
+  }> = [];
+  private activeCollectionSetSource: string[] | null = null;
+  private activeCollectionRowKeySet = new Set<string>();
 
   private readonly draftPatchDebounceMs = 250;
   private draftPatchTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -485,12 +496,29 @@ export class ItemExplorerFacade implements OnDestroy {
 
   get activeCollectionItems(): Array<{
     rowKey: string;
+    position: number;
     item: ExplorerItem | null;
   }> {
     const collection = this.activeItemCollection;
-    if (!collection) return [];
-    const itemMap = new Map(this.items.map((item) => [item.rowKey, item] as const));
-    return collection.rowKeys.map((rowKey) => ({ rowKey, item: itemMap.get(rowKey) || null }));
+    if (!collection) {
+      this.collectionItemsCacheSource = null;
+      this.collectionItemsCache = [];
+      return this.collectionItemsCache;
+    }
+    if (
+      this.collectionItemsCacheSource !== collection.rowKeys ||
+      this.collectionItemsCacheItemSource !== this.items
+    ) {
+      const itemMap = this.getCollectionItemMap();
+      this.collectionItemsCacheSource = collection.rowKeys;
+      this.collectionItemsCacheItemSource = this.items;
+      this.collectionItemsCache = collection.rowKeys.map((rowKey, index) => ({
+        rowKey,
+        position: index + 1,
+        item: itemMap.get(rowKey) || null,
+      }));
+    }
+    return this.collectionItemsCache;
   }
 
   get selectedPreviewTarget(): string {
@@ -812,8 +840,12 @@ export class ItemExplorerFacade implements OnDestroy {
     this.columnFilterText = value;
   }
 
-  toggleCollectionDrawer(): void {
-    this.showCollectionDrawer = !this.showCollectionDrawer;
+  openCollectionDialog(): void {
+    if (this.activeItemCollection) this.showCollectionDialog = true;
+  }
+
+  closeCollectionDialog(): void {
+    if (!this.collectionBusy) this.showCollectionDialog = false;
   }
 
   setMetadataDrawerOpen(open: boolean): void {
@@ -1190,7 +1222,7 @@ export class ItemExplorerFacade implements OnDestroy {
     this.collectionBusy = false;
     this.collectionError = '';
     this.collectionLoadState = 'idle';
-    this.showCollectionDrawer = false;
+    this.showCollectionDialog = false;
     this.applyFilter(false);
     if (nextIdentity) {
       this.loadItemCollections();
@@ -1306,30 +1338,31 @@ export class ItemExplorerFacade implements OnDestroy {
   }
 
   isItemInActiveCollection(item: ReadonlyExplorerItem): boolean {
-    return this.activeItemCollection?.rowKeys.includes(item.rowKey) === true;
+    return this.getActiveCollectionRowKeySet().has(item.rowKey);
   }
 
   async toggleItemInActiveCollection(item: ReadonlyExplorerItem) {
     let collection = this.activeItemCollection;
     if (!collection) collection = await this.createCollection();
     if (!collection) return;
-    const nextRowKeys = collection.rowKeys.includes(item.rowKey)
-      ? collection.rowKeys.filter((rowKey) => rowKey !== item.rowKey)
-      : [...collection.rowKeys, item.rowKey];
-    await this.persistActiveCollectionRows(nextRowKeys);
+    const mutation = this.getActiveCollectionRowKeySet().has(item.rowKey)
+      ? { removeRowKeys: [item.rowKey] }
+      : { addRowKeys: [item.rowKey] };
+    await this.persistActiveCollectionRowsMutation(mutation);
   }
 
-  async removeRowFromActiveCollection(rowKey: string) {
-    const collection = this.activeItemCollection;
-    if (!collection) return;
-    await this.persistActiveCollectionRows(
-      collection.rowKeys.filter((candidate) => candidate !== rowKey),
-    );
+  async removeRowFromActiveCollection(rowKey: string): Promise<boolean> {
+    return this.removeRowsFromActiveCollection([rowKey]);
   }
 
-  async clearActiveCollection() {
-    if (!this.activeItemCollection?.rowKeys.length) return;
-    await this.persistActiveCollectionRows([]);
+  async removeRowsFromActiveCollection(rowKeys: string[]): Promise<boolean> {
+    if (!rowKeys.length) return true;
+    return this.persistActiveCollectionRowsMutation({ removeRowKeys: rowKeys });
+  }
+
+  async clearActiveCollection(): Promise<boolean> {
+    if (!this.activeItemCollection?.rowKeys.length) return true;
+    return this.persistActiveCollectionRowsMutation({ clear: true });
   }
 
   async renameActiveCollection() {
@@ -1358,7 +1391,7 @@ export class ItemExplorerFacade implements OnDestroy {
       );
       if (!this.isCurrentItemCollectionSession(session)) return;
       this.applyItemCollectionsPayload(payload);
-      if (!this.activeItemCollection) this.showCollectionDrawer = false;
+      this.showCollectionDialog = false;
     } catch {
       if (!this.isCurrentItemCollectionSession(session)) return;
       this.collectionError = 'Die Auswahlliste konnte nicht gelöscht werden.';
@@ -1407,8 +1440,63 @@ export class ItemExplorerFacade implements OnDestroy {
       : `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
   }
 
-  private async persistActiveCollectionRows(rowKeys: string[]) {
-    await this.persistActiveCollectionUpdate({ rowKeys });
+  private async persistActiveCollectionRowsMutation(
+    mutation: { addRowKeys: string[] } | { removeRowKeys: string[] } | { clear: true },
+  ): Promise<boolean> {
+    const collection = this.activeItemCollection;
+    if (!collection || this.collectionBusy) return false;
+    const session = this.getItemCollectionSession();
+    if (!session.identity) return false;
+    const previous = structuredClone(collection);
+    if ('addRowKeys' in mutation) {
+      const existing = new Set(collection.rowKeys);
+      collection.rowKeys = [
+        ...collection.rowKeys,
+        ...mutation.addRowKeys.filter((rowKey) => !existing.has(rowKey)),
+      ];
+    } else if ('removeRowKeys' in mutation) {
+      const removals = new Set(mutation.removeRowKeys);
+      collection.rowKeys = collection.rowKeys.filter((rowKey) => !removals.has(rowKey));
+      collection.unavailableRowKeys = collection.unavailableRowKeys.filter(
+        (rowKey) => !removals.has(rowKey),
+      );
+    } else {
+      collection.rowKeys = [];
+      collection.unavailableRowKeys = [];
+    }
+    this.recalculateCollectionSummaries();
+    this.applyFilter(false);
+    this.collectionBusy = true;
+    this.collectionError = '';
+    try {
+      const result = await firstValueFrom(
+        this.api.mutateItemCollectionRows(this.acpId, collection.id, {
+          baseVersion: previous.version,
+          perspective: this.getPerspectiveForViewerRequests(),
+          ...mutation,
+        }),
+      );
+      if (!this.isCurrentItemCollectionSession(session)) return false;
+      const updated = this.itemCollections.find((candidate) => candidate.id === collection.id);
+      if (!updated) return false;
+      updated.version = result.version;
+      updated.updatedAt = result.updatedAt;
+      updated.summary = result.summary;
+      return true;
+    } catch (error: any) {
+      if (!this.isCurrentItemCollectionSession(session)) return false;
+      const index = this.itemCollections.findIndex((candidate) => candidate.id === previous.id);
+      if (index >= 0) this.itemCollections[index] = previous;
+      this.applyFilter(false);
+      this.collectionError =
+        error?.status === 409
+          ? 'Die Auswahlliste wurde parallel geändert und wird neu geladen.'
+          : 'Die Auswahlliste konnte nicht gespeichert werden.';
+      if (error?.status === 409) this.loadItemCollections(true);
+      return false;
+    } finally {
+      if (this.isCurrentItemCollectionSession(session)) this.collectionBusy = false;
+    }
   }
 
   private async persistActiveCollectionUpdate(update: { name?: string; rowKeys?: string[] }) {
@@ -1497,7 +1585,7 @@ export class ItemExplorerFacade implements OnDestroy {
   }
 
   private recalculateCollectionSummaries() {
-    const itemMap = new Map(this.items.map((item) => [item.rowKey, item] as const));
+    const itemMap = this.getCollectionItemMap();
     this.itemCollections = this.itemCollections.map((collection) => {
       const items = collection.rowKeys
         .map((rowKey) => itemMap.get(rowKey))
@@ -1508,6 +1596,23 @@ export class ItemExplorerFacade implements OnDestroy {
         summary: this.calculateCollectionSummary(items, collection.rowKeys.length),
       };
     });
+  }
+
+  private getCollectionItemMap(): Map<string, ExplorerItem> {
+    if (this.collectionItemMapSource !== this.items) {
+      this.collectionItemMapSource = this.items;
+      this.collectionItemMap = new Map(this.items.map((item) => [item.rowKey, item] as const));
+    }
+    return this.collectionItemMap;
+  }
+
+  private getActiveCollectionRowKeySet(): Set<string> {
+    const rowKeys = this.activeItemCollection?.rowKeys || null;
+    if (this.activeCollectionSetSource !== rowKeys) {
+      this.activeCollectionSetSource = rowKeys;
+      this.activeCollectionRowKeySet = new Set(rowKeys || []);
+    }
+    return this.activeCollectionRowKeySet;
   }
 
   private calculateCollectionSummary(

--- a/frontend/src/app/views/item-explorer/item-explorer.view-models.ts
+++ b/frontend/src/app/views/item-explorer/item-explorer.view-models.ts
@@ -176,10 +176,12 @@ export type ItemExplorerCollectionsViewModel = ReadonlyViewModelSlice<
     | 'itemCollections'
     | 'loadItemCollections'
     | 'removeRowFromActiveCollection'
+    | 'removeRowsFromActiveCollection'
     | 'renameActiveCollection'
-    | 'showCollectionDrawer'
+    | 'showCollectionDialog'
+    | 'openCollectionDialog'
+    | 'closeCollectionDialog'
     | 'setCollectionViewMode'
-    | 'toggleCollectionDrawer'
   >
 >;
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -352,37 +352,6 @@ app-item-explorer {
     margin: 6px 12px;
   }
 
-  .collection-drawer {
-    padding: 12px;
-    border-bottom: 1px solid var(--color-border);
-    background: var(--color-surface);
-    max-height: 240px;
-    overflow: auto;
-    flex-shrink: 0;
-  }
-
-  .collection-drawer-header,
-  .collection-items li {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-  }
-
-  .collection-drawer-header > div {
-    display: flex;
-    gap: 6px;
-  }
-
-  .collection-items {
-    margin: 10px 0 0;
-    padding-left: 24px;
-  }
-
-  .collection-items li {
-    padding: 5px 0;
-  }
-
   .collection-select-col {
     width: 38px;
     min-width: 38px;


### PR DESCRIPTION
## Summary

- replace the inline personal collection details with an accessible, viewport-sized modal
- add client-side search, 50-row pagination, page selection, and confirmed batch removal
- introduce a compact versioned row-mutation API for add, remove, and clear operations
- cache collection lookups and membership checks for large collections
- preserve unavailable rows so they remain searchable and removable

## Why

Rendering every stored row inline displaced the main item table and did not scale to collections containing thousands of entries. Single-row changes also transferred the complete collection on every update.

## Impact

The details view now renders at most 50 rows at once while keeping the stored order. Row mutations send only the affected keys and keep optimistic update, rollback, and conflict-reload behavior. Existing rename, delete, CSV export, activation, and active-only filtering remain compatible.

## Validation

- backend test suite: 674 tests passed
- frontend test suite: 483 tests passed
- frontend and backend builds passed
- frontend and backend lint passed
- Playwright collection flows passed, including pagination and cross-page batch removal
- diff whitespace validation passed
