### PR TITLE
Fix Keycloak logout redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable changes to ContentPool are documented in this file. Releases use
   paginated collection-detail editing.
 - Route all application-user authentication through Keycloak OIDC while
   retaining ACP-specific credential-list access for restricted viewers.
+- Return OIDC logout to the installer-approved `/login` URL so existing
+  Keycloak client settings accept the post-logout redirect.
 
 ### Breaking changes
 

--- a/frontend/src/app/core/services/auth.service.oidc.spec.ts
+++ b/frontend/src/app/core/services/auth.service.oidc.spec.ts
@@ -317,6 +317,22 @@ describe('AuthService OIDC and Crypto Paths', () => {
     expect(sessionStorage.getItem('oidc_code_verifier')).toBeNull();
   });
 
+  it('uses the installer-approved login URL for the Keycloak logout redirect', () => {
+    const navigateSpy = vi
+      .spyOn(service as any, 'navigateBrowserTo')
+      .mockImplementation(() => undefined);
+
+    (service as any).redirectToKeycloakLogout('id-token');
+
+    const logoutUrl = new URL(navigateSpy.mock.calls[0][0]);
+    expect(logoutUrl.pathname).toBe('/protocol/openid-connect/logout');
+    expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe(
+      `${window.location.origin}/login`,
+    );
+    expect(logoutUrl.searchParams.get('client_id')).toBe(oidcConfig.clientId);
+    expect(logoutUrl.searchParams.get('id_token_hint')).toBe('id-token');
+  });
+
   it('falls back to the public start page when the logout configuration cannot be loaded', () => {
     httpClientMock.get.mockReturnValueOnce(throwError(() => new Error('network failure')));
     const navigateSpy = vi

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -332,7 +332,7 @@ export class AuthService {
 
         try {
           const logoutUrl = new URL(`${config.issuerUrl}/protocol/openid-connect/logout`);
-          logoutUrl.searchParams.set('post_logout_redirect_uri', `${window.location.origin}/`);
+          logoutUrl.searchParams.set('post_logout_redirect_uri', `${window.location.origin}/login`);
           logoutUrl.searchParams.set('client_id', config.clientId);
           if (idToken) {
             logoutUrl.searchParams.set('id_token_hint', idToken);


### PR DESCRIPTION
## Summary
- align the frontend post-logout redirect with the `/login` URI registered by the installer
- add regression coverage for the complete Keycloak logout URL
- document the correction in the 0.2.0 changelog

## Verification
- `npm test -- --run src/app/core/services/auth.service.oidc.spec.ts`
- `npm run lint`
- `npx prettier --check "src/**/*.{ts,html,scss}"`
- isolated Keycloak rehearsal accepts the configured redirect and returns HTTP 302