### PR TITLE
Make release recovery retry-safe

### DIFF
--- a/.github/ISSUE_TEMPLATE/production-release-exception.md
+++ b/.github/ISSUE_TEMPLATE/production-release-exception.md
@@ -1,0 +1,47 @@
+---
+name: Production-only release exception
+about: Approve a release when no isolated staging environment is available
+title: "Production-only release exception for vX.Y.Z"
+labels: release
+assignees: ''
+---
+
+<!-- content-pool-production-release-exception -->
+
+## Decision
+
+Document why this release must bypass isolated staging. This record must not
+claim that staging validation occurred.
+
+## Release evidence
+
+- Release PR:
+- Source commit:
+- Successful `release-gate`:
+- Release candidate:
+- Migration classification:
+
+## Required production preconditions
+
+- [ ] Release owner and authorized production approver recorded
+- [ ] Maintenance window defined and communicated
+- [ ] Current production version and exact image digests recorded
+- [ ] Current deployment adopted by the managed release tooling if required
+- [ ] `DEPLOYMENT_ENV=production`, `DB_SYNCHRONIZE=false`, and `DB_RUN_MIGRATIONS=true` verified
+- [ ] Database, upload, and runtime-configuration backups created and validated
+- [ ] Exact application rollback target and commands confirmed
+
+## Post-deployment verification
+
+- [ ] `/api/version` and `/version.json` report the promoted release identity
+- [ ] Keycloak login and logout succeed
+- [ ] ACP read, edit, save, and file upload succeed
+- [ ] Public/read view succeeds
+- [ ] Item Explorer, coding, and collections smoke tests succeed
+- [ ] Keycloak user count did not decrease
+- [ ] Logs contain no critical errors during the observation window
+
+## Rollback
+
+Record the exact stable release and image digests to restore. Application
+rollback must not automatically revert database migrations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - run: ./scripts/check-release-metadata.sh
-      - run: python3 -m unittest scripts/test_release_manifest.py
+      - run: python3 -m unittest discover -s scripts -p 'test_*.py'
       - run: ./scripts/test-deployment-scripts.sh
 
   backend-test:

--- a/.github/workflows/cleanup-failed-release-candidate.yml
+++ b/.github/workflows/cleanup-failed-release-candidate.yml
@@ -1,0 +1,84 @@
+name: Cleanup Failed Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: Failed candidate, for example v0.3.0-rc.3
+        required: true
+        type: string
+      source_commit:
+        description: Exact 40-character source commit recorded in the image tag
+        required: true
+        type: string
+      confirmation:
+        description: Type delete-failed-candidate
+        required: true
+        type: string
+
+concurrency:
+  group: cleanup-failed-release-candidate
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete orphaned candidate image versions
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate failed candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE: ${{ inputs.candidate }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          test "$CONFIRMATION" = delete-failed-candidate
+          [[ "$CANDIDATE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$ ]]
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          ! git ls-remote --exit-code --tags origin "refs/tags/${CANDIDATE}" >/dev/null 2>&1
+          ! gh release view "$CANDIDATE" >/dev/null 2>&1
+      - name: Delete exact orphaned package versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE: ${{ inputs.candidate }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER}"
+          sha_tag="sha-${SOURCE_COMMIT}"
+          deleted=0
+          for package in content-pool-backend content-pool-frontend; do
+            versions="$(gh api --paginate --slurp \
+              "orgs/${owner}/packages/container/${package}/versions?per_page=100")"
+            matches="$(jq --arg candidate "$CANDIDATE" --arg sha "$sha_tag" '[
+              .[][]
+              | select(
+                  (.metadata.container.tags | index($candidate)) != null
+                  or (.metadata.container.tags | index($sha)) != null
+                )
+            ]' <<<"$versions")"
+            while IFS= read -r version; do
+              [[ -n "$version" ]] || continue
+              id="$(jq -r .id <<<"$version")"
+              unexpected="$(jq --arg candidate "$CANDIDATE" --arg sha "$sha_tag" -r '[
+                .metadata.container.tags[]
+                | select(. != $candidate and . != $sha)
+              ] | join(",")' <<<"$version")"
+              test -z "$unexpected" || {
+                echo "Refusing to delete ${package} version ${id}; additional tags: ${unexpected}" >&2
+                exit 1
+              }
+              gh api --method DELETE \
+                "orgs/${owner}/packages/container/${package}/versions/${id}"
+              echo "Deleted ${package} version ${id} (${CANDIDATE}, ${sha_tag})"
+              deleted=$((deleted + 1))
+            done < <(jq -c '.[]' <<<"$matches")
+          done
+          test "$deleted" -gt 0 || {
+            echo "No orphaned image version matched ${CANDIDATE} and ${sha_tag}" >&2
+            exit 1
+          }

--- a/.github/workflows/promote-production-exception.yml
+++ b/.github/workflows/promote-production-exception.yml
@@ -1,14 +1,14 @@
-name: Promote Release
+name: Promote Production Exception
 
 on:
   workflow_dispatch:
     inputs:
       candidate:
-        description: Release candidate tag, for example v0.2.0-rc.1
+        description: Release candidate tag, for example v0.3.0-rc.5
         required: true
         type: string
-      staging_evidence:
-        description: Link or identifier for the successful staging checklist
+      exception_issue:
+        description: Repository issue documenting the approved production-only exception
         required: true
         type: string
 
@@ -25,6 +25,6 @@ jobs:
     uses: ./.github/workflows/promote-release-core.yml
     with:
       candidate: ${{ inputs.candidate }}
-      validation_mode: staging
-      validation_evidence: ${{ inputs.staging_evidence }}
+      validation_mode: production-exception
+      validation_evidence: ${{ inputs.exception_issue }}
     secrets: inherit

--- a/.github/workflows/promote-release-core.yml
+++ b/.github/workflows/promote-release-core.yml
@@ -1,0 +1,165 @@
+name: Promote Release Core
+
+on:
+  workflow_call:
+    inputs:
+      candidate:
+        required: true
+        type: string
+      validation_mode:
+        required: true
+        type: string
+      validation_evidence:
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/content-pool-backend
+  FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/content-pool-frontend
+
+jobs:
+  promote:
+    name: Promote tested digests
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: write
+      issues: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve and validate candidate
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE: ${{ inputs.candidate }}
+          VALIDATION_MODE: ${{ inputs.validation_mode }}
+          VALIDATION_EVIDENCE: ${{ inputs.validation_evidence }}
+        run: |
+          [[ "$VALIDATION_EVIDENCE" =~ [^[:space:]]{5,} ]] || {
+            echo "Validation evidence must contain a meaningful URL or record identifier" >&2
+            exit 1
+          }
+          [[ "$CANDIDATE" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-rc\.[1-9][0-9]*$ ]] || {
+            echo "Invalid candidate: ${CANDIDATE}" >&2
+            exit 1
+          }
+          stable="v${BASH_REMATCH[1]}"
+          echo "stable=${stable}" >> "$GITHUB_OUTPUT"
+          echo "validation_mode=${VALIDATION_MODE}" >> "$GITHUB_OUTPUT"
+          mkdir -p dist
+          gh release download "$CANDIDATE" --dir dist
+          (cd dist && sha256sum --check SHA256SUMS)
+          validation_args=(
+            --manifest dist/release-manifest.json
+            --expected-release "$CANDIDATE"
+            --runtime-archive "dist/$(./scripts/release_manifest.py get --manifest dist/release-manifest.json --field runtime.archive)"
+          )
+          case "$VALIDATION_MODE" in
+            staging)
+              ./scripts/release_manifest.py validate "${validation_args[@]}" --environment staging
+              ;;
+            production-exception)
+              prefix="https://github.com/${GITHUB_REPOSITORY}/issues/"
+              [[ "$VALIDATION_EVIDENCE" == "${prefix}"* ]] || {
+                echo "Production exception evidence must be an issue in ${GITHUB_REPOSITORY}" >&2
+                exit 1
+              }
+              issue_number="${VALIDATION_EVIDENCE#"$prefix"}"
+              [[ "$issue_number" =~ ^[1-9][0-9]*$ ]]
+              gh issue view "$issue_number" --json state,body | \
+                python3 scripts/production_exception.py validate \
+                  --repository "$GITHUB_REPOSITORY" \
+                  --issue-url "$VALIDATION_EVIDENCE"
+              ./scripts/release_manifest.py validate "${validation_args[@]}"
+              ;;
+            *)
+              echo "Unsupported validation mode: ${VALIDATION_MODE}" >&2
+              exit 1
+              ;;
+          esac
+          test "$(./scripts/release_manifest.py get --manifest dist/release-manifest.json --field migrations.classification)" != manual || {
+            echo "Manual/incompatible migrations cannot use the normal promotion workflow" >&2
+            exit 1
+          }
+          source_commit="$(./scripts/release_manifest.py get --manifest dist/release-manifest.json --field sourceCommit)"
+          tag_commit="$(git rev-list -n 1 "$CANDIDATE")"
+          test "$source_commit" = "$tag_commit"
+          if git ls-remote --exit-code --tags origin "refs/tags/${stable}" >/dev/null 2>&1; then
+            git fetch --force origin "refs/tags/${stable}:refs/tags/${stable}"
+            test "$(git rev-list -n 1 "$stable")" = "$source_commit" || {
+              echo "Stable tag ${stable} belongs to a different commit" >&2
+              exit 1
+            }
+            if gh release view "$stable" >/dev/null 2>&1; then
+              echo "Stable release ${stable} is already published" >&2
+              exit 1
+            fi
+            echo "Retrying ${stable} after an incomplete publication"
+          fi
+          expected_version="${stable#v}"
+          test "$(git show "${source_commit}:VERSION" | tr -d '[:space:]')" = "$expected_version"
+      - name: Promote image manifests without rebuilding
+        env:
+          STABLE: ${{ steps.release.outputs.stable }}
+        run: |
+          backend="$(./scripts/release_manifest.py get --manifest dist/release-manifest.json --field images.backend)"
+          frontend="$(./scripts/release_manifest.py get --manifest dist/release-manifest.json --field images.frontend)"
+          ensure_promoted_tag() {
+            local stable_ref="$1" source_ref="$2" expected="${2##*@}" actual
+            if docker buildx imagetools inspect "$stable_ref" >/dev/null 2>&1; then
+              actual="$(docker buildx imagetools inspect "$stable_ref" --format '{{json .Manifest}}' | jq -r .digest)"
+              test "$actual" = "$expected" || {
+                echo "${stable_ref} is already assigned to ${actual}, expected ${expected}" >&2
+                return 1
+              }
+            else
+              docker buildx imagetools create --tag "$stable_ref" "$source_ref"
+            fi
+          }
+          ensure_promoted_tag "${BACKEND_IMAGE}:${STABLE}" "$backend"
+          ensure_promoted_tag "${FRONTEND_IMAGE}:${STABLE}" "$frontend"
+          test "$(docker buildx imagetools inspect "${BACKEND_IMAGE}:${STABLE}" --format '{{json .Manifest}}' | jq -r .digest)" = "${backend##*@}"
+          test "$(docker buildx imagetools inspect "${FRONTEND_IMAGE}:${STABLE}" --format '{{json .Manifest}}' | jq -r .digest)" = "${frontend##*@}"
+      - name: Create stable manifest and checksums
+        env:
+          STABLE: ${{ steps.release.outputs.stable }}
+        run: |
+          ./scripts/release_manifest.py promote \
+            --manifest dist/release-manifest.json \
+            --release "$STABLE" \
+            --output dist/release-manifest.stable.json
+          mv dist/release-manifest.stable.json dist/release-manifest.json
+          archive="$(./scripts/release_manifest.py get --manifest dist/release-manifest.json --field runtime.archive)"
+          (cd dist && sha256sum "$archive" release-manifest.json > SHA256SUMS)
+      - name: Publish stable tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE: ${{ inputs.candidate }}
+          STABLE: ${{ steps.release.outputs.stable }}
+          VALIDATION_MODE: ${{ steps.release.outputs.validation_mode }}
+          VALIDATION_EVIDENCE: ${{ inputs.validation_evidence }}
+        run: |
+          source_commit="$(./scripts/release_manifest.py get --manifest dist/release-manifest.json --field sourceCommit)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git rev-parse --verify "refs/tags/${STABLE}" >/dev/null 2>&1; then
+            test "$(git rev-list -n 1 "$STABLE")" = "$source_commit"
+          else
+            git tag -a "$STABLE" "$source_commit" -m "Release ${STABLE} promoted from ${CANDIDATE}"
+            git push origin "refs/tags/${STABLE}"
+          fi
+          gh release create "$STABLE" dist/* \
+            --verify-tag \
+            --generate-notes \
+            --notes "Promoted from \`${CANDIDATE}\`. Validation mode: \`${VALIDATION_MODE}\`. Evidence: ${VALIDATION_EVIDENCE}" \
+            --title "ContentPool ${STABLE}"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -32,10 +32,11 @@ jobs:
     permissions:
       checks: read
       contents: read
+      packages: read
     outputs:
       release: ${{ steps.release.outputs.release }}
       version: ${{ steps.release.outputs.version }}
-      built_at: ${{ steps.release.outputs.built_at }}
+      built_at: ${{ steps.identity.outputs.built_at }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -73,10 +74,8 @@ jobs:
         run: |
           version="$(tr -d '[:space:]' < VERSION)"
           release="v${version}-rc.${RC_NUMBER}"
-          built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "release=${release}" >> "$GITHUB_OUTPUT"
-          echo "built_at=${built_at}" >> "$GITHUB_OUTPUT"
       - name: Require successful quality gate for this commit
         env:
           GH_TOKEN: ${{ github.token }}
@@ -89,22 +88,65 @@ jobs:
           }
       - name: Reject reused release candidate
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE: ${{ steps.release.outputs.release }}
         run: |
           if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE}" >/dev/null 2>&1; then
-            echo "Tag ${RELEASE} already exists" >&2
-            exit 1
+            git fetch --force origin "refs/tags/${RELEASE}:refs/tags/${RELEASE}"
+            test "$(git rev-list -n 1 "$RELEASE")" = "$GITHUB_SHA" || {
+              echo "Tag ${RELEASE} belongs to a different commit" >&2
+              exit 1
+            }
+            if gh release view "$RELEASE" >/dev/null 2>&1; then
+              echo "Release candidate ${RELEASE} is already published" >&2
+              exit 1
+            fi
+            echo "Retrying ${RELEASE} after an incomplete publication"
           fi
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve retry-safe build identity
+        id: identity
+        env:
+          RELEASE: ${{ steps.release.outputs.release }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          built_at=""
+          for image in "$BACKEND_IMAGE" "$FRONTEND_IMAGE"; do
+            ref="${image}:${RELEASE}-build"
+            if metadata="$(docker buildx imagetools inspect "$ref" --format '{{json .}}' 2>/dev/null)"; then
+              revisions="$(jq -r '[.image[]?.config.Labels["org.opencontainers.image.revision"]] | unique | .[]' <<<"$metadata")"
+              versions="$(jq -r '[.image[]?.config.Labels["org.opencontainers.image.version"]] | unique | .[]' <<<"$metadata")"
+              created="$(jq -r '[.image[]?.config.Labels["org.opencontainers.image.created"]] | unique | .[]' <<<"$metadata")"
+              test "$revisions" = "$GITHUB_SHA"
+              test "$versions" = "$VERSION"
+              test -n "$created"
+              if [[ -n "$built_at" ]]; then
+                test "$built_at" = "$created"
+              else
+                built_at="$created"
+              fi
+            fi
+          done
+          if [[ -z "$built_at" ]]; then
+            built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          fi
+          echo "built_at=${built_at}" >> "$GITHUB_OUTPUT"
 
   backend:
     name: Build and scan backend
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.image.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-qemu-action@v3
@@ -114,33 +156,51 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Reject an existing candidate image
+      - name: Resolve existing candidate build
+        id: existing
         env:
           RELEASE: ${{ needs.validate.outputs.release }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          ! docker buildx imagetools inspect "${BACKEND_IMAGE}:${RELEASE}" >/dev/null 2>&1
-          ! docker buildx imagetools inspect "${BACKEND_IMAGE}:sha-${GITHUB_SHA}" >/dev/null 2>&1
+          ref="${BACKEND_IMAGE}:${RELEASE}-build"
+          if ! metadata="$(docker buildx imagetools inspect "$ref" --format '{{json .}}' 2>/dev/null)"; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          test "$(jq -r '[.image[]?.config.Labels["org.opencontainers.image.revision"]] | unique | .[]' <<<"$metadata")" = "$GITHUB_SHA"
+          test "$(jq -r '[.image[]?.config.Labels["org.opencontainers.image.version"]] | unique | .[]' <<<"$metadata")" = "$VERSION"
+          test "$(jq -r '[.image[]?.config.Labels["org.opencontainers.image.created"]] | unique | .[]' <<<"$metadata")" = "${{ needs.validate.outputs.built_at }}"
+          echo "digest=$(jq -r .manifest.digest <<<"$metadata")" >> "$GITHUB_OUTPUT"
+          echo "exists=true" >> "$GITHUB_OUTPUT"
       - name: Build backend once
         id: build
+        if: steps.existing.outputs.exists != 'true'
         uses: docker/build-push-action@v6
         with:
           context: ./backend
           file: ./backend/Dockerfile.prod
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.BACKEND_IMAGE }}:${{ needs.validate.outputs.release }}
-            ${{ env.BACKEND_IMAGE }}:sha-${{ github.sha }}
+          tags: ${{ env.BACKEND_IMAGE }}:${{ needs.validate.outputs.release }}-build
           build-args: |
             APP_VERSION=${{ needs.validate.outputs.version }}
             APP_COMMIT=${{ github.sha }}
             APP_BUILT_AT=${{ needs.validate.outputs.built_at }}
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend
+      - name: Resolve backend digest
+        id: image
+        env:
+          EXISTING_DIGEST: ${{ steps.existing.outputs.digest }}
+          BUILT_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          digest="${EXISTING_DIGEST:-$BUILT_DIGEST}"
+          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
       - name: Scan published backend image
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ${{ env.BACKEND_IMAGE }}@${{ steps.build.outputs.digest }}
+          image-ref: ${{ env.BACKEND_IMAGE }}@${{ steps.image.outputs.digest }}
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           trivyignores: .trivyignore.yaml
@@ -150,11 +210,12 @@ jobs:
     name: Build and scan frontend
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.image.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-qemu-action@v3
@@ -164,33 +225,51 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Reject an existing candidate image
+      - name: Resolve existing candidate build
+        id: existing
         env:
           RELEASE: ${{ needs.validate.outputs.release }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          ! docker buildx imagetools inspect "${FRONTEND_IMAGE}:${RELEASE}" >/dev/null 2>&1
-          ! docker buildx imagetools inspect "${FRONTEND_IMAGE}:sha-${GITHUB_SHA}" >/dev/null 2>&1
+          ref="${FRONTEND_IMAGE}:${RELEASE}-build"
+          if ! metadata="$(docker buildx imagetools inspect "$ref" --format '{{json .}}' 2>/dev/null)"; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          test "$(jq -r '[.image[]?.config.Labels["org.opencontainers.image.revision"]] | unique | .[]' <<<"$metadata")" = "$GITHUB_SHA"
+          test "$(jq -r '[.image[]?.config.Labels["org.opencontainers.image.version"]] | unique | .[]' <<<"$metadata")" = "$VERSION"
+          test "$(jq -r '[.image[]?.config.Labels["org.opencontainers.image.created"]] | unique | .[]' <<<"$metadata")" = "${{ needs.validate.outputs.built_at }}"
+          echo "digest=$(jq -r .manifest.digest <<<"$metadata")" >> "$GITHUB_OUTPUT"
+          echo "exists=true" >> "$GITHUB_OUTPUT"
       - name: Build frontend once
         id: build
+        if: steps.existing.outputs.exists != 'true'
         uses: docker/build-push-action@v6
         with:
           context: ./frontend
           file: ./frontend/Dockerfile.prod
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.release }}
-            ${{ env.FRONTEND_IMAGE }}:sha-${{ github.sha }}
+          tags: ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.release }}-build
           build-args: |
             APP_VERSION=${{ needs.validate.outputs.version }}
             APP_COMMIT=${{ github.sha }}
             APP_BUILT_AT=${{ needs.validate.outputs.built_at }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
+      - name: Resolve frontend digest
+        id: image
+        env:
+          EXISTING_DIGEST: ${{ steps.existing.outputs.digest }}
+          BUILT_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          digest="${EXISTING_DIGEST:-$BUILT_DIGEST}"
+          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
       - name: Scan published frontend image
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ${{ env.FRONTEND_IMAGE }}@${{ steps.build.outputs.digest }}
+          image-ref: ${{ env.FRONTEND_IMAGE }}@${{ steps.image.outputs.digest }}
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           trivyignores: .trivyignore.yaml
@@ -202,10 +281,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build runtime bundle and manifest
         env:
           RELEASE: ${{ needs.validate.outputs.release }}
@@ -233,14 +319,42 @@ jobs:
             --required-configuration CONTENT_POOL_FRONTEND_IMAGE \
             --output dist/release-manifest.json
           (cd dist && sha256sum "$archive" release-manifest.json > SHA256SUMS)
+      - name: Publish verified image tags
+        env:
+          RELEASE: ${{ needs.validate.outputs.release }}
+          BACKEND_DIGEST: ${{ needs.backend.outputs.digest }}
+          FRONTEND_DIGEST: ${{ needs.frontend.outputs.digest }}
+        run: |
+          ensure_tag() {
+            local target="$1" source="$2" expected="$3" actual
+            if docker buildx imagetools inspect "$target" >/dev/null 2>&1; then
+              actual="$(docker buildx imagetools inspect "$target" --format '{{json .}}' | jq -r .manifest.digest)"
+              test "$actual" = "$expected" || {
+                echo "${target} already points to ${actual}, expected ${expected}" >&2
+                return 1
+              }
+            else
+              docker buildx imagetools create --tag "$target" "$source"
+            fi
+            actual="$(docker buildx imagetools inspect "$target" --format '{{json .}}' | jq -r .manifest.digest)"
+            test "$actual" = "$expected"
+          }
+          ensure_tag "${BACKEND_IMAGE}:${RELEASE}" "${BACKEND_IMAGE}@${BACKEND_DIGEST}" "$BACKEND_DIGEST"
+          ensure_tag "${BACKEND_IMAGE}:sha-${GITHUB_SHA}" "${BACKEND_IMAGE}@${BACKEND_DIGEST}" "$BACKEND_DIGEST"
+          ensure_tag "${FRONTEND_IMAGE}:${RELEASE}" "${FRONTEND_IMAGE}@${FRONTEND_DIGEST}" "$FRONTEND_DIGEST"
+          ensure_tag "${FRONTEND_IMAGE}:sha-${GITHUB_SHA}" "${FRONTEND_IMAGE}@${FRONTEND_DIGEST}" "$FRONTEND_DIGEST"
       - name: Create annotated candidate tag
         env:
           RELEASE: ${{ needs.validate.outputs.release }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$RELEASE" "$GITHUB_SHA" -m "Release candidate ${RELEASE}"
-          git push origin "refs/tags/${RELEASE}"
+          if git rev-parse --verify "refs/tags/${RELEASE}" >/dev/null 2>&1; then
+            test "$(git rev-list -n 1 "$RELEASE")" = "$GITHUB_SHA"
+          else
+            git tag -a "$RELEASE" "$GITHUB_SHA" -m "Release candidate ${RELEASE}"
+            git push origin "refs/tags/${RELEASE}"
+          fi
       - name: Create GitHub prerelease
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to ContentPool are documented in this file. Releases use
   workflows and install all required browser dependencies in CI.
 - Update transitive `brace-expansion` dependencies to patched releases and
   document the scanner exception for fixed 1.x and 2.x backports.
+- Make release-candidate image publication retry-safe and add an explicit,
+  protected production-only exception path that does not claim staging evidence.
 
 ### Breaking changes
 

--- a/docs/operations/releases.md
+++ b/docs/operations/releases.md
@@ -24,9 +24,17 @@ person as production approver:
 1. Merge a release PR into `master` after the required `release-gate` succeeds.
 2. Run **Release Candidate** from `master`, provide the RC number and the exact
    migration classification from `CHANGELOG.md`.
-3. The workflow builds and scans backend/frontend images once, publishes a
-   `vX.Y.Z-rc.N` prerelease, and records immutable image digests in
-   `release-manifest.json`.
+3. The workflow builds backend/frontend images under retryable `-build` tags
+   and scans both immutable digests. Only after both scans pass does it publish
+   the final `vX.Y.Z-rc.N` and `sha-*` image tags, the prerelease, and
+   `release-manifest.json`. Re-running an incomplete candidate reuses a build
+   only after its version, source commit, and build timestamp match.
+
+If a candidate from the older non-retryable workflow left partial RC and SHA
+tags without publishing a Git tag or GitHub release, run **Cleanup Failed
+Release Candidate** with that RC, its exact source commit, and the required
+confirmation text. The cleanup refuses candidates with a Git tag/release and
+refuses package versions carrying any additional tag.
 4. Deploy the candidate to the isolated staging stack:
 
    ```bash
@@ -51,6 +59,26 @@ person as production approver:
 Migration classification `manual` intentionally cannot use the normal
 promotion workflow. Redesign the migration as expand/contract or use a reviewed
 maintenance plan outside the routine release process.
+
+## Production-only exception
+
+An unavailable staging environment is not staging evidence. If an urgent
+release must go directly to production, open the **Production-only release
+exception** issue template and complete every item under **Required production
+preconditions**. The issue must remain open as the operational record.
+
+Run **Promote Production Exception** with the candidate and that repository
+issue URL. The separate workflow validates the issue marker and completed
+preconditions, records `production-exception` in the stable release notes, and
+still requires approval through the protected `production` environment. It
+validates candidate checksums, source identity, migration classification, and
+image digests, but does not claim that staging validation occurred.
+
+Promotion does not deploy the application. After promotion, use the normal
+production update command during the recorded maintenance window, complete the
+post-deployment checks in the exception issue, attach the deployment record,
+and then close the issue. If the preconditions cannot be completed, do not
+promote or deploy the candidate.
 
 ## First managed deployment
 

--- a/scripts/production_exception.py
+++ b/scripts/production_exception.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import sys
+from typing import Any
+
+
+MARKER = "<!-- content-pool-production-release-exception -->"
+PRECONDITIONS_HEADING = "## Required production preconditions"
+
+
+class ProductionExceptionError(ValueError):
+    pass
+
+
+def validate_issue(repository: str, issue_url: str, issue: dict[str, Any]) -> int:
+    prefix = f"https://github.com/{repository}/issues/"
+    if not issue_url.startswith(prefix):
+        raise ProductionExceptionError(
+            f"production exception evidence must be an issue in {repository}"
+        )
+    raw_number = issue_url.removeprefix(prefix)
+    if not re.fullmatch(r"[1-9][0-9]*", raw_number):
+        raise ProductionExceptionError("production exception issue URL is invalid")
+    if issue.get("state") != "OPEN":
+        raise ProductionExceptionError("production exception issue must remain open")
+    body = issue.get("body")
+    if not isinstance(body, str) or MARKER not in body:
+        raise ProductionExceptionError(
+            "issue is not a production release exception record"
+        )
+    if PRECONDITIONS_HEADING not in body:
+        raise ProductionExceptionError(
+            "production exception preconditions section is missing"
+        )
+    preconditions = body.split(PRECONDITIONS_HEADING, 1)[1].split("\n## ", 1)[0]
+    if not re.search(r"^- \[[xX]\] ", preconditions, flags=re.MULTILINE):
+        raise ProductionExceptionError(
+            "production exception preconditions contain no completed checks"
+        )
+    if re.search(r"^- \[ \] ", preconditions, flags=re.MULTILINE):
+        raise ProductionExceptionError("production exception preconditions are incomplete")
+    return int(raw_number)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--repository", required=True)
+    validate.add_argument("--issue-url", required=True)
+    args = parser.parse_args()
+    try:
+        issue = json.load(sys.stdin)
+        number = validate_issue(args.repository, args.issue_url, issue)
+    except (json.JSONDecodeError, ProductionExceptionError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    print(f"Production exception issue {number} is complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_production_exception.py
+++ b/scripts/test_production_exception.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from production_exception import MARKER, ProductionExceptionError, validate_issue
+
+
+REPOSITORY = "iqb-berlin/content-pool-next"
+ISSUE_URL = f"https://github.com/{REPOSITORY}/issues/109"
+
+
+def issue(body: str, state: str = "OPEN") -> dict[str, str]:
+    return {"state": state, "body": body}
+
+
+COMPLETE_BODY = f"""{MARKER}
+
+## Required production preconditions
+
+- [x] Release owner recorded
+- [X] Backups validated
+
+## Post-deployment verification
+
+- [ ] Version endpoint checked
+"""
+
+
+class ProductionExceptionTest(unittest.TestCase):
+    def test_accepts_complete_open_repository_issue(self) -> None:
+        self.assertEqual(validate_issue(REPOSITORY, ISSUE_URL, issue(COMPLETE_BODY)), 109)
+
+    def test_rejects_issue_from_another_repository(self) -> None:
+        with self.assertRaisesRegex(ProductionExceptionError, "must be an issue"):
+            validate_issue(REPOSITORY, "https://github.com/example/repo/issues/109", issue(COMPLETE_BODY))
+
+    def test_rejects_missing_marker(self) -> None:
+        with self.assertRaisesRegex(ProductionExceptionError, "not a production"):
+            validate_issue(REPOSITORY, ISSUE_URL, issue(COMPLETE_BODY.replace(MARKER, "")))
+
+    def test_rejects_closed_issue(self) -> None:
+        with self.assertRaisesRegex(ProductionExceptionError, "remain open"):
+            validate_issue(REPOSITORY, ISSUE_URL, issue(COMPLETE_BODY, state="CLOSED"))
+
+    def test_rejects_incomplete_preconditions(self) -> None:
+        body = COMPLETE_BODY.replace("- [X] Backups validated", "- [ ] Backups validated")
+        with self.assertRaisesRegex(ProductionExceptionError, "incomplete"):
+            validate_issue(REPOSITORY, ISSUE_URL, issue(body))
+
+    def test_ignores_unchecked_post_deployment_checks(self) -> None:
+        self.assertEqual(validate_issue(REPOSITORY, ISSUE_URL, issue(COMPLETE_BODY)), 109)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_workflows.py
+++ b/scripts/test_release_workflows.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+class ReleaseWorkflowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.candidate = (WORKFLOWS / "release-candidate.yml").read_text()
+        cls.staging = (WORKFLOWS / "promote-release.yml").read_text()
+        cls.exception = (WORKFLOWS / "promote-production-exception.yml").read_text()
+        cls.core = (WORKFLOWS / "promote-release-core.yml").read_text()
+        cls.cleanup = (WORKFLOWS / "cleanup-failed-release-candidate.yml").read_text()
+        cls.exception_template = (
+            ROOT / ".github" / "ISSUE_TEMPLATE" / "production-release-exception.md"
+        ).read_text()
+
+    def test_candidate_tags_are_published_only_after_both_scans(self) -> None:
+        self.assertEqual(self.candidate.count("${{ needs.validate.outputs.release }}-build"), 2)
+        publish = self.candidate.index("name: Publish verified image tags")
+        self.assertLess(self.candidate.index("name: Scan published backend image"), publish)
+        self.assertLess(self.candidate.index("name: Scan published frontend image"), publish)
+        self.assertNotIn("name: Reject an existing candidate image", self.candidate)
+
+    def test_candidate_builds_can_be_reused_safely(self) -> None:
+        self.assertEqual(self.candidate.count("name: Resolve existing candidate build"), 2)
+        self.assertEqual(self.candidate.count("org.opencontainers.image.revision"), 3)
+        self.assertEqual(self.candidate.count("org.opencontainers.image.version"), 3)
+        self.assertEqual(self.candidate.count("org.opencontainers.image.created"), 3)
+        self.assertEqual(self.candidate.count("timeout-minutes: 45"), 2)
+
+    def test_staging_and_exception_promotions_are_separate(self) -> None:
+        core_call = "uses: ./.github/workflows/promote-release-core.yml"
+        self.assertIn(core_call, self.staging)
+        self.assertIn("validation_mode: staging", self.staging)
+        self.assertNotIn("production-exception", self.staging)
+        self.assertIn(core_call, self.exception)
+        self.assertIn("validation_mode: production-exception", self.exception)
+        self.assertIn("environment: production", self.core)
+
+    def test_production_exception_requires_a_completed_issue_record(self) -> None:
+        marker = "<!-- content-pool-production-release-exception -->"
+        self.assertIn("scripts/production_exception.py validate", self.core)
+        self.assertIn(marker, self.exception_template)
+        preconditions = self.exception_template.split(
+            "## Required production preconditions", 1
+        )[1].split("## Post-deployment verification", 1)[0]
+        self.assertIn("- [ ]", preconditions)
+
+    def test_failed_candidate_cleanup_is_strictly_scoped(self) -> None:
+        self.assertIn("delete-failed-candidate", self.cleanup)
+        self.assertIn("! git ls-remote --exit-code --tags", self.cleanup)
+        self.assertIn("! gh release view", self.cleanup)
+        self.assertIn("Refusing to delete", self.cleanup)
+        self.assertIn("packages: write", self.cleanup)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- build and scan release images under retryable candidate-build tags, publishing final RC and SHA tags only after both scans pass
- reuse partial builds only when version, source commit, and build timestamp match
- extract the protected promotion implementation into one reusable workflow with separate staging and production-exception entry points
- require an open, completed production-exception issue without representing it as staging evidence
- add a guarded workflow for deleting exact orphaned candidate package versions
- add regression tests and operational documentation

## Root cause

The previous workflow pushed final component tags before both parallel image scans completed. A failed or stalled sibling job therefore left partial RC/SHA tags, and the immutability guard prevented a clean retry of the same commit.

## Safety

- application APIs and database schemas are unchanged
- the protected production environment remains required for stable promotion and destructive package cleanup
- cleanup refuses candidates with Git tags or GitHub releases and refuses versions with unexpected additional tags
- production-only promotion requires every pre-deployment checkbox in a repository exception issue to be complete

## Validation

- actionlint 1.7.12
- workflow YAML parsing
- 17 release and exception unit tests
- release metadata consistency
- deployment script tests
- whitespace validation
- OCI label and digest extraction against an existing multi-platform image