### PR TITLE
Harden deployment health checks

### DIFF
--- a/scripts/check-health.sh
+++ b/scripts/check-health.sh
@@ -9,7 +9,28 @@ API_URL="${3:-http://localhost:3000/api}"
 FRONTEND_URL="${4:-http://localhost:4201}"
 EXPECTED_RELEASE="${5:-}"
 EXPECTED_COMMIT="${6:-}"
+HEALTH_CHECK_ATTEMPTS="${HEALTH_CHECK_ATTEMPTS:-1}"
+HEALTH_CHECK_INTERVAL_SECONDS="${HEALTH_CHECK_INTERVAL_SECONDS:-5}"
+HEALTH_CHECK_CONNECT_TIMEOUT_SECONDS="${HEALTH_CHECK_CONNECT_TIMEOUT_SECONDS:-3}"
+HEALTH_CHECK_MAX_TIME_SECONDS="${HEALTH_CHECK_MAX_TIME_SECONDS:-5}"
 FAILURES=0
+
+[[ "$HEALTH_CHECK_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || {
+    echo "HEALTH_CHECK_ATTEMPTS must be a positive integer" >&2
+    exit 2
+}
+[[ "$HEALTH_CHECK_INTERVAL_SECONDS" =~ ^[0-9]+$ ]] || {
+    echo "HEALTH_CHECK_INTERVAL_SECONDS must be a non-negative integer" >&2
+    exit 2
+}
+[[ "$HEALTH_CHECK_CONNECT_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || {
+    echo "HEALTH_CHECK_CONNECT_TIMEOUT_SECONDS must be a positive integer" >&2
+    exit 2
+}
+[[ "$HEALTH_CHECK_MAX_TIME_SECONDS" =~ ^[1-9][0-9]*$ ]] || {
+    echo "HEALTH_CHECK_MAX_TIME_SECONDS must be a positive integer" >&2
+    exit 2
+}
 
 echo "=== ContentPool Health Check ==="
 echo "Environment: $ENV"
@@ -23,43 +44,33 @@ NC='\033[0m' # No Color
 check_url() {
     local name=$1
     local url=$2
+    local status
 
     echo -n "Checking $name... "
 
-    if curl -s -o /dev/null -w "%{http_code}" "$url" | grep -q "200\|301\|302"; then
+    status="$(curl --connect-timeout "$HEALTH_CHECK_CONNECT_TIMEOUT_SECONDS" \
+        --max-time "$HEALTH_CHECK_MAX_TIME_SECONDS" \
+        -sS -o /dev/null -w "%{http_code}" "$url" 2>/dev/null)" || status=""
+    if [[ "$status" =~ ^(200|301|302)$ ]]; then
         echo -e "${GREEN}OK${NC}"
     else
-        echo -e "${RED}FAILED${NC}"
+        echo -e "${RED}FAILED${NC} (${status:-unreachable})"
         FAILURES=$((FAILURES + 1))
     fi
 
     return 0
 }
 
-if [[ "$KEYCLOAK_URL" == *"/realms/"* ]]; then
-    KEYCLOAK_HEALTH_URL="${KEYCLOAK_URL%/}/.well-known/openid-configuration"
-else
-    KEYCLOAK_HEALTH_URL="${KEYCLOAK_URL%/}/realms/master/.well-known/openid-configuration"
-fi
+check_release_identity() {
+    [[ -n "$EXPECTED_RELEASE" || -n "$EXPECTED_COMMIT" ]] || return 0
 
-# Check Keycloak
-check_url "Keycloak discovery" "$KEYCLOAK_HEALTH_URL"
-
-# Check Backend API
-check_url "API liveness" "${API_URL%/}/health/live"
-check_url "API readiness" "${API_URL%/}/health/ready"
-check_url "API OIDC config" "${API_URL%/}/auth/oidc-config"
-
-# Check Frontend
-check_url "Frontend" "${FRONTEND_URL%/}/"
-
-if [[ -n "$EXPECTED_RELEASE" || -n "$EXPECTED_COMMIT" ]]; then
     echo -n "Checking deployed release identity... "
-    BACKEND_VERSION="$(mktemp "${TMPDIR:-/tmp}/content-pool-backend-version.XXXXXX")"
-    FRONTEND_VERSION="$(mktemp "${TMPDIR:-/tmp}/content-pool-frontend-version.XXXXXX")"
-    trap 'rm -f "$BACKEND_VERSION" "$FRONTEND_VERSION"' EXIT
-    if curl -fsS "${API_URL%/}/version" -o "$BACKEND_VERSION" && \
-       curl -fsS "${FRONTEND_URL%/}/version.json" -o "$FRONTEND_VERSION" && \
+    if curl --connect-timeout "$HEALTH_CHECK_CONNECT_TIMEOUT_SECONDS" \
+       --max-time "$HEALTH_CHECK_MAX_TIME_SECONDS" \
+       -fsS "${API_URL%/}/version" -o "$BACKEND_VERSION" && \
+       curl --connect-timeout "$HEALTH_CHECK_CONNECT_TIMEOUT_SECONDS" \
+       --max-time "$HEALTH_CHECK_MAX_TIME_SECONDS" \
+       -fsS "${FRONTEND_URL%/}/version.json" -o "$FRONTEND_VERSION" && \
        python3 - "$BACKEND_VERSION" "$FRONTEND_VERSION" "$EXPECTED_RELEASE" "$EXPECTED_COMMIT" <<'PY'
 import json
 import sys
@@ -81,7 +92,46 @@ PY
         echo -e "${RED}FAILED${NC}"
         FAILURES=$((FAILURES + 1))
     fi
+}
+
+run_health_pass() {
+    FAILURES=0
+
+    check_url "Keycloak discovery" "$KEYCLOAK_HEALTH_URL"
+    check_url "API liveness" "${API_URL%/}/health/live"
+    check_url "API readiness" "${API_URL%/}/health/ready"
+    check_url "API OIDC config" "${API_URL%/}/auth/oidc-config"
+    check_url "Frontend" "${FRONTEND_URL%/}/"
+    check_release_identity
+
+    [[ "$FAILURES" -eq 0 ]]
+}
+
+if [[ "$KEYCLOAK_URL" == *"/realms/"* ]]; then
+    KEYCLOAK_HEALTH_URL="${KEYCLOAK_URL%/}/.well-known/openid-configuration"
+else
+    KEYCLOAK_HEALTH_URL="${KEYCLOAK_URL%/}/realms/master/.well-known/openid-configuration"
 fi
+
+if [[ -n "$EXPECTED_RELEASE" || -n "$EXPECTED_COMMIT" ]]; then
+    BACKEND_VERSION="$(mktemp "${TMPDIR:-/tmp}/content-pool-backend-version.XXXXXX")"
+    FRONTEND_VERSION="$(mktemp "${TMPDIR:-/tmp}/content-pool-frontend-version.XXXXXX")"
+    trap 'rm -f "$BACKEND_VERSION" "$FRONTEND_VERSION"' EXIT
+fi
+
+HEALTH_PASSED=0
+for ((attempt = 1; attempt <= HEALTH_CHECK_ATTEMPTS; attempt += 1)); do
+    echo "Health check attempt ${attempt}/${HEALTH_CHECK_ATTEMPTS}"
+    if run_health_pass; then
+        HEALTH_PASSED=1
+        break
+    fi
+    if [[ "$attempt" -lt "$HEALTH_CHECK_ATTEMPTS" ]]; then
+        echo "Attempt ${attempt}/${HEALTH_CHECK_ATTEMPTS} failed; retrying in ${HEALTH_CHECK_INTERVAL_SECONDS}s..."
+        sleep "$HEALTH_CHECK_INTERVAL_SECONDS"
+        echo ""
+    fi
+done
 
 echo ""
 echo "=== Docker Container Status ==="
@@ -101,7 +151,7 @@ else
 fi
 
 echo ""
-if [ "$FAILURES" -gt 0 ]; then
+if [[ "$HEALTH_PASSED" -ne 1 ]]; then
     echo -e "=== Health Check Complete: ${RED}${FAILURES} check(s) failed${NC} ==="
     exit 1
 fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -140,6 +140,8 @@ docker compose "${CONTENT_POOL_COMPOSE_ARGS[@]}" up -d --wait --wait-timeout 180
 if [[ "$HEALTH_CHECK" -eq 1 ]]; then
   release="$(cp_env_get .env APPLICATION_VERSION)"
   commit="$(cp_env_get .env RELEASE_COMMIT)"
+  export HEALTH_CHECK_ATTEMPTS="${HEALTH_CHECK_ATTEMPTS:-24}"
+  export HEALTH_CHECK_INTERVAL_SECONDS="${HEALTH_CHECK_INTERVAL_SECONDS:-5}"
   if [[ -n "$BASE_URL" ]]; then
     ./scripts/check-health.sh "$MODE" "$(cp_env_get .env OIDC_PUBLIC_ISSUER_URL)" \
       "${BASE_URL%/}/api" "${BASE_URL%/}" "$release" "$commit"

--- a/scripts/test-deployment-scripts.sh
+++ b/scripts/test-deployment-scripts.sh
@@ -18,6 +18,14 @@ grep -q 'up -d --wait --wait-timeout 180' "$ROOT_DIR/scripts/restore.sh" || {
   echo "not every managed update/rollback start waits for stack readiness" >&2
   exit 1
 }
+grep -q 'HEALTH_CHECK_ATTEMPTS="${HEALTH_CHECK_ATTEMPTS:-24}"' "$ROOT_DIR/scripts/update.sh" || {
+  echo "managed updates do not enable bounded health-check retries" >&2
+  exit 1
+}
+grep -q 'HEALTH_CHECK_ATTEMPTS="${HEALTH_CHECK_ATTEMPTS:-24}"' "$ROOT_DIR/scripts/restore.sh" || {
+  echo "managed restores do not enable bounded health-check retries" >&2
+  exit 1
+}
 
 temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/content-pool-script-test.XXXXXX")"
 trap 'rm -rf "$temp_dir"' EXIT
@@ -31,6 +39,122 @@ if [[ "${1:-}" == compose && "${2:-}" == version ]]; then exit 0; fi
 exit 0
 SH
 chmod +x "$temp_dir/bin/docker"
+
+health_bin="$temp_dir/health-bin"
+mkdir -p "$health_bin"
+cat > "$health_bin/docker" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+cat > "$health_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+url=""
+output_file=""
+write_format=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output_file="$2"
+      shift 2
+      ;;
+    -w)
+      write_format="$2"
+      shift 2
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$url" ]] || exit 2
+current_attempt="$(cat "$HEALTH_TEST_STATE" 2>/dev/null || true)"
+current_attempt="${current_attempt:-0}"
+if [[ "$url" == *"/.well-known/openid-configuration" ]]; then
+  current_attempt=$((current_attempt + 1))
+  printf '%s\n' "$current_attempt" >"$HEALTH_TEST_STATE"
+fi
+current_attempt="${current_attempt:-1}"
+
+status=200
+version=0.3.0
+case "$HEALTH_TEST_SCENARIO" in
+  transient)
+    if [[ "$current_attempt" -eq 1 && "$url" == *"/.well-known/openid-configuration" ]]; then
+      status=503
+    fi
+    ;;
+  persistent)
+    if [[ "$url" == *"/.well-known/openid-configuration" ]]; then
+      status=503
+    fi
+    ;;
+  identity-mismatch)
+    if [[ "$url" == */version || "$url" == */version.json ]]; then
+      version=0.2.0
+    fi
+    ;;
+  mixed-then-current)
+    if [[ "$current_attempt" -eq 1 && "$url" == */version.json ]]; then
+      version=0.2.0
+    fi
+    ;;
+esac
+
+if [[ "$url" == */version || "$url" == */version.json ]]; then
+  printf '{"version":"%s","commit":"%s","builtAt":"2026-07-31T12:25:34Z"}\n' \
+    "$version" "$HEALTH_TEST_COMMIT" >"$output_file"
+elif [[ -n "$write_format" ]]; then
+  printf '%s' "$status"
+fi
+SH
+chmod +x "$health_bin/docker" "$health_bin/curl"
+
+health_commit=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+health_state="$temp_dir/health-state"
+health_log="$temp_dir/health.log"
+
+run_health_test() {
+  local scenario="$1"
+  local attempts="$2"
+  : >"$health_state"
+  HEALTH_TEST_SCENARIO="$scenario" \
+  HEALTH_TEST_STATE="$health_state" \
+  HEALTH_TEST_COMMIT="$health_commit" \
+  HEALTH_CHECK_ATTEMPTS="$attempts" \
+  HEALTH_CHECK_INTERVAL_SECONDS=0 \
+  HEALTH_CHECK_CONNECT_TIMEOUT_SECONDS=1 \
+  HEALTH_CHECK_MAX_TIME_SECONDS=1 \
+  PATH="$health_bin:$PATH" \
+    "$ROOT_DIR/scripts/check-health.sh" server \
+      https://auth.example/realms/iqb https://content.example/api https://content.example \
+      0.3.0 "$health_commit" >"$health_log" 2>&1
+}
+
+run_health_test transient 3
+test "$(cat "$health_state")" = 2
+grep -q 'Health check attempt 2/3' "$health_log"
+
+if run_health_test persistent 3; then
+  echo "health check accepted a persistent external failure" >&2
+  exit 1
+fi
+test "$(cat "$health_state")" = 3
+
+if run_health_test identity-mismatch 2; then
+  echo "health check accepted a persistent release identity mismatch" >&2
+  exit 1
+fi
+test "$(cat "$health_state")" = 2
+
+run_health_test mixed-then-current 2
+test "$(cat "$health_state")" = 2
 
 (
   cd "$temp_dir"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -273,8 +273,10 @@ run_health_check() {
     api_url="http://localhost/api"
     frontend_url="http://localhost"
   fi
-  ./scripts/check-health.sh "$MODE" "$keycloak_url" "$api_url" "$frontend_url" \
-    "$TARGET_APPLICATION_VERSION" "$TARGET_COMMIT"
+  HEALTH_CHECK_ATTEMPTS="${HEALTH_CHECK_ATTEMPTS:-24}" \
+    HEALTH_CHECK_INTERVAL_SECONDS="${HEALTH_CHECK_INTERVAL_SECONDS:-5}" \
+    ./scripts/check-health.sh "$MODE" "$keycloak_url" "$api_url" "$frontend_url" \
+      "$TARGET_APPLICATION_VERSION" "$TARGET_COMMIT"
 }
 
 restore_previous_application() {


### PR DESCRIPTION
## Summary

- retry the complete external health and release-identity suite as one consistent pass
- give managed updates and restores a bounded 24-attempt, five-second convergence window
- add short curl connection and response timeouts while keeping manual health checks single-shot by default
- cover transient recovery, persistent failure, identity mismatch, and mixed old/new responses

## Root cause

Docker Compose correctly waited for container health, but Traefik routing could still be converging. The following external health check ran once, so a transient routing failure immediately triggered the existing application rollback.

## Safety and impact

A deployment is accepted only after Keycloak, API live/ready/OIDC, frontend, and backend/frontend release identity all pass in the same attempt. Persistent failures still exhaust the bounded window and invoke the existing rollback path. No application API, database, Keycloak, or production data behavior changes.

## Validation

- `bash -n scripts/check-health.sh scripts/update.sh scripts/restore.sh scripts/test-deployment-scripts.sh`
- `./scripts/check-release-metadata.sh`
- `python3 -m unittest scripts/test_release_manifest.py`
- `./scripts/test-deployment-scripts.sh`
- `git diff --check`
