### PR TITLE
Fix Trivy ignore input

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -143,7 +143,7 @@ jobs:
           image-ref: ${{ env.BACKEND_IMAGE }}@${{ steps.build.outputs.digest }}
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          ignorefile: .trivyignore.yaml
+          trivyignores: .trivyignore.yaml
           exit-code: '1'
 
   frontend:
@@ -193,7 +193,7 @@ jobs:
           image-ref: ${{ env.FRONTEND_IMAGE }}@${{ steps.build.outputs.digest }}
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          ignorefile: .trivyignore.yaml
+          trivyignores: .trivyignore.yaml
           exit-code: '1'
 
   publish:


### PR DESCRIPTION
## Summary

- use the supported `trivyignores` input for both release candidate image scans
- keep the scoped `.trivyignore.yaml` exceptions active for the backend and frontend scans

## Validation

- release metadata check
- release manifest tests
- deployment script tests
- workflow YAML parsing
- whitespace check

## Context

The `v0.3.0-rc.2` run exposed that `ignorefile` is not a supported input of `aquasecurity/trivy-action@v0.36.0`. The candidate run was cancelled before publication. This change wires the existing ignore file through the action’s documented input.