### PR TITLE
Bound release image build time

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -100,6 +100,7 @@ jobs:
     name: Build and scan backend
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -150,6 +151,7 @@ jobs:
     name: Build and scan frontend
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- cap backend and frontend release-candidate jobs at 45 minutes
- prevent stalled multi-platform image builds from occupying a runner for the default six-hour limit

## Validation

- workflow YAML parsing
- release metadata check
- release manifest tests
- deployment script tests
- whitespace check

## Context

Two release-candidate attempts encountered separate multi-platform build runners that stayed in one build step for more than 35 minutes, while equivalent successful jobs normally finished in under eight minutes. This adds an explicit upper bound without changing application behavior or release artifacts.